### PR TITLE
avoid the conda/travis/pip/scipy mess with a simple skip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,26 +14,8 @@ matrix:
       env: CONDA_ENV=py27
     - python: 3.4
       env: CONDA_ENV=py34
-      addons:
-          apt:
-            packages:
-            - libatlas-dev
-            - libatlas-base-dev
-            - liblapack-dev
-            - gfortran
-            - libgmp-dev
-            - libmpfr-dev
     - python: 3.5
       env: CONDA_ENV=py35
-      addons:
-          apt:
-            packages:
-            - libatlas-dev
-            - libatlas-base-dev
-            - liblapack-dev
-            - gfortran
-            - libgmp-dev
-            - libmpfr-dev
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
     - echo $PATH
     - ls -l /home/travis/miniconda/envs/test_env/lib
     #- pip install . # use pip to automatically install anything not in the yml files (i.e. numpy/scipy/pandas for py3*)
-    - pip install scipy # won't do anything if already installed
+    #- pip install scipy # won't do anything if already installed
     - python setup.py install
 
 script:

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -1,11 +1,12 @@
 name: test_env
 dependencies:
     - python=3.4
+    - numpy
+    - scipy
+    - pandas
     - nose
     - pytz
     - ephem
-    #- numba
+    - numba
     - pip:
-        - numpy
-        - pandas
         - coveralls

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -1,11 +1,12 @@
 name: test_env
 dependencies:
     - python=3.5
+    - numpy
+    - scipy
+    - pandas
     - nose
     - pytz
     - ephem
-#    - numba
+    - numba
     - pip:
-        - numpy
-        - pandas
         - coveralls

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -2,6 +2,7 @@
 # the xray/xarray project
 
 import sys
+import platform
 
 try:
     import unittest2 as unittest
@@ -17,15 +18,16 @@ except ImportError:
 def requires_scipy(test):
     return test if has_scipy else unittest.skip('requires scipy')(test)
 
-def incompatible_conda_py3(test):
+def incompatible_conda_linux_py3(test):
     """
     Test won't work in Python 3.x due to Anaconda issue.
     """
     major = sys.version_info[0]
     minor = sys.version_info[1]
+    system = platform.system()
 
-    if major == 3:
-        out = unittest.skip('error on Python 3 due to anaconda')(test)
+    if major == 3 and system == 'Linux':
+        out = unittest.skip('error on Linux Python 3 due to Anaconda')(test)
     else:
         out = test
 

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -1,0 +1,29 @@
+import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    import scipy
+    has_scipy = True
+except ImportError:
+    has_scipy = False
+
+def requires_scipy(test):
+    return test if has_scipy else unittest.skip('requires scipy')(test)
+
+def incompatible_conda_py3(test):
+    """
+    Test won't work in Python 3.x due to Anaconda issue.
+    """
+    major = sys.version_info[0]
+    minor = sys.version_info[1]
+
+    if major == 3:
+        out = unittest.skip('error on Python 3 due to anaconda')(test)
+    else:
+        out = test
+
+    return out

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -1,3 +1,6 @@
+# the has/skip patterns closely follow the examples set by
+# the xray/xarray project
+
 import sys
 
 try:

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from nose.tools import assert_equals, assert_almost_equals
 from pandas.util.testing import assert_series_equal, assert_frame_equal
+from . import incompatible_conda_py3
 
 from pvlib import tmy
 from pvlib import pvsystem
@@ -122,7 +123,7 @@ def test_calcparams_desoto():
                                EgRef=1.121,
                                dEgdT=-0.0002677)
 
-
+@incompatible_conda_py3
 def test_i_from_v():
     output = pvsystem.i_from_v(20, .1, .5, 40, 6e-7, 7)
     assert_almost_equals(-299.746389916, output, 5)
@@ -140,7 +141,7 @@ def test_singlediode_series():
     out = pvsystem.singlediode(cecmodule, IL, I0, Rs, Rsh, nNsVth)
     assert isinstance(out, pd.DataFrame)
 
-
+@incompatible_conda_py3
 def test_singlediode_series():  
     cecmodule = sam_data['cecmod'].Example_Module                       
     out = pvsystem.singlediode(cecmodule, 7, 6e-7, .1, 20, .5)

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from nose.tools import assert_equals, assert_almost_equals
 from pandas.util.testing import assert_series_equal, assert_frame_equal
-from . import incompatible_conda_py3
+from . import incompatible_conda_linux_py3
 
 from pvlib import tmy
 from pvlib import pvsystem
@@ -123,7 +123,7 @@ def test_calcparams_desoto():
                                EgRef=1.121,
                                dEgdT=-0.0002677)
 
-@incompatible_conda_py3
+@incompatible_conda_linux_py3
 def test_i_from_v():
     output = pvsystem.i_from_v(20, .1, .5, 40, 6e-7, 7)
     assert_almost_equals(-299.746389916, output, 5)
@@ -141,7 +141,7 @@ def test_singlediode_series():
     out = pvsystem.singlediode(cecmodule, IL, I0, Rs, Rsh, nNsVth)
     assert isinstance(out, pd.DataFrame)
 
-@incompatible_conda_py3
+@incompatible_conda_linux_py3
 def test_singlediode_series():  
     cecmodule = sam_data['cecmod'].Example_Module                       
     out = pvsystem.singlediode(cecmodule, 7, 6e-7, .1, 20, .5)


### PR DESCRIPTION
This PR simplifies the testing configuration mess. It simply skips a couple of tests that we know will fail due to Anaconda+Python3+Linux problems. All of the tests will still run on the Python 2.7 build.

Some history... In PR #90 I reconfigured Travis to build numpy, pandas, and scipy, if necessary. That has turned out be a poor solution. The tests take forever to run and often fail because of the long time that it takes to compile scipy. I'm also in the process of creating a PR with forecasting tools (see #86), which will require more tests for optional dependencies, and that will benefit from a simplified testing configuration.

I'll merge in 24 hours unless there are objections.