### PR TITLE
add missing functions section to matlab page

### DIFF
--- a/docs/sphinx/source/comparison_pvlib_matlab.rst
+++ b/docs/sphinx/source/comparison_pvlib_matlab.rst
@@ -17,6 +17,13 @@ will require the efforts of the larger pvlib-python community, not just
 the maintainers. Therefore, do not expect feature parity between the
 libaries, only similarity.
 
+Missing functions
+~~~~~~~~~~~~~~~~~
+
+See pvlib-python GitHub `issue #2
+<https://github.com/pvlib/pvlib-python/issues/2>`_ for a list of
+functions missing from the Python version of the library.
+
 Major differences
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I added a link to issue #2 to the matlab differences page.