### PR TITLE
Python 3.5, reconfigure Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,71 @@
+# Based on
+# http://conda.pydata.org/docs/travis.html
+# https://github.com/xray/xray/blob/master/.travis.yml
+# https://github.com/scipy/scipy/blob/master/.travis.yml
+
 language: python
-python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-env:
-    - PD_VERSION=0.13.1
-    - PD_VERSION="0.14.*"
-    - PD_VERSION="0.15.*"
-    - PD_VERSION="0.16.*"
-    - PD_VERSION="0.17.*"
+sudo: false # if false, use TravisCI's container based build
+
+matrix:
+    include:
+    - python: 2.7
+      env: CONDA_ENV=py27-min
+    - python: 2.7
+      env: CONDA_ENV=py27
+    - python: 3.4
+      env: CONDA_ENV=py34
+      addons:
+          apt:
+            packages:
+            - libatlas-dev
+            - libatlas-base-dev
+            - liblapack-dev
+            - gfortran
+            - libgmp-dev
+            - libmpfr-dev
+    - python: 3.5
+      env: CONDA_ENV=py35
+      addons:
+          apt:
+            packages:
+            - libatlas-dev
+            - libatlas-base-dev
+            - liblapack-dev
+            - gfortran
+            - libgmp-dev
+            - libmpfr-dev
+
+
+#    - ccache
+#cache:
+#  directories:
+#    - $HOME/.ccache
 
 # setup miniconda for numpy, scipy, pandas
 before_install:
     - echo "before install"
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
-    - sudo rm -rf /dev/shm
-    - sudo ln -s /run/shm /dev/shm
-    - date
-    - uname -a
-    - python -V
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
     
 install:
     - echo "install"
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas=$PD_VERSION nose pytz ephem; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' || $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION numpy=1.8 scipy=0.14 pandas nose pytz ephem; conda install --yes pandas=$PD_VERSION --no-deps; fi
-    - test $PD_VERSION != 0.13.1 && conda install --yes "numba>=0.17" || echo "Not installing numba"
-    - conda install --yes coverage
-    - pip install coveralls
+    - conda env create --file ci/requirements-$CONDA_ENV.yml
+    - source activate test_env # all envs are named test_env in the yml files
+    - conda list
+    - echo $PATH
+    - ls -l /home/travis/miniconda/envs/test_env/lib
+    #- pip install . # use pip to automatically install anything not in the yml files (i.e. numpy/scipy/pandas for py3*)
+    - pip install scipy # won't do anything if already installed
     - python setup.py install
-    # for nosetests to actually work since it alters the path
-    - python setup.py build_ext --inplace
 
 script:
     - nosetests -v --with-coverage --cover-package=pvlib pvlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
 env:
     - PD_VERSION=0.13.1
     - PD_VERSION="0.14.*"
     - PD_VERSION="0.15.*"
     - PD_VERSION="0.16.*"
+    - PD_VERSION="0.17.*"
 
 # setup miniconda for numpy, scipy, pandas
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,19 @@ matrix:
             - libgmp-dev
             - libmpfr-dev
 
+addons:
+    apt:
+        packages:
+            - ccache
 
-#    - ccache
-#cache:
-#  directories:
-#    - $HOME/.ccache
+cache:
+    directories:
+        - $HOME/.ccache
 
 # setup miniconda for numpy, scipy, pandas
 before_install:
     - echo "before install"
+    - export PATH=/usr/lib/ccache:$PATH
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
       else

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ License
 Compatibility
 =============
 
-pvlib-python is compatible with Python versions 2.7, 3.3, and 3.4, and pandas versions 0.13.1 through 0.16.2.
+pvlib-python is compatible with Python versions 2.7, 3.3, 3.4, 3.5 and Pandas versions 0.13.1 through 0.17. Note that our Numba-accelerated solar position algorithms have more specific version requirements that will be resolved by the Numba installer.
 
-For Linux + Python 3 users: The combination of Linux, Python 3, NumPy 1.9, and SciPy 0.15 has some bugs. The most common place for these bugs to show up when using pvlib-python is in calculating IV curve parameters using the ``singlediode`` function. Downgrade your NumPy to 1.8 and SciPy to 0.14, then install whatever version of pandas you want but without dependencies. The conda commands for this are:
+For Linux + Python 3 users: Continuum's Python 3.x SciPy conda package is not compiled properly and has a few bugs related to complex arithmetic. The most common place for these bugs to show up when using pvlib-python is in calculating IV curve parameters using the ``singlediode`` function. We reported [the issue](https://github.com/ContinuumIO/anaconda-issues/issues/425) to Continuum and are waiting for it to be fixed. In the meantime, you can compile your own SciPy distribution, or you can use this trick on Python 3.3 and 3.4 (not 3.5): Downgrade your NumPy to 1.8 and SciPy to 0.14, then install whatever version of pandas you want but without dependencies. The conda commands for this are:
 
 ```
 conda install numpy=1.8 scipy=0.14

--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+    - python=2.7 
+    - numpy==1.8.2
+    - scipy
+    - pandas==0.13.1
+    - nose
+    - pytz
+    - ephem
+    - pip:
+        - coveralls

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -1,0 +1,12 @@
+name: test_env
+dependencies:
+    - python=2.7 
+    - numpy
+    - scipy
+    - pandas
+    - nose
+    - pytz
+    - ephem
+    - numba
+    - pip:
+        - coveralls

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+    - python=3.4
+    - nose
+    - pytz
+    - ephem
+    #- numba
+    - pip:
+        - numpy
+        - pandas
+        - coveralls

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+    - python=3.5
+    - nose
+    - pytz
+    - ephem
+#    - numba
+    - pip:
+        - numpy
+        - pandas
+        - coveralls

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(version_file, 'r') as f:
     exec(f.read())
 
 # check python version.
-if not sys.version_info[:2] in ((2,7), (3,3), (3,4)):
+if not sys.version_info[:2] in ((2,7), (3,3), (3,4), (3,5)):
    sys.exit('%s requires Python 2.7, 3.3, or 3.4' % DISTNAME)
 
 setuptools_kwargs = {

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if not sys.version_info[:2] in ((2,7), (3,3), (3,4), (3,5)):
 
 setuptools_kwargs = {
     'zip_safe': False,
-    'install_requires': ['numpy >= 1.7.0',
+    'install_requires': ['numpy >= 1.8.2',
                          'pandas >= 0.13.1',
                          'pytz',
                          'six',


### PR DESCRIPTION
This PR primarily does two things:
* Allows pvlib to be installed on Python 3.5
* Reconfigures the TravisCI set up to work around Continuum's crappy scipy/linux/python3 package.

I originally thought that there was an issue with scipy/linux/python3, but it turns out that it's actually a problem with the version of gcc that Continuum uses to build scipy. For more, see ContinuumIO/anaconda-issues#425. The Readme text has been updated accordingly. 

The Travis build matrix was getting to be too big and take too long, so this PR only tests the minimum pandas/numpy version on Python 2.7, and the latest versions for Python 2.7, 3.4, and 3.5. I think it is reasonable to say that pvlib is supported on the intermediate versions (Python 3.3, pandas 0.14-0.16) even if we're not explicitly testing for it.

One thing that I'm no longer testing is the numba accelerated SPA code on Python 3. It is still tested on Python 2.7. I'll change it once Continuum gets their SciPy packages fixed. I've already spent way too much time on this PR to hack this together too.

@bmu @Calama-Consulting I will merge this in ~24 hours if nobody objects. I think it's also worth the effort to make a minor release later this week.

Closes #87.