### PR TITLE
Doctest fixes

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.2.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.2.0.txt
@@ -26,6 +26,7 @@ Bug fixes
 * The release date of 0.1 was fixed in the documentation
   (see :ref:`whatsnew_0100`)
 * fix casting of DateTimeIndex to int64 epoch timestamp on machines with 32 bit python int (:issue:`63`)
+* fixed some docstrings with failing doctests (:issue:`62`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -511,9 +511,10 @@ def retrieve_sam(name=None, samfile=None):
     Examples
     --------
 
-    >>> invdb = pvsystem.retrieveSAM(name='SandiaInverter')
+    >>> from pvlib import pvsystem
+    >>> invdb = pvsystem.retrieve_sam(name='SandiaInverter')
     >>> inverter = invdb.AE_Solar_Energy__AE6_0__277V__277V__CEC_2012_
-    >>> inverter    
+    >>> inverter
     Vac           277.000000
     Paco         6000.000000
     Pdco         6165.670000

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -432,8 +432,8 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
          Source: [4]
 
      Copper Indium Gallium diSelenide (CIGS):
-         EgRef = 1.15
-         dEgdT = ????
+         * EgRef = 1.15
+         * dEgdT = ????
 
          >>> M = np.polyval([-9.07E-5, 0.0022, -0.0202, 0.0652, 0.9417],
          ...                AMa) # doctest: +SKIP
@@ -444,7 +444,8 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
          * EgRef = 1.424
          * dEgdT = -0.000433
          * M = unknown
-         Source = [4]
+
+         Source: [4]
     '''
 
     M = np.max(M, 0)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -405,47 +405,46 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
     temperature, and airmass) per DeSoto's equations.
 
      Silicon (Si):
-         EgRef = 1.121
-         dEgdT = -0.0002677
+         * EgRef = 1.121
+         * dEgdT = -0.0002677
 
-         >>> M = polyval([-0.000126, 0.002816, -0.024459, 0.086257, 0.918093],
-         ...             AMa) # doctest: +SKIP
+         >>> M = np.polyval([-1.26E-4, 2.816E-3, -0.024459, 0.086257, 0.918093],
+         ...                AMa) # doctest: +SKIP
 
-         Source: Reference 1
+         Source: [1]
 
      Cadmium Telluride (CdTe):
-         EgRef = 1.475
-         dEgdT = -0.0003
+         * EgRef = 1.475
+         * dEgdT = -0.0003
 
-         >>> M = polyval([-2.46E-5, 9.607E-4, -0.0134, 0.0716, 0.9196],
-         ...             AMa) # doctest: +SKIP
+         >>> M = np.polyval([-2.46E-5, 9.607E-4, -0.0134, 0.0716, 0.9196],
+         ...                AMa) # doctest: +SKIP
 
-         Source = Reference 4
+         Source: [4]
 
      Copper Indium diSelenide (CIS):
-         EgRef = 1.010
-         dEgdT = -0.00011
+         * EgRef = 1.010
+         * dEgdT = -0.00011
 
-         >>> M = polyval([-3.74E-5, 0.00125, -0.01462, 0.0718, 0.9210],
-         ...             AMa) # doctest: +SKIP
+         >>> M = np.polyval([-3.74E-5, 0.00125, -0.01462, 0.0718, 0.9210],
+         ...                AMa) # doctest: +SKIP
 
-         Source = Reference 4
+         Source: [4]
 
      Copper Indium Gallium diSelenide (CIGS):
          EgRef = 1.15
          dEgdT = ????
 
-         >>> M = polyval([-9.07E-5, 0.0022, -0.0202, 0.0652, 0.9417],
-         ...             AMa) # doctest: +SKIP
+         >>> M = np.polyval([-9.07E-5, 0.0022, -0.0202, 0.0652, 0.9417],
+         ...                AMa) # doctest: +SKIP
 
-         Source = Wikipedia
+         Source: Wikipedia
 
      Gallium Arsenide (GaAs):
-
-         EgRef = 1.424
-         dEgdT = -0.000433
-         M = unknown
-         Source = Reference 4
+         * EgRef = 1.424
+         * dEgdT = -0.000433
+         * M = unknown
+         Source = [4]
     '''
 
     M = np.max(M, 0)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -326,7 +326,8 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
         to be 1). Source [1] suggests that an appropriate value for M
         as a function absolute airmass (AMa) may be:
 
-        >>> M = np.polyval([-0.000126, 0.002816, -0.024459, 0.086257, 0.918093], AMa)
+        >>> M = np.polyval([-0.000126, 0.002816, -0.024459, 0.086257, 0.918093],
+        ...                AMa) # doctest: +SKIP
 
         M may be a DataFrame.
 
@@ -407,15 +408,17 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
          EgRef = 1.121
          dEgdT = -0.0002677
 
-         >>> M = polyval([-0.000126 0.002816 -0.024459 0.086257 0.918093], AMa)
+         >>> M = polyval([-0.000126, 0.002816, -0.024459, 0.086257, 0.918093],
+         ...             AMa) # doctest: +SKIP
 
-         Source = Reference 1
+         Source: Reference 1
 
      Cadmium Telluride (CdTe):
          EgRef = 1.475
          dEgdT = -0.0003
 
-         >>> M = polyval([-2.46E-5 9.607E-4 -0.0134 0.0716 0.9196], AMa)
+         >>> M = polyval([-2.46E-5, 9.607E-4, -0.0134, 0.0716, 0.9196],
+         ...             AMa) # doctest: +SKIP
 
          Source = Reference 4
 
@@ -423,7 +426,8 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
          EgRef = 1.010
          dEgdT = -0.00011
 
-         >>> M = polyval([-3.74E-5 0.00125 -0.01462 0.0718 0.9210], AMa)
+         >>> M = polyval([-3.74E-5, 0.00125, -0.01462, 0.0718, 0.9210],
+         ...             AMa) # doctest: +SKIP
 
          Source = Reference 4
 
@@ -431,7 +435,8 @@ def calcparams_desoto(S, temp_cell, alpha_isc, module_parameters, EgRef,
          EgRef = 1.15
          dEgdT = ????
 
-         >>> M = polyval([-9.07E-5 0.0022 -0.0202 0.0652 0.9417], AMa)
+         >>> M = polyval([-9.07E-5, 0.0022, -0.0202, 0.0652, 0.9417],
+         ...             AMa) # doctest: +SKIP
 
          Source = Wikipedia
 


### PR DESCRIPTION
Fixed existing doctests so that

`nosetests -v -w pvlib --with-coverage --cover-package=pvlib --with-doctest`

runs without failure.

Not sure if this work for all versions, as the string representation of pandas objects changed in recent versions (doctest compares the output, so older versions may fail).
