### PR TITLE
Fix Appveyor builds by using latest Miniconda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,9 @@ install:
     - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
     # install depenencies
-    - "conda install --yes --quiet pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
+    - "conda env create -n test_env python=%PYTHON_VERSION% pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
+    - "activate test_env"
+    - "conda list"
 
     # install pvlib
     - "python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
     - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
     # install depenencies
-    - "conda install --yes --quiet pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
+    - "conda install --yes --quiet pip numpy scipy pandas nose pytz ephem numba"
 
     # install pvlib
     - "python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34-conda64"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python35-conda64"
+      PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,6 @@
 # This file was based on Olivier Grisel's python-appveyor-demo
 
 environment:
-  global:
-    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
     - PYTHON: "C:\\Python27-conda32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python35-conda64"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python34-conda64"
+      PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
 
 install:
@@ -32,7 +32,7 @@ install:
     - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
     # install depenencies
-    - "conda install --yes --quiet pip numpy scipy pandas nose pytz ephem numba"
+    - "conda install --yes --quiet pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
 
     # install pvlib
     - "python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
     - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
     # install depenencies
-    - "conda env create -n test_env python=%PYTHON_VERSION% pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
+    - "conda create -n test_env --yes python=%PYTHON_VERSION% pip numpy scipy=0.16.0 pandas nose pytz ephem numba"
     - "activate test_env"
     - "conda list"
 

--- a/ci/install_python.ps1
+++ b/ci/install_python.ps1
@@ -8,7 +8,7 @@ $BASE_URL = "https://www.python.org/ftp/python/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
+    if ($python_version -like "3.*") {
         $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"

--- a/ci/install_python.ps1
+++ b/ci/install_python.ps1
@@ -8,10 +8,10 @@ $BASE_URL = "https://www.python.org/ftp/python/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
-        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
+    if ($python_version -eq "3.5") {
+        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 

--- a/ci/install_python.ps1
+++ b/ci/install_python.ps1
@@ -8,7 +8,7 @@ $BASE_URL = "https://www.python.org/ftp/python/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.5") {
+    if ($python_version -eq "3.4") {
         $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"


### PR DESCRIPTION
The Appveyor builds are broken... again...

It's not clear to me exactly why they broke or exactly why this fixes it. I think it broke because 1) we were using an older version of Miniconda and 2) something changed with Continuum's packages. The PR uses the "latest" version of Miniconda which seems to handle whatever changed with Continuum's packages. I will merge it as soon as the tests pass.