### PR TITLE
implement simplified solis clear sky model

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.3.3.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.3.txt
@@ -1,6 +1,6 @@
 .. _whatsnew_0330:
 
-v0.3.3 (June xx, 2016)
+v0.3.3 (June 15, 2016)
 -----------------------
 
 This is a minor release from 0.3.2.
@@ -32,6 +32,7 @@ Enhancements
   (:issue:`190`)
 * Improve speed of ``singlediode`` function by using ``v_from_i`` to
   determine ``v_oc``. Speed is ~2x faster. (:issue:`190`)
+* Adds the Simplified Solis clear sky model. (:issue:`148`)
 
 
 Bug fixes

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -368,9 +368,10 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
     Returns
     --------
     clearsky : pd.DataFrame or np.array (determined by ``return_raw``)
-        DataFrame contains the columns ``ghi, dni, dhi`` with the units
-        of the ``dni_extra`` input. If ``return_raw=True``, returns the
-        array [dni, ghi, dhi] with shape determined by the input arrays.
+        DataFrame contains the columns ``'dhi', 'dni', 'ghi'`` with the
+        units of the ``dni_extra`` input. If ``return_raw=True``,
+        returns the array [dhi, dni, ghi] with shape determined by the
+        input arrays.
 
     References
     ----------
@@ -415,7 +416,7 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
     ghi = i0p * np.exp(-taug/sin_elev**g) * sin_elev
     dhi = i0p * np.exp(-taud/sin_elev**d)
 
-    irrads = np.array([dni, ghi, dhi])
+    irrads = np.array([dhi, dni, ghi])
 
     if not return_raw:
         if isinstance(dni, pd.Series):
@@ -424,13 +425,13 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
             index = None
 
         try:
-            irrads = pd.DataFrame(irrads.T, columns=['dni', 'ghi', 'dhi'],
+            irrads = pd.DataFrame(irrads.T, columns=['dhi', 'dni', 'ghi'],
                                   index=index)
         except ValueError:
             # probably all scalar input, so we
             # need to increase the dimensionality
             irrads = pd.DataFrame(np.array([irrads]),
-                                  columns=['dni', 'ghi', 'dhi'])
+                                  columns=['dhi', 'dni', 'ghi'])
         finally:
             irrads = irrads.fillna(0)
 

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -1,5 +1,5 @@
 """
-The ``clearsky`` module contains several methods 
+The ``clearsky`` module contains several methods
 to calculate clear sky GHI, DNI, and DHI.
 """
 
@@ -19,7 +19,7 @@ from pvlib import atmosphere
 from pvlib import solarposition
 
 
-def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None, 
+def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
              solarposition_method='nrel_numpy', zenith_data=None,
              airmass_model='young1994', airmass_data=None,
              interp_turbidity=True):
@@ -31,37 +31,37 @@ def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
     the clear-sky diffuse horizontal (DHI) component as the difference
     between GHI and DNI*cos(zenith) as presented in [1, 2]. A report on clear
     sky models found the Ineichen/Perez model to have excellent performance
-    with a minimal input data set [3]. 
-    
+    with a minimal input data set [3].
+
     Default values for montly Linke turbidity provided by SoDa [4, 5].
 
     Parameters
     -----------
     time : pandas.DatetimeIndex
-    
+
     latitude : float
-    
+
     longitude : float
 
     altitude : float
-    
+
     linke_turbidity : None or float
         If None, uses ``LinkeTurbidities.mat`` lookup table.
-    
+
     solarposition_method : string
-        Sets the solar position algorithm. 
+        Sets the solar position algorithm.
         See solarposition.get_solarposition()
-    
+
     zenith_data : None or Series
         If None, ephemeris data will be calculated using ``solarposition_method``.
-    
+
     airmass_model : string
         See pvlib.airmass.relativeairmass().
-    
+
     airmass_data : None or Series
-        If None, absolute air mass data will be calculated using 
+        If None, absolute air mass data will be calculated using
         ``airmass_model`` and location.alitude.
-    
+
     interp_turbidity : bool
         If ``True``, interpolates the monthly Linke turbidity values
         found in ``LinkeTurbidities.mat`` to daily values.
@@ -100,16 +100,16 @@ def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
     # Initial implementation of this algorithm by Matthew Reno.
     # Ported to python by Rob Andrews
     # Added functionality by Will Holmgren (@wholmgren)
-    
+
     I0 = irradiance.extraradiation(time.dayofyear)
-    
+
     if zenith_data is None:
         ephem_data = solarposition.get_solarposition(time,
                                                      latitude=latitude,
                                                      longitude=longitude,
                                                      altitude=altitude,
                                                      method=solarposition_method)
-        time = ephem_data.index # fixes issue with time possibly not being tz-aware    
+        time = ephem_data.index # fixes issue with time possibly not being tz-aware
         try:
             ApparentZenith = ephem_data['apparent_zenith']
         except KeyError:
@@ -119,7 +119,7 @@ def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
         ApparentZenith = zenith_data
     #ApparentZenith[ApparentZenith >= 90] = 90 # can cause problems in edge cases
 
-    
+
     if linke_turbidity is None:
         TL = lookup_linke_turbidity(time, latitude, longitude,
                                     interp_turbidity=interp_turbidity)
@@ -128,13 +128,13 @@ def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
 
     # Get the absolute airmass assuming standard local pressure (per
     # alt2pres) using Kasten and Young's 1989 formula for airmass.
-    
+
     if airmass_data is None:
         AMabsolute = atmosphere.absoluteairmass(airmass_relative=atmosphere.relativeairmass(ApparentZenith, airmass_model),
                                                 pressure=atmosphere.alt2pres(altitude))
     else:
         AMabsolute = airmass_data
-        
+
     fh1 = np.exp(-altitude/8000.)
     fh2 = np.exp(-altitude/1250.)
     cg1 = 5.09e-05 * altitude + 0.868
@@ -156,37 +156,37 @@ def ineichen(time, latitude, longitude, altitude=0, linke_turbidity=None,
     #  TLcorr = TL;
     #  TLcorr(TL < 2) = TLcorr(TL < 2) - 0.25 .* (2-TLcorr(TL < 2)) .^ (0.5);
 
-    #  This equation is found in Solar Energy 73, pg 311. 
+    #  This equation is found in Solar Energy 73, pg 311.
     #  Full ref: Perez et. al., Vol. 73, pp. 307-317 (2002).
-    #  It is slightly different than the equation given in Solar Energy 73, pg 156. 
-    #  We used the equation from pg 311 because of the existence of known typos 
-    #  in the pg 156 publication (notably the fh2-(TL-1) should be fh2 * (TL-1)). 
-    
+    #  It is slightly different than the equation given in Solar Energy 73, pg 156.
+    #  We used the equation from pg 311 because of the existence of known typos
+    #  in the pg 156 publication (notably the fh2-(TL-1) should be fh2 * (TL-1)).
+
     cos_zenith = tools.cosd(ApparentZenith)
-    
+
     clearsky_GHI = ( cg1 * I0 * cos_zenith *
                      np.exp(-cg2*AMabsolute*(fh1 + fh2*(TL - 1))) *
                      np.exp(0.01*AMabsolute**1.8) )
     clearsky_GHI[clearsky_GHI < 0] = 0
-    
+
     # BncI == "normal beam clear sky radiation"
     b = 0.664 + 0.163/fh1
     BncI = b * I0 * np.exp( -0.09 * AMabsolute * (TL - 1) )
     logger.debug('b=%s', b)
-    
+
     # "empirical correction" SE 73, 157 & SE 73, 312.
     BncI_2 = ( clearsky_GHI *
                ( 1 - (0.1 - 0.2*np.exp(-TL))/(0.1 + 0.882/fh1) ) /
                cos_zenith )
 
     clearsky_DNI = np.minimum(BncI, BncI_2)
-    
+
     clearsky_DHI = clearsky_GHI - clearsky_DNI*cos_zenith
-    
-    df_out = pd.DataFrame({'ghi':clearsky_GHI, 'dni':clearsky_DNI, 
+
+    df_out = pd.DataFrame({'ghi':clearsky_GHI, 'dni':clearsky_DNI,
                            'dhi':clearsky_DHI})
     df_out.fillna(0, inplace=True)
-    
+
     return df_out
 
 
@@ -222,11 +222,11 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
     # from -180 to 180; and the depth (third dimension) represents months of
     # the year from January (1) to December (12). To determine the Linke
     # turbidity for a position on the Earth's surface for a given month do the
-    # following: LT = LinkeTurbidity(LatitudeIndex, LongitudeIndex, month).  
-    # Note that the numbers within the matrix are 20 * Linke Turbidity, 
+    # following: LT = LinkeTurbidity(LatitudeIndex, LongitudeIndex, month).
+    # Note that the numbers within the matrix are 20 * Linke Turbidity,
     # so divide the number from the file by 20 to get the
-    # turbidity. 
-    
+    # turbidity.
+
     try:
         import scipy.io
     except ImportError:
@@ -252,7 +252,7 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
         # Assume that data corresponds to the value at
         # the middle of each month.
         # This means that we need to add previous Dec and next Jan
-        # to the array so that the interpolation will work for 
+        # to the array so that the interpolation will work for
         # Jan 1 - Jan 15 and Dec 16 - Dec 31.
         # Then we map the month value to the day of year value.
         # This is approximate and could be made more accurate.
@@ -274,12 +274,12 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
 def haurwitz(apparent_zenith):
     '''
     Determine clear sky GHI from Haurwitz model.
-   
+
     Implements the Haurwitz clear sky model for global horizontal
     irradiance (GHI) as presented in [1, 2]. A report on clear
     sky models found the Haurwitz model to have the best performance of
     models which require only zenith angle [3]. Extreme care should
-    be taken in the interpretation of this result! 
+    be taken in the interpretation of this result!
 
     Parameters
     ----------
@@ -288,7 +288,7 @@ def haurwitz(apparent_zenith):
         in degrees.
 
     Returns
-    -------        
+    -------
     pd.Series
     The modeled global horizonal irradiance in W/m^2 provided
     by the Haurwitz clear-sky model.
@@ -298,10 +298,10 @@ def haurwitz(apparent_zenith):
     References
     ----------
 
-    [1] B. Haurwitz, "Insolation in Relation to Cloudiness and Cloud 
+    [1] B. Haurwitz, "Insolation in Relation to Cloudiness and Cloud
      Density," Journal of Meteorology, vol. 2, pp. 154-166, 1945.
 
-    [2] B. Haurwitz, "Insolation in Relation to Cloud Type," Journal of 
+    [2] B. Haurwitz, "Insolation in Relation to Cloud Type," Journal of
      Meteorology, vol. 3, pp. 123-124, 1946.
 
     [3] M. Reno, C. Hansen, and J. Stein, "Global Horizontal Irradiance Clear
@@ -314,16 +314,208 @@ def haurwitz(apparent_zenith):
     clearsky_GHI = 1098.0 * cos_zenith * np.exp(-0.059/cos_zenith)
 
     clearsky_GHI[clearsky_GHI < 0] = 0
-    
+
     df_out = pd.DataFrame({'ghi':clearsky_GHI})
-    
+
     return df_out
 
 
 def _linearly_scale(inputmatrix, inputmin, inputmax, outputmin, outputmax):
     """ used by linke turbidity lookup function """
-    
+
     inputrange = inputmax - inputmin
     outputrange = outputmax - outputmin
     OutputMatrix = (inputmatrix-inputmin) * outputrange/inputrange + outputmin
     return OutputMatrix
+
+
+def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
+                     pressure=101325., dni_extra=1364., return_raw=False):
+    """
+    Calculate the clear sky GHI, DNI, and DHI according to the
+    simplified Solis model [1]_.
+
+    Reference [1]_ describes the accuracy of the model as being 15, 20,
+    and 18 W/m^2 for the beam, global, and diffuse components. Reference
+    [2]_ provides comparisons with other clear sky models.
+
+    Parameters
+    ----------
+    apparent_elevation: numeric
+        The apparent elevation of the sun above the horizon (deg).
+
+    aod700: numeric
+        The aerosol optical depth at 700 nm (unitless).
+        Algorithm derived for values between 0 and 0.45.
+
+    precipitable_water: numeric
+        The precipitable water of the atmosphere (cm).
+        Algorithm derived for values between 0.2 and 10 cm.
+
+    pressure: numeric
+        The atmospheric pressure (Pascals).
+        Algorithm derived for altitudes between sea level and 7000 m,
+        or 101325 and 41000 Pascals.
+
+    dni_extra: numeric
+        Extraterrestrial irradiance.
+
+    return_raw: bool
+        Controls the return type. If False, function returns a DataFrame,
+        if True, function returns an array.
+
+    Returns
+    --------
+    clearsky : pd.DataFrame or np.array (determined by ``return_raw``)
+        DataFrame contains the columns ``ghi, dni, dhi`` with the units
+        of the ``dni_extra`` input. If ``return_raw=True``, returns the
+        array [dni, ghi, dhi] with shape determined by the input arrays.
+
+    References
+    ----------
+    .. [1] P. Ineichen, "A broadband simplified version of the
+       Solis clear sky model," Solar Energy, 82, 758-762 (2008).
+
+    .. [2] P. Ineichen, "Validation of models that estimate the clear
+       sky global and beam solar irradiance," Solar Energy, 132,
+       332-344 (2016).
+    """
+
+    p = pressure
+    p0 = 101325.
+
+    w = precipitable_water
+
+    # this algorithm is reasonably fast already, but it could be made
+    # faster by precalculating the powers of aod700, the log(p/p0), and
+    # the log(w) instead of repeating the calculations as needed in each
+    # function
+
+    i0p = _calc_i0p(dni_extra, w, aod700, p, p0)
+
+    taub = _calc_taub(w, aod700, p, p0)
+    b = _calc_b(w, aod700)
+
+    taug = _calc_taug(w, aod700, p, p0)
+    g = _calc_g(w, aod700)
+
+    taud = _calc_taud(w, aod700, p, p0)
+    d = _calc_d(w, aod700, p, p0)
+
+    sin_elev = np.sin(np.radians(apparent_elevation))
+
+    dni = i0p * np.exp(-taub/sin_elev**b)
+    ghi = i0p * np.exp(-taug/sin_elev**g) * sin_elev
+    dhi = i0p * np.exp(-taud/sin_elev**d)
+
+    irrads = np.array([dni, ghi, dhi])
+
+    if not return_raw:
+        try:
+            irrads = pd.DataFrame(irrads.T, columns=['dni', 'ghi', 'dhi'])
+        except ValueError:
+            # probably all scalar input, so we
+            # need to increase the dimensionality
+            irrads = pd.DataFrame(np.array([irrads]),
+                                  columns=['dni', 'ghi', 'dhi'])
+        finally:
+            irrads = irrads.fillna(0)
+
+    return irrads
+
+
+def _calc_i0p(i0, w, aod700, p, p0):
+    """Calculate the "enhanced extraterrestrial irradiance"."""
+    io0 = 1.08 * w**0.0051
+    i01 = 0.97 * w**0.032
+    i02 = 0.12 * w**0.56
+    i0p = i0 * (i02*aod700**2 + i01*aod700 + io0 + 0.071*np.log(p/p0))
+
+    return i0p
+
+
+def _calc_taub(w, aod700, p, p0):
+    """Calculate the taub coefficient"""
+
+    tb1 = 1.82 + 0.056*np.log(w) + 0.0071*np.log(w)**2
+    tb0 = 0.33 + 0.045*np.log(w) + 0.0096*np.log(w)**2
+    tbp = 0.0089*w + 0.13
+
+    taub = tb1*aod700 + tb0 + tbp*np.log(p/p0)
+
+    return taub
+
+
+def _calc_b(w, aod700):
+    """Calculate the b coefficient."""
+
+    b1 = 0.00925*aod700**2 + 0.0148*aod700 - 0.0172
+    b0 = -0.7565*aod700**2 + 0.5057*aod700 + 0.4557
+
+    b = b1 * np.log(w) + b0
+
+    return b
+
+
+def _calc_taug(w, aod700, p, p0):
+    """Calculate the taug coefficient"""
+
+    tg1 = 1.24 + 0.047*np.log(w) + 0.0061*np.log(w)**2
+    tg0 = 0.27 + 0.043*np.log(w) + 0.0090*np.log(w)**2
+    tgp = 0.0079*w + 0.1
+    taug = tg1*aod700 + tg0 + tgp*np.log(p/p0)
+
+    return taug
+
+
+def _calc_g(w, aod700):
+    """Calculate the g coefficient."""
+
+    g = -0.0147*np.log(w) - 0.3079*aod700**2 + 0.2846*aod700 + 0.3798
+
+    return g
+
+
+def _calc_taud(w, aod700, p, p0):
+    """Calculate the taud coefficient."""
+
+    # isscalar tests needed to ensure that the arrays will have the
+    # right shape in the tds calculation
+
+    if np.isscalar(w):
+        w = np.array([w])
+
+    if np.isscalar(aod700):
+        aod700 = np.array([aod700])
+
+    aod700_mask = aod700 < 0.05
+    aod700_mask = np.array([aod700_mask, ~aod700_mask], dtype=np.int)
+
+    # create tuples of coefficients for
+    # aod700 < 0.05, aod700 >= 0.05
+    td4 = 86*w - 13800, -0.21*w + 11.6
+    td3 = -3.11*w + 79.4, 0.27*w - 20.7
+    td2 = -0.23*w + 74.8, -0.134*w + 15.5
+    td1 = 0.092*w - 8.86, 0.0554*w - 5.71
+    td0 = 0.0042*w + 3.12, 0.0057*w + 2.94
+    tdp = -0.83*(1+aod700)**(-17.2), -0.71*(1+aod700)**(-15.0)
+
+    tds = (np.array([td0, td1, td2, td3, td4, tdp]) * aod700_mask).sum(axis=1)
+
+    taud = (tds[4]*aod700**4 + tds[3]*aod700**3 + tds[2]*aod700**2 +
+            tds[1]*aod700 + tds[0] + tds[5]*np.log(p/p0))
+
+    # be polite about matching the output type to the input type(s)
+    if len(taud) == 1:
+        taud = taud[0]
+
+    return taud
+
+
+def _calc_d(w, aod700, p, p0):
+    """Calculate the d coefficient."""
+
+    dp = 1/(18 + 152*aod700)
+    d = -0.337*aod700**2 + 0.63*aod700 + 0.116 + dp*np.log(p/p0)
+
+    return d

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -411,8 +411,14 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
     irrads = np.array([dni, ghi, dhi])
 
     if not return_raw:
+        if isinstance(dni, pd.Series):
+            index = dni.index
+        else:
+            index = None
+
         try:
-            irrads = pd.DataFrame(irrads.T, columns=['dni', 'ghi', 'dhi'])
+            irrads = pd.DataFrame(irrads.T, columns=['dni', 'ghi', 'dhi'],
+                                  index=index)
         except ValueError:
             # probably all scalar input, so we
             # need to increase the dimensionality

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -239,7 +239,7 @@ def _spa_python_import(how):
 
 def spa_python(time, latitude, longitude,
                altitude=0, pressure=101325, temperature=12, delta_t=None,
-               atmos_refract=None, how='numpy', numthreads=4):
+               atmos_refract=None, how='numpy', numthreads=4, **kwargs):
     """
     Calculate the solar position using a python implementation of the
     NREL SPA algorithm described in [1].

--- a/pvlib/test/test_clearsky.py
+++ b/pvlib/test/test_clearsky.py
@@ -150,33 +150,113 @@ def test_haurwitz():
     assert_frame_equal(expected, out)
 
 
-def test_simplified_solis():
-    clearsky.simplified_solis()
+def test_simplified_solis_series_elevation():
+    expected = pd.DataFrame(
+        np.array([[    0.        ,     0.        ,     0.        ],
+                  [    0.        ,     0.        ,     0.        ],
+                  [  377.80060035,    79.91931339,    42.77453223],
+                  [  869.47538184,   706.37903999,   110.05635962],
+                  [  958.89448856,  1062.44821373,   129.02349236],
+                  [  913.3209839 ,   860.48978599,   118.94598678],
+                  [  634.01066762,   256.00505836,    72.18396705],
+                  [    0.        ,     0.        ,     0.        ],
+                  [    0.        ,     0.        ,     0.        ]]),
+                            columns=['dni', 'ghi', 'dhi'],
+                            index=times_localized)
+
+    out = clearsky.simplified_solis(ephem_data['apparent_elevation'])
+    assert_frame_equal(expected, out)
 
 
-def test_calc_i0p():
-    clearsky._calc_i0p(w, aod700, p, p0)
+def test_simplified_solis_scalar_elevation():
+    expected = pd.DataFrame(np.array([[959.335463,  1064.653145,  129.125602]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(80)
+    assert_frame_equal(expected, out)
 
 
-def test_calc_taub():
-    clearsky._calc_taub(w, aod700, p, p0)
+def test_simplified_solis_array_elevation():
+    expected = pd.DataFrame(np.array([[959.335463,  1064.653145,  129.125602]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(np.array([80]))
+    assert_frame_equal(expected, out)
 
 
-def test_calc_b():
-    clearsky._calc_b(w, aod700, p, p0)
+def test_simplified_solis_dni_extra():
+    expected = pd.DataFrame(np.array([[963.555414,  1069.33637,  129.693603]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(80, dni_extra=1370)
+    assert_frame_equal(expected, out)
 
 
-def test_calc_taug():
-    clearsky._calc_taug(w, aod700, p, p0)
+def test_simplified_solis_pressure():
+    expected = pd.DataFrame(np.
+        array([[  964.26930718,  1067.96543669,   127.22841797],
+               [  961.88811874,  1066.36847963,   128.1402539 ],
+               [  959.58112234,  1064.81837558,   129.0304193 ]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(
+        80, pressure=np.array([95000, 98000, 101000]))
+    assert_frame_equal(expected, out)
 
 
-def test_calc_g():
-    clearsky._calc_g(w, aod700, p, p0)
+def test_simplified_solis_aod700():
+    expected = pd.DataFrame(np.
+        array([[ 1056.61710493,  1105.7229086 ,    64.41747323],
+               [ 1007.50558875,  1085.74139063,   102.96233698],
+               [  959.3354628 ,  1064.65314509,   129.12560167],
+               [  342.45810926,   638.63409683,    77.71786575],
+               [   55.24140911,     7.5413313 ,     0.        ]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    aod700 = np.array([0.0, 0.05, 0.1, 1, 10])
+    out = clearsky.simplified_solis(80, aod700=aod700)
+    assert_frame_equal(expected, out)
 
 
-def test_calc_taud():
-    clearsky._calc_taud(w, aod700, p, p0)
+def test_simplified_solis_precipitable_water():
+    expected = pd.DataFrame(np.
+        array([[ 1001.15353307,  1107.84678941,   128.58887606],
+               [ 1001.15353307,  1107.84678941,   128.58887606],
+               [  983.51027357,  1089.62306672,   129.08755996],
+               [  959.3354628 ,  1064.65314509,   129.12560167],
+               [  872.02335029,   974.18046717,   125.63581346]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(
+        80, precipitable_water=pd.Series([0.0, 0.2, 0.5, 1.0, 5.0]))
+    assert_frame_equal(expected, out)
 
 
-def test_calc_d():
-    clearsky._calc_d(w, aod700, p, p0)
+def test_simplified_solis_small_scalar_pw():
+    expected = pd.DataFrame(np.
+        array([[ 1001.15353307,  1107.84678941,   128.58887606]]),
+                            columns=['dni', 'ghi', 'dhi'])
+
+    out = clearsky.simplified_solis(80, precipitable_water=0.1)
+    assert_frame_equal(expected, out)
+
+
+def test_simplified_solis_return_raw():
+    expected = np.array([[[ 1099.25706525,   656.24601381],
+                          [  915.31689149,   530.31697378]],
+
+                         [[ 1148.40081325,   913.42330823],
+                          [  965.48550828,   760.04527609]],
+
+                         [[   64.1063074 ,   254.6186615 ],
+                          [   62.75642216,   232.21931597]]])
+
+    aod700 = np.linspace(0, 0.5, 2)
+    precipitable_water = np.linspace(0, 10, 2)
+
+    aod700, precipitable_water = np.meshgrid(aod700, precipitable_water)
+
+    out = clearsky.simplified_solis(80, aod700, precipitable_water,
+                                    return_raw=True)
+
+    np.allclose(expected, out)

--- a/pvlib/test/test_clearsky.py
+++ b/pvlib/test/test_clearsky.py
@@ -148,3 +148,35 @@ def test_haurwitz():
                              columns=['ghi'], index=times_localized)
     out = clearsky.haurwitz(ephem_data['zenith'])
     assert_frame_equal(expected, out)
+
+
+def test_simplified_solis():
+    clearsky.simplified_solis()
+
+
+def test_calc_i0p():
+    clearsky._calc_i0p(w, aod700, p, p0)
+
+
+def test_calc_taub():
+    clearsky._calc_taub(w, aod700, p, p0)
+
+
+def test_calc_b():
+    clearsky._calc_b(w, aod700, p, p0)
+
+
+def test_calc_taug():
+    clearsky._calc_taug(w, aod700, p, p0)
+
+
+def test_calc_g():
+    clearsky._calc_g(w, aod700, p, p0)
+
+
+def test_calc_taud():
+    clearsky._calc_taud(w, aod700, p, p0)
+
+
+def test_calc_d():
+    clearsky._calc_d(w, aod700, p, p0)

--- a/pvlib/test/test_clearsky.py
+++ b/pvlib/test/test_clearsky.py
@@ -163,6 +163,7 @@ def test_simplified_solis_series_elevation():
                   [    0.        ,     0.        ,     0.        ]]),
                             columns=['dni', 'ghi', 'dhi'],
                             index=times_localized)
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(ephem_data['apparent_elevation'])
     assert_frame_equal(expected, out)
@@ -171,6 +172,7 @@ def test_simplified_solis_series_elevation():
 def test_simplified_solis_scalar_elevation():
     expected = pd.DataFrame(np.array([[959.335463,  1064.653145,  129.125602]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(80)
     assert_frame_equal(expected, out)
@@ -179,6 +181,7 @@ def test_simplified_solis_scalar_elevation():
 def test_simplified_solis_array_elevation():
     expected = pd.DataFrame(np.array([[959.335463,  1064.653145,  129.125602]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(np.array([80]))
     assert_frame_equal(expected, out)
@@ -187,6 +190,7 @@ def test_simplified_solis_array_elevation():
 def test_simplified_solis_dni_extra():
     expected = pd.DataFrame(np.array([[963.555414,  1069.33637,  129.693603]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(80, dni_extra=1370)
     assert_frame_equal(expected, out)
@@ -198,6 +202,7 @@ def test_simplified_solis_pressure():
                [  961.88811874,  1066.36847963,   128.1402539 ],
                [  959.58112234,  1064.81837558,   129.0304193 ]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(
         80, pressure=np.array([95000, 98000, 101000]))
@@ -212,6 +217,7 @@ def test_simplified_solis_aod700():
                [  342.45810926,   638.63409683,    77.71786575],
                [   55.24140911,     7.5413313 ,     0.        ]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     aod700 = np.array([0.0, 0.05, 0.1, 1, 10])
     out = clearsky.simplified_solis(80, aod700=aod700)
@@ -226,6 +232,7 @@ def test_simplified_solis_precipitable_water():
                [  959.3354628 ,  1064.65314509,   129.12560167],
                [  872.02335029,   974.18046717,   125.63581346]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(
         80, precipitable_water=pd.Series([0.0, 0.2, 0.5, 1.0, 5.0]))
@@ -236,6 +243,7 @@ def test_simplified_solis_small_scalar_pw():
     expected = pd.DataFrame(np.
         array([[ 1001.15353307,  1107.84678941,   128.58887606]]),
                             columns=['dni', 'ghi', 'dhi'])
+    expected = expected[['dhi', 'dni', 'ghi']]
 
     out = clearsky.simplified_solis(80, precipitable_water=0.1)
     assert_frame_equal(expected, out)

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -79,6 +79,96 @@ def test_get_clearsky_haurwitz():
     assert_frame_equal(expected, clearsky)
 
 
+def test_get_clearsky_simplified_solis():
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='20160101T0600-0700',
+                             end='20160101T1800-0700',
+                             freq='3H')
+    clearsky = tus.get_clearsky(times, model='simplified_solis')
+    expected = pd.DataFrame(data=np.
+        array([[   0.        ,    0.        ,    0.        ],
+               [  70.00146271,  638.01145669,  236.71136245],
+               [ 101.69729217,  852.51950946,  577.1117803 ],
+               [  86.1679965 ,  755.98048017,  385.59586091],
+               [   0.        ,    0.        ,    0.        ]]),
+                            columns=['dhi', 'dni', 'ghi'],
+                            index=times)
+    assert_frame_equal(expected, clearsky)
+
+
+def test_get_clearsky_simplified_solis_apparent_elevation():
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='20160101T0600-0700',
+                             end='20160101T1800-0700',
+                             freq='3H')
+    apparent_elevation = pd.Series(80, index=times)
+    clearsky = tus.get_clearsky(times, model='simplified_solis',
+                                apparent_elevation=apparent_elevation)
+    expected = pd.DataFrame(data=np.
+        array([[  131.3124497 ,  1001.14754036,  1108.14147919],
+               [  131.3124497 ,  1001.14754036,  1108.14147919],
+               [  131.3124497 ,  1001.14754036,  1108.14147919],
+               [  131.3124497 ,  1001.14754036,  1108.14147919],
+               [  131.3124497 ,  1001.14754036,  1108.14147919]]),
+                            columns=['dhi', 'dni', 'ghi'],
+                            index=times)
+    assert_frame_equal(expected, clearsky)
+
+
+def test_get_clearsky_simplified_solis_dni_extra():
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='20160101T0600-0700',
+                             end='20160101T1800-0700',
+                             freq='3H')
+    clearsky = tus.get_clearsky(times, model='simplified_solis',
+                                dni_extra=1370)
+    expected = pd.DataFrame(data=np.
+        array([[   0.        ,    0.        ,    0.        ],
+               [  67.82281485,  618.15469596,  229.34422063],
+               [  98.53217848,  825.98663808,  559.15039353],
+               [  83.48619937,  732.45218243,  373.59500313],
+               [   0.        ,    0.        ,    0.        ]]),
+                            columns=['dhi', 'dni', 'ghi'],
+                            index=times)
+    assert_frame_equal(expected, clearsky)
+
+
+def test_get_clearsky_simplified_solis_pressure():
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='20160101T0600-0700',
+                             end='20160101T1800-0700',
+                             freq='3H')
+    clearsky = tus.get_clearsky(times, model='simplified_solis',
+                                pressure=95000)
+    expected = pd.DataFrame(data=np.
+        array([[   0.        ,    0.        ,    0.        ],
+               [  70.20556637,  635.53091983,  236.17716435],
+               [ 102.08954904,  850.49502085,  576.28465815],
+               [  86.46561686,  753.70744638,  384.90537859],
+               [   0.        ,    0.        ,    0.        ]]),
+                            columns=['dhi', 'dni', 'ghi'],
+                            index=times)
+    assert_frame_equal(expected, clearsky)
+
+
+def test_get_clearsky_simplified_solis_aod_pw():
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='20160101T0600-0700',
+                             end='20160101T1800-0700',
+                             freq='3H')
+    clearsky = tus.get_clearsky(times, model='simplified_solis',
+                                aod700=0.25, precipitable_water=2.)
+    expected = pd.DataFrame(data=np.
+        array([[   0.        ,    0.        ,    0.        ],
+               [  85.77821205,  374.58084365,  179.48483117],
+               [ 143.52743364,  625.91745295,  490.06254157],
+               [ 114.63275842,  506.52275195,  312.24711495],
+               [   0.        ,    0.        ,    0.        ]]),
+                            columns=['dhi', 'dni', 'ghi'],
+                            index=times)
+    assert_frame_equal(expected, clearsky)
+
+
 @raises(ValueError)
 def test_get_clearsky_valueerror():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -93,6 +93,7 @@ def test_get_clearsky_simplified_solis():
                [   0.        ,    0.        ,    0.        ]]),
                             columns=['dhi', 'dni', 'ghi'],
                             index=times)
+    expected = expected[['ghi', 'dni', 'dhi']]
     assert_frame_equal(expected, clearsky)
 
 
@@ -112,6 +113,7 @@ def test_get_clearsky_simplified_solis_apparent_elevation():
                [  131.3124497 ,  1001.14754036,  1108.14147919]]),
                             columns=['dhi', 'dni', 'ghi'],
                             index=times)
+    expected = expected[['ghi', 'dni', 'dhi']]
     assert_frame_equal(expected, clearsky)
 
 
@@ -130,6 +132,7 @@ def test_get_clearsky_simplified_solis_dni_extra():
                [   0.        ,    0.        ,    0.        ]]),
                             columns=['dhi', 'dni', 'ghi'],
                             index=times)
+    expected = expected[['ghi', 'dni', 'dhi']]
     assert_frame_equal(expected, clearsky)
 
 
@@ -148,6 +151,7 @@ def test_get_clearsky_simplified_solis_pressure():
                [   0.        ,    0.        ,    0.        ]]),
                             columns=['dhi', 'dni', 'ghi'],
                             index=times)
+    expected = expected[['ghi', 'dni', 'dhi']]
     assert_frame_equal(expected, clearsky)
 
 
@@ -166,6 +170,7 @@ def test_get_clearsky_simplified_solis_aod_pw():
                [   0.        ,    0.        ,    0.        ]]),
                             columns=['dhi', 'dni', 'ghi'],
                             index=times)
+    expected = expected[['ghi', 'dni', 'dhi']]
     assert_frame_equal(expected, clearsky)
 
 
@@ -250,10 +255,10 @@ def test_get_airmass_valueerror():
                              end='20160101T1800-0700',
                              freq='3H')
     clearsky = tus.get_airmass(times, model='invalid_model')
-    
+
 def test_Location___repr__():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
     assert tus.__repr__()==('Tucson: latitude=32.2, longitude=-111, '+
     'tz=US/Arizona, altitude=700')
-    
-    
+
+


### PR DESCRIPTION
Here's an implementation of Ineichen's "simplified Solis" clear sky model (see the references below). Though I've only just implemented it and have not tested it against any data or the existing ``ineichen`` algorithm, it seems like it could be a useful addition to pvlib. I like the fact that it is simple to program, continuous, and has good limiting behavior. I could easily be missing something, though, since my experience with it is currently limited to the plots below. Does anyone else have any experience with this model? Maybe someone at Sandia, @cwhanse?

For this to be merged we would need to:

- [x] agree that it is a useful addition
- [x] think about the function's API (what is required, what is optional? I think that the existing ``ineichen`` function does too much.).
- [x] consider adding some helping functions such as aod converters. These can be added separately.
- [x] hook it up the ``Location.get_clearsky`` method
- [x] fill in the empty tests

[1] P. Ineichen, "A broadband simplified version of the Solis clear sky model," Solar Energy, 82, 758-762 (2008).

[2] P. Ineichen, "Validation of models that estimate the clear sky global and beam solar irradiance," Solar Energy, 132, 332-344 (2016).

![aod0 1_pw0 5](https://cloud.githubusercontent.com/assets/4383303/14546793/ae08774a-025c-11e6-80dd-c8ddc38b3946.png)
![aod0 01_pw0 5](https://cloud.githubusercontent.com/assets/4383303/14546797/ae437dae-025c-11e6-8cbb-b2c4e297ea2a.png)
![aod0 1_pw5](https://cloud.githubusercontent.com/assets/4383303/14546795/ae3c3422-025c-11e6-9387-28b001cd4929.png)
![aod0 01_pw5](https://cloud.githubusercontent.com/assets/4383303/14546799/ae48afa4-025c-11e6-99b2-986a3c27f7c7.png)
![dhi](https://cloud.githubusercontent.com/assets/4383303/14546844/0034d37e-025d-11e6-96d8-32ddf44eff6e.png)
![dni](https://cloud.githubusercontent.com/assets/4383303/14546846/005d8c24-025d-11e6-8e2e-a002b8481b53.png)
![ghi](https://cloud.githubusercontent.com/assets/4383303/14546845/005c0ae8-025d-11e6-8ea1-d8899f58ab22.png)
