### PR TITLE
Add hint that cec-database does not provide coefficients for the sapm function

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.2.2.txt
+++ b/docs/sphinx/source/whatsnew/v0.2.2.txt
@@ -1,7 +1,7 @@
 .. _whatsnew_0220:
 
 v0.2.2 (November 13, 2015)
------------------------
+--------------------------
 
 This is a minor release from 0.2.1.
 We recommend that all users upgrade to this version.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -641,9 +641,9 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
     The coefficients from SAPM which are required in ``module`` are listed in
     the following table.
 
-    Remark that modules of the Sandia module database contain these
-    coefficients but modules of the CEC module database do not. Both databases
-    can be accessed using :py:func:`retrieve_sam`.
+    The modules in the Sandia module database contain these coefficients, but
+    the modules in the CEC module database do not. Both databases can be
+    accessed using :py:func:`retrieve_sam`.
 
     ================   ========================================================
     Key                Description

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -603,7 +603,8 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
     Parameters
     ----------
     module : Series or dict
-        A DataFrame defining the SAPM performance parameters.
+        A DataFrame defining the SAPM performance parameters. See the notes
+        section for more details.
 
     poa_direct : Series
         The direct irradiance incident upon the module (W/m^2).
@@ -637,7 +638,12 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
 
     Notes
     -----
-    The coefficients from SAPM which are required in ``module`` are:
+    The coefficients from SAPM which are required in ``module`` are listed in
+    the following table.
+
+    Remark that modules of the Sandia module database contain these
+    coefficients but modules of the CEC module database do not. Both databases
+    can be accessed using :py:func:`retrieve_sam`.
 
     ================   ========================================================
     Key                Description

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -637,35 +637,37 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
     -----
     The coefficients from SAPM which are required in ``module`` are:
 
-    ========   ===============================================================
-    Key        Description
-    ========   ===============================================================
-    A0-A4      The airmass coefficients used in calculating
-               effective irradiance
-    B0-B5      The angle of incidence coefficients used in calculating
-               effective irradiance
-    C0-C7      The empirically determined coefficients relating
-               Imp, Vmp, Ix, and Ixx to effective irradiance
-    Isco       Short circuit current at reference condition (amps)
-    Impo       Maximum power current at reference condition (amps)
-    Aisc       Short circuit current temperature coefficient at
-               reference condition (1/C)
-    Aimp       Maximum power current temperature coefficient at
-               reference condition (1/C)
-    Bvoco      Open circuit voltage temperature coefficient at
-               reference condition (V/C)
-    Mbvoc      Coefficient providing the irradiance dependence for the BetaVoc
-               temperature coefficient at reference irradiance (V/C)
-    Bvmpo      Maximum power voltage temperature coefficient at
-               reference condition
-    Mbvmp      Coefficient providing the irradiance dependence for the
-               BetaVmp temperature coefficient at reference irradiance (V/C)
-    N          Empirically determined "diode factor" (dimensionless)
+    ================   ========================================================
+    Key                Description
+    ================   ========================================================
+    A0-A4              The airmass coefficients used in calculating
+                       effective irradiance
+    B0-B5              The angle of incidence coefficients used in calculating
+                       effective irradiance
+    C0-C7              The empirically determined coefficients relating
+                       Imp, Vmp, Ix, and Ixx to effective irradiance
+    Isco               Short circuit current at reference condition (amps)
+    Impo               Maximum power current at reference condition (amps)
+    Aisc               Short circuit current temperature coefficient at
+                       reference condition (1/C)
+    Aimp               Maximum power current temperature coefficient at
+                       reference condition (1/C)
+    Bvoco              Open circuit voltage temperature coefficient at
+                       reference condition (V/C)
+    Mbvoc              Coefficient providing the irradiance dependence for the
+                       BetaVoc temperature coefficient at reference irradiance
+                       (V/C)
+    Bvmpo              Maximum power voltage temperature coefficient at
+                       reference condition
+    Mbvmp              Coefficient providing the irradiance dependence for the
+                       BetaVmp temperature coefficient at reference irradiance
+                       (V/C)
+    N                  Empirically determined "diode factor" (dimensionless)
     Cells_in_Series    Number of cells in series in a module's cell string(s)
-    IXO        Ix at reference conditions
-    IXXO       Ixx at reference conditions
-    FD         Fraction of diffuse irradiance used by module
-    ========   ===============================================================
+    IXO                Ix at reference conditions
+    IXXO               Ixx at reference conditions
+    FD                 Fraction of diffuse irradiance used by module
+    ================   ========================================================
 
     References
     ----------


### PR DESCRIPTION
Please have a look at the commits 5f0df9f and 110688e. Commit f81529b contains only pep8 changes. Sorry it is knee-jerk and if you don't like you can just revert it.

The first commit (5f0df9f) fixes the table in the docstring of the sapm function. It does not show up in the current documentation (see: http://pvlib-python.readthedocs.org/en/latest/pvlib.html#pvlib.pvsystem.sapm)

The third commit (110688e) adds the new hints. Please fix typos if necessary, my English is not too good.

There are 6 Errors using `nosetest3` but they have been there before my changes.