### PR TITLE
fix error in test_get_sun_rise_set_transit

### DIFF
--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -398,11 +398,11 @@ def get_sun_rise_set_transit(time, latitude, longitude, how='numpy',
         unixtime, lat, lon, delta_t, numthreads)
 
     # arrays are in seconds since epoch format, need to conver to timestamps
-    transit = pd.to_datetime(transit, unit='s', utc=True).tz_convert(
+    transit = pd.to_datetime(transit*1e9, unit='ns', utc=True).tz_convert(
         time.tz).tolist()
-    sunrise = pd.to_datetime(sunrise, unit='s', utc=True).tz_convert(
+    sunrise = pd.to_datetime(sunrise*1e9, unit='ns', utc=True).tz_convert(
         time.tz).tolist()
-    sunset = pd.to_datetime(sunset, unit='s', utc=True).tz_convert(
+    sunset = pd.to_datetime(sunset*1e9, unit='ns', utc=True).tz_convert(
         time.tz).tolist()
 
     result = pd.DataFrame({'transit': transit,

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -63,3 +63,18 @@ def incompatible_pandas_0180(test):
         out = test
 
     return out
+
+
+def incompatible_pandas_0131(test):
+    """
+    Test won't work on pandas 0.18.0 due to pandas/numpy issue with
+    np.round.
+    """
+
+    if pd.__version__ == '0.13.1':
+        out = unittest.skip(
+            'error on pandas 0.13.1 due to pandas/numpy')(test)
+    else:
+        out = test
+
+    return out

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -14,7 +14,7 @@ from pandas.util.testing import assert_frame_equal, assert_index_equal
 from pvlib.location import Location
 from pvlib import solarposition
 
-from . import requires_ephem
+from . import requires_ephem, incompatible_pandas_0131
 
 # setup times and locations to be tested.
 times = pd.date_range(start=datetime.datetime(2014,6,24),
@@ -141,6 +141,7 @@ def test_spa_python_numba_physical_dst():
     assert_frame_equal(this_expected, ephem_data[expected.columns])
 
 
+@incompatible_pandas_0131
 def test_get_sun_rise_set_transit():
     south = Location(-35.0, 0.0, tz='UTC')
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -141,6 +141,7 @@ def test_spa_python_numba_physical_dst():
     assert_frame_equal(this_expected, ephem_data[expected.columns])
 
 
+@incompatible_pandas_0131
 def test_get_sun_rise_set_transit():
     south = Location(-35.0, 0.0, tz='UTC')
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),
@@ -157,6 +158,8 @@ def test_get_sun_rise_set_transit():
                                                     delta_t=64.0)
     frame = pd.DataFrame({'sunrise':sunrise, 'sunset':sunset}, index=times)
     result_rounded = pd.DataFrame(index=result.index)
+    # need to iterate because to_datetime does not accept 2D data
+    # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = pd.to_datetime(
             np.floor(data.astype(int) / 1e9)*1e9, utc=True)
@@ -182,6 +185,8 @@ def test_get_sun_rise_set_transit():
                                                     delta_t=64.0)
     frame = pd.DataFrame({'sunrise':sunrise, 'sunset':sunset}, index=times)
     result_rounded = pd.DataFrame(index=result.index)
+    # need to iterate because to_datetime does not accept 2D data
+    # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = (pd.to_datetime(
             np.floor(data.astype(int) / 1e9)*1e9, utc=True)

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -162,7 +162,7 @@ def test_get_sun_rise_set_transit():
     # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = pd.to_datetime(
-            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.values.astype(np.int64) / 1e9)*1e9, utc=True)
 
     del result_rounded['transit']
     assert_frame_equal(frame, result_rounded)
@@ -189,7 +189,7 @@ def test_get_sun_rise_set_transit():
     # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = (pd.to_datetime(
-            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.values.astype(np.int64) / 1e9)*1e9, utc=True)
             .tz_convert('MST'))
 
     del result_rounded['transit']

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -146,18 +146,23 @@ def test_get_sun_rise_set_transit():
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),
                               datetime.datetime(2004, 12, 4, 0)]
                              ).tz_localize('UTC')
-    sunrise = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 7, 8, 15, 471676),
-                                datetime.datetime(2004, 12, 4, 4, 38, 57, 27416)]
+    sunrise = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 7, 8, 15),
+                                datetime.datetime(2004, 12, 4, 4, 38, 57)]
                                ).tz_localize('UTC').tolist()
-    sunset = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 17, 1, 4, 479889),
-                               datetime.datetime(2004, 12, 4, 19, 2, 2, 499704)]
+    sunset = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 17, 1, 4),
+                               datetime.datetime(2004, 12, 4, 19, 2, 2)]
                               ).tz_localize('UTC').tolist()
     result = solarposition.get_sun_rise_set_transit(times, south.latitude,
                                                     south.longitude,
                                                     delta_t=64.0)
     frame = pd.DataFrame({'sunrise':sunrise, 'sunset':sunset}, index=times)
-    del result['transit']
-    assert_frame_equal(frame, result)
+    result_rounded = pd.DataFrame(index=result.index)
+    for col, data in result.iteritems():
+        result_rounded[col] = pd.to_datetime(
+            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+
+    del result_rounded['transit']
+    assert_frame_equal(frame, result_rounded)
 
 
     # tests from USNO
@@ -166,18 +171,25 @@ def test_get_sun_rise_set_transit():
     times = pd.DatetimeIndex([datetime.datetime(2015, 1, 2),
                               datetime.datetime(2015, 8, 2),]
                              ).tz_localize('MST')
-    sunrise = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 7, 19, 2, 225169),
-                                datetime.datetime(2015, 8, 2, 5, 1, 26, 963145)
+    sunrise = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 7, 19, 2),
+                                datetime.datetime(2015, 8, 2, 5, 1, 26)
                                 ]).tz_localize('MST').tolist()
-    sunset = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 16, 49, 10, 13145),
-                               datetime.datetime(2015, 8, 2, 19, 11, 31, 816401)
+    sunset = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 16, 49, 10),
+                               datetime.datetime(2015, 8, 2, 19, 11, 31)
                                ]).tz_localize('MST').tolist()
     result = solarposition.get_sun_rise_set_transit(times, golden.latitude,
                                                     golden.longitude,
                                                     delta_t=64.0)
     frame = pd.DataFrame({'sunrise':sunrise, 'sunset':sunset}, index=times)
-    del result['transit']
-    assert_frame_equal(frame, result)
+    result_rounded = pd.DataFrame(index=result.index)
+    for col, data in result.iteritems():
+        result_rounded[col] = (pd.to_datetime(
+            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+            .tz_convert('MST'))
+
+    del result_rounded['transit']
+    assert_frame_equal(frame, result_rounded)
+
 
 @requires_ephem
 def test_pyephem_physical():

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -141,7 +141,6 @@ def test_spa_python_numba_physical_dst():
     assert_frame_equal(this_expected, ephem_data[expected.columns])
 
 
-@incompatible_pandas_0131
 def test_get_sun_rise_set_transit():
     south = Location(-35.0, 0.0, tz='UTC')
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),
@@ -160,7 +159,7 @@ def test_get_sun_rise_set_transit():
     result_rounded = pd.DataFrame(index=result.index)
     for col, data in result.iteritems():
         result_rounded[col] = pd.to_datetime(
-            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.astype(int) / 1e9)*1e9, utc=True)
 
     del result_rounded['transit']
     assert_frame_equal(frame, result_rounded)
@@ -185,7 +184,7 @@ def test_get_sun_rise_set_transit():
     result_rounded = pd.DataFrame(index=result.index)
     for col, data in result.iteritems():
         result_rounded[col] = (pd.to_datetime(
-            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.astype(int) / 1e9)*1e9, utc=True)
             .tz_convert('MST'))
 
     del result_rounded['transit']

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -162,7 +162,7 @@ def test_get_sun_rise_set_transit():
     # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = pd.to_datetime(
-            np.floor(data.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
 
     del result_rounded['transit']
     assert_frame_equal(frame, result_rounded)
@@ -189,7 +189,7 @@ def test_get_sun_rise_set_transit():
     # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = (pd.to_datetime(
-            np.floor(data.astype(int) / 1e9)*1e9, utc=True)
+            np.floor(data.values.astype(int) / 1e9)*1e9, utc=True)
             .tz_convert('MST'))
 
     del result_rounded['transit']


### PR DESCRIPTION
The recently released pandas 0.18.1 changed the way that ``pd.to_datetime`` handles fractions of seconds, which caused the ``test_get_sun_rise_set_transit`` function to fail since the expected times were specified to microseconds. This PR changes the expected times only have 1 second precision, and rounds the output of ``get_sun_rise_set_transit`` for the test. The problem is that the Timestamp rounding doesn't work on pandas 0.13-0.16. I don't want to raise the version requirements just for this test, so it gets a skip decorator instead. It's a bad hack that I'll try to revisit after the workshop.