### PR TITLE
fix issue converting datetimeindex to epoch int on 32 bit machines

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.2.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.2.0.txt
@@ -25,6 +25,7 @@ Bug fixes
 * fix local build of the documentation (:issue:`49`, :issue:`56`)
 * The release date of 0.1 was fixed in the documentation
   (see :ref:`whatsnew_0100`)
+* fix casting of DateTimeIndex to int64 epoch timestamp on machines with 32 bit python int (:issue:`63`)
 
 Contributors
 ~~~~~~~~~~~~
@@ -32,3 +33,4 @@ Contributors
 * Will Holmgren
 * Rob Andrews
 * bmu
+* Tony Lorenzo

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -287,7 +287,7 @@ def spa_python(time, location, pressure=101325, temperature=12, delta_t=None,
         except (TypeError, ValueError):
             time = pd.DatetimeIndex([time, ])
 
-    unixtime = localize_to_utc(time, location).astype(int)/10**9
+    unixtime = localize_to_utc(time, location).astype(np.int64)/10**9
 
     spa = _spa_python_import(how)
 
@@ -363,7 +363,7 @@ def get_sun_rise_set_transit(time, location, how='numpy', delta_t=None,
 
     # must convert to midnight UTC on day of interest
     utcday = pd.DatetimeIndex(time.date).tz_localize('UTC')
-    unixtime = utcday.astype(int)/10**9
+    unixtime = utcday.astype(np.int64)/10**9
 
     spa = _spa_python_import(how)
 

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -1078,7 +1078,7 @@ def solar_position(unixtime, lat, lon, elev, pressure, temp, delta_t,
     unixtime : numpy array
         Array of unix/epoch timestamps to calculate solar position for.
         Unixtime is the number of seconds since Jan. 1, 1970 00:00:00 UTC.
-        A pandas.DatetimeIndex is easily converted using .astype(int)/10**9
+        A pandas.DatetimeIndex is easily converted using .astype(np.int64)/10**9
     lat : float
         Latitude to calculate solar position for
     lon : float

--- a/pvlib/test/test_spa.py
+++ b/pvlib/test/test_spa.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 times = pd.date_range('2003-10-17 12:30:30', periods=1, freq='D').tz_localize('MST')
-unixtimes = times.tz_convert('UTC').astype(int)*1.0/10**9
+unixtimes = times.tz_convert('UTC').astype(np.int64)*1.0/10**9
 lat = 39.742476
 lon = -105.1786
 elev = 1830.14
@@ -246,24 +246,24 @@ class SpaBase(object):
         # tests at greenwich
         times = pd.DatetimeIndex([dt.datetime(1996, 7, 5, 0),
                                   dt.datetime(2004, 12, 4, 0)]
-                                 ).tz_localize('UTC').astype(int)*1.0/10**9
+                                 ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunrise = pd.DatetimeIndex([dt.datetime(1996, 7, 5, 7, 8, 15),
                                     dt.datetime(2004, 12, 4, 4, 38, 57)]
-                                   ).tz_localize('UTC').astype(int)*1.0/10**9
+                                   ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunset = pd.DatetimeIndex([dt.datetime(1996, 7, 5, 17, 1, 4),
                                    dt.datetime(2004, 12, 4, 19, 2, 2)]
-                                  ).tz_localize('UTC').astype(int)*1.0/10**9
+                                  ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         result = self.spa.transit_sunrise_sunset(times, -35.0, 0.0, 64.0, 1)
         npt.assert_almost_equal(sunrise/1e3, result[1]/1e3, 3)
         npt.assert_almost_equal(sunset/1e3, result[2]/1e3, 3)
 
 
         times = pd.DatetimeIndex([dt.datetime(1994, 1, 2),]
-                                 ).tz_localize('UTC').astype(int)*1.0/10**9
+                                 ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunset = pd.DatetimeIndex([dt.datetime(1994, 1, 2, 16, 59, 55),]
-                                  ).tz_localize('UTC').astype(int)*1.0/10**9
+                                  ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunrise = pd.DatetimeIndex([dt.datetime(1994, 1, 2, 7, 8, 12),]
-                                   ).tz_localize('UTC').astype(int)*1.0/10**9
+                                   ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         result = self.spa.transit_sunrise_sunset(times, 35.0, 0.0, 64.0, 1)
         npt.assert_almost_equal(sunrise/1e3, result[1]/1e3, 3)
         npt.assert_almost_equal(sunset/1e3, result[2]/1e3, 3)
@@ -274,17 +274,17 @@ class SpaBase(object):
                                   dt.datetime(2015, 4, 2),
                                   dt.datetime(2015, 8, 2),
                                   dt.datetime(2015, 12, 2),],
-                                 ).tz_localize('UTC').astype(int)*1.0/10**9
+                                 ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunrise = pd.DatetimeIndex([dt.datetime(2015, 1, 2, 7, 19),
                                     dt.datetime(2015, 4, 2, 5, 43),
                                     dt.datetime(2015, 8, 2, 5, 1),
                                     dt.datetime(2015, 12, 2, 7, 1),],
-                                   ).tz_localize('MST').astype(int)*1.0/10**9
+                                   ).tz_localize('MST').astype(np.int64)*1.0/10**9
         sunset = pd.DatetimeIndex([dt.datetime(2015, 1, 2, 16, 49),
                                    dt.datetime(2015, 4, 2, 18, 24),
                                    dt.datetime(2015, 8, 2, 19, 10),
                                    dt.datetime(2015, 12, 2, 16, 38),],
-                                  ).tz_localize('MST').astype(int)*1.0/10**9
+                                  ).tz_localize('MST').astype(np.int64)*1.0/10**9
         result = self.spa.transit_sunrise_sunset(times, 39.0, -105.0, 64.0, 1)
         npt.assert_almost_equal(sunrise/1e3, result[1]/1e3, 1)
         npt.assert_almost_equal(sunset/1e3, result[2]/1e3, 1)
@@ -294,19 +294,19 @@ class SpaBase(object):
                                   dt.datetime(2015, 4, 2),
                                   dt.datetime(2015, 8, 2),
                                   dt.datetime(2015, 12, 2),],
-                                 ).tz_localize('UTC').astype(int)*1.0/10**9
+                                 ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunrise = pd.DatetimeIndex([dt.datetime(2015, 1, 2, 7, 36),
                                     dt.datetime(2015, 4, 2, 5, 58),
                                     dt.datetime(2015, 8, 2, 5, 13),
                                     dt.datetime(2015, 12, 2, 7, 17),],
                                    ).tz_localize('Asia/Shanghai'
-                                   ).astype(int)*1.0/10**9
+                                   ).astype(np.int64)*1.0/10**9
         sunset = pd.DatetimeIndex([dt.datetime(2015, 1, 2, 17, 0),
                                    dt.datetime(2015, 4, 2, 18, 39),
                                    dt.datetime(2015, 8, 2, 19, 28),
                                    dt.datetime(2015, 12, 2, 16, 50),],
                                   ).tz_localize('Asia/Shanghai'
-                                  ).astype(int)*1.0/10**9
+                                  ).astype(np.int64)*1.0/10**9
         result = self.spa.transit_sunrise_sunset(times, 39.917, 116.383, 64.0,1)
         npt.assert_almost_equal(sunrise/1e3, result[1]/1e3, 1)
         npt.assert_almost_equal(sunset/1e3, result[2]/1e3, 1)


### PR DESCRIPTION
Fixes #63

On some machines, the python `int` type is 32-bits but pandas represents `Timestamp` objects as 64-bit integers. This causes conversion of a `DateTimeIndex` to seconds since an epoch with `.astype(int)` to fail.