### PR TITLE
Resolve #140 snlinverter night tare power issue

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.3.1.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.1.txt
@@ -15,8 +15,10 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+* Fixes snlinverter Pnt problem (:issue:`140`)
 
 
 Contributors
 ~~~~~~~~~~~~
 
+* ejmiller2

--- a/docs/sphinx/source/whatsnew/v0.3.1.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.1.txt
@@ -15,7 +15,12 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-* Fixes night tare issue in snlinverter. When the DC input power (p_dc) to an inverter is below the inversion startup power (Ps0), the model should set the AC output (ac_power) to the night tare value (Pnt). The night tare power indicates the power consumed by the inverter to sense PV array voltage. The model was erroneously comparing Ps0 with the AC output power (ac_power), rather than the DC input power (p_dc).
+* Fixes night tare issue in snlinverter. When the DC input power (p_dc)
+  to an inverter is below the inversion startup power (Ps0), the model
+  should set the AC output (ac_power) to the night tare value (Pnt). 
+  The night tare power indicates the power consumed by the inverter to
+  sense PV array voltage. The model was erroneously comparing Ps0 with
+  the AC output power (ac_power), rather than the DC input power (p_dc).
 
 
 Contributors

--- a/docs/sphinx/source/whatsnew/v0.3.1.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.1.txt
@@ -15,7 +15,7 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-* Fixes snlinverter Pnt problem (:issue:`140`)
+* Fixes night tare issue in snlinverter. When the DC input power (p_dc) to an inverter is below the inversion startup power (Ps0), the model should set the AC output (ac_power) to the night tare value (Pnt). The night tare power indicates the power consumed by the inverter to sense PV array voltage. The model was erroneously comparing Ps0 with the AC output power (ac_power), rather than the DC input power (p_dc).
 
 
 Contributors

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1662,7 +1662,7 @@ def snlinverter(inverter, v_dc, p_dc):
 
     ac_power = (Paco/(A-B) - C*(A-B)) * (p_dc-B) + C*((p_dc-B)**2)
     ac_power[ac_power > Paco] = Paco
-    ac_power[ac_power < Pso] = - 1.0 * abs(Pnt)
+    ac_power[p_dc < Pso] = - 1.0 * abs(Pnt)
 
     if len(ac_power) == 1:
         ac_power = ac_power.ix[0]

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -384,6 +384,17 @@ def test_snlinverter_float():
     assert_almost_equals(pacs, 132.004278, 5)
 
 
+def test_snlinverter_Pnt_micro():
+    inverters = sam_data['cecinverter']
+    testinv = 'Enphase_Energy__M250_60_2LL_S2x___ZC____NA__208V_208V__CEC_2013_'
+    vdcs = pd.Series(np.linspace(0,50,3))
+    idcs = pd.Series(np.linspace(0,11,3))
+    pdcs = idcs * vdcs
+
+    pacs = pvsystem.snlinverter(inverters[testinv], vdcs, pdcs)
+    assert_series_equal(pacs, pd.Series([-0.043000, 132.545914746, 240.000000]))
+
+
 def test_PVSystem_creation():
     pv_system = pvsystem.PVSystem(module='blah', inverter='blarg')
 


### PR DESCRIPTION
Fixing #140 by changing the start power (Pso) comparison to use the DC input power (p_dc) instead of the calculated AC power (ac_power).