### PR TITLE
convert indexing arrays to int to avoid future deprecation

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.3.3.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.3.txt
@@ -35,7 +35,8 @@ Bug fixes
 * Fix snlinverter and singlediode documentation. They incorrectly said that
   inverter/module must be a DataFrame, when in reality they can be any
   dict-like object. (:issue:`157`)
-
+* Fix numpy 1.11 deprecation warnings caused by some functions using
+  non-integer indices.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -64,3 +65,4 @@ Contributors
 * Will Holmgren
 * Mark Mikofski
 * Johannes Oos
+* Tony Lorenzo

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -241,8 +241,8 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
     mat = scipy.io.loadmat(filepath)
     linke_turbidity_table = mat['LinkeTurbidity']
 
-    latitude_index = np.around(_linearly_scale(latitude, 90, -90, 1, 2160))
-    longitude_index = np.around(_linearly_scale(longitude, -180, 180, 1, 4320))
+    latitude_index = np.around(_linearly_scale(latitude, 90, -90, 1, 2160)).astype(np.int64)
+    longitude_index = np.around(_linearly_scale(longitude, -180, 180, 1, 4320)).astype(np.int64)
 
     g = linke_turbidity_table[latitude_index][longitude_index]
 

--- a/pvlib/test/test_irradiance.py
+++ b/pvlib/test/test_irradiance.py
@@ -216,6 +216,19 @@ def test_dirint_value():
     assert_almost_equal(dirint_data.values,
                         np.array([928.85, 688.26]), 1)
 
+
+def test_dirint_nans():
+    times = pd.DatetimeIndex(start='2014-06-24T12-0700', periods=5, freq='6H')
+    ghi = pd.Series([np.nan, 1038.62, 1038.62, 1038.62, 1038.62], index=times)
+    zenith = pd.Series([10.567, np.nan, 10.567, 10.567, 10.567,], index=times)
+    pressure = pd.Series([93193., 93193., np.nan, 93193., 93193.], index=times)
+    temp_dew = pd.Series([10, 10, 10, np.nan, 10], index=times)
+    dirint_data = irradiance.dirint(ghi, zenith, times, pressure=pressure,
+                                    temp_dew=temp_dew)
+    assert_almost_equal(dirint_data.values,
+                        np.array([np.nan, np.nan, np.nan, np.nan, 934.2]), 1)
+
+
 def test_dirint_tdew():
     times = pd.DatetimeIndex(['2014-06-24T12-0700','2014-06-24T18-0700'])
     ghi = pd.Series([1038.62, 254.53], index=times)


### PR DESCRIPTION
This PR just gets rid of some deprecation warnings using numpy 1.11 from non-integer indices. The default for the bins in irradiance.py is now 0 (versus the old NaN), which may or may not be a problem. Maybe the default should be something else?