### PR TITLE
timedelta and pandas compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
     - 2.7
     - 3.3
     - 3.4
+env:
+    - PD_VERSION=0.13.1
+    - PD_VERSION="0.14.*"
+    - PD_VERSION="0.15.*"
+
 # setup miniconda for numpy, scipy, pandas
 before_install:
     - echo "before install"
@@ -19,7 +24,7 @@ before_install:
     
 install:
     - echo "install"
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas nose pytz ephem
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas=$PD_VERSION nose pytz ephem
     - conda install --yes coverage
     - pip install coveralls
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - PD_VERSION=0.13.1
     - PD_VERSION="0.14.*"
     - PD_VERSION="0.15.*"
+    - PD_VERSION="0.16.*"
 
 # setup miniconda for numpy, scipy, pandas
 before_install:

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -10,6 +10,8 @@ from __future__ import division
 import logging
 pvl_logger = logging.getLogger('pvlib')
 
+import datetime
+
 import numpy as np
 import pandas as pd
 
@@ -167,7 +169,7 @@ def _doy_to_timestamp(doy, epoch='2013-12-31'):
     -------
     pd.Timestamp
     """
-    return pd.Timestamp('2013-12-31') + pd.Timedelta(days=float(doy))
+    return pd.Timestamp('2013-12-31') + datetime.timedelta(days=float(doy))
 
 
 def aoi_projection(surf_tilt, surf_az, sun_zen, sun_az):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not sys.version_info[:2] in ((2,7), (3,3), (3,4)):
 setuptools_kwargs = {
     'zip_safe': False,
     'install_requires': ['numpy >= 1.7.0',
-                         'pandas >= 0.15',
+                         'pandas >= 0.13.1',
                          'pytz',
                          'six',
                          'pyephem',


### PR DESCRIPTION
@alorenzo175 complained that pvlib required ``pandas >= 0.15``, so I removed a ``pd.Timedelta`` dependency and was able to get the tests to pass on pandas 13.1. Conda wouldn't install 13.0 on my Python 3.4 environment, so I stopped there. 

I also added a pandas environment variable to the travis config to run the test suite against multiple pandas versions.