### PR TITLE
Updated pointers to current SAM files, updated column names, ... 

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.2.1.txt
+++ b/docs/sphinx/source/whatsnew/v0.2.1.txt
@@ -7,6 +7,12 @@ This is a minor release from 0.2. It includes a large number of bug fixes
 for the IPython notebook tutorials.
 We recommend that all users upgrade to this version.
 
+Enhancements
+~~~~~~~~~~~~
+
+* Update component info from SAM (csvs dated 2015-6-30) (:issue:`75`)
+
+
 Bug fixes
 ~~~~~~~~~
 
@@ -17,3 +23,4 @@ Contributors
 ~~~~~~~~~~~~
 
 * Will Holmgren
+* Jessica Forbess

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -472,13 +472,13 @@ def calcparams_desoto(poa_global, temp_cell, alpha_isc, module_parameters,
 
 def retrieve_sam(name=None, samfile=None):
     '''
-    Retrieve lastest module and inverter info from SAM website.
+    Retrieve latest module and inverter info from SAM website.
 
     This function will retrieve either:
 
         * CEC module database
         * Sandia Module database
-        * Sandia Inverter database
+        * CEC Inverter database
 
     and return it as a pandas dataframe.
 
@@ -489,7 +489,8 @@ def retrieve_sam(name=None, samfile=None):
         Name can be one of:
 
         * 'CECMod' - returns the CEC module database
-        * 'SandiaInverter' - returns the Sandia Inverter database
+        * 'CECInverter' - returns the CEC Inverter database
+        * 'SandiaInverter' - returns the CEC Inverter database (CEC is only current inverter db available; tag kept for backwards compatibility)
         * 'SandiaMod' - returns the Sandia Module database
         
     samfile : String
@@ -503,14 +504,14 @@ def retrieve_sam(name=None, samfile=None):
     Returns
     -------
     A DataFrame containing all the elements of the desired database. 
-    Each column representa a module or inverter, and a specific dataset
-    can be retreived by the command
+    Each column represents a module or inverter, and a specific dataset
+    can be retrieved by the command
 
     Examples
     --------
 
     >>> from pvlib import pvsystem
-    >>> invdb = pvsystem.retrieve_sam(name='SandiaInverter')
+    >>> invdb = pvsystem.retrieve_sam(name='CECInverter')
     >>> inverter = invdb.AE_Solar_Energy__AE6_0__277V__277V__CEC_2012_
     >>> inverter
     Vac           277.000000

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -99,7 +99,7 @@ sam_data = {}
 def test_retrieve_sam_network():
     sam_data['cecmod'] = pvsystem.retrieve_sam('cecmod')
     sam_data['sandiamod'] = pvsystem.retrieve_sam('sandiamod')
-    sam_data['sandiainverter'] = pvsystem.retrieve_sam('sandiainverter')
+    sam_data['cecinverter'] = pvsystem.retrieve_sam('cecinverter')
 
 
 def test_sapm():
@@ -180,7 +180,7 @@ def test_sapm_celltemp_with_index():
 
     
 def test_snlinverter():
-    inverters = sam_data['sandiainverter']
+    inverters = sam_data['cecinverter']
     testinv = 'ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_'
     vdcs = pd.Series(np.linspace(0,50,3))
     idcs = pd.Series(np.linspace(0,11,3))
@@ -191,7 +191,7 @@ def test_snlinverter():
 
 
 def test_snlinverter_float():
-    inverters = sam_data['sandiainverter']
+    inverters = sam_data['cecinverter']
     testinv = 'ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_'
     vdcs = 25.
     idcs = 5.5

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -117,7 +117,7 @@ def test_calcparams_desoto():
     cecmodule = sam_data['cecmod'].Example_Module 
     pvsystem.calcparams_desoto(irrad_data['ghi'],
                                temp_cell=25,
-                               alpha_isc=cecmodule['Alpha_sc'],
+                               alpha_isc=cecmodule['alpha_sc'],
                                module_parameters=cecmodule,
                                EgRef=1.121,
                                dEgdT=-0.0002677)
@@ -133,7 +133,7 @@ def test_singlediode_series():
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
                                          irrad_data['ghi'],
                                          temp_cell=25,
-                                         alpha_isc=cecmodule['Alpha_sc'],
+                                         alpha_isc=cecmodule['alpha_sc'],
                                          module_parameters=cecmodule,
                                          EgRef=1.121,
                                          dEgdT=-0.0002677)                       
@@ -198,5 +198,5 @@ def test_snlinverter_float():
     pdcs = idcs * vdcs
 
     pacs = pvsystem.snlinverter(inverters[testinv], vdcs, pdcs)
-    assert_almost_equals(pacs, 132.004308, 5)
+    assert_almost_equals(pacs, 132.004278, 5)
     


### PR DESCRIPTION
and added more replace chars for equipment names [Issue 75]. 

The calcparams_desoto and sapm functions won't work with the previous csv files, because Sandia changed some column names between CSVs, and the change is hardcoded. It seems worth forcing the upgrade, though. 