### PR TITLE
refactor ModelChain. add SingleDiode modelchain

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.4.0.txt
 .. include:: whatsnew/v0.3.3.txt
 .. include:: whatsnew/v0.3.2.txt
 .. include:: whatsnew/v0.3.1.txt

--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -1,0 +1,23 @@
+.. _whatsnew_0400:
+
+v0.4.0 (June xx, 2016)
+-----------------------
+
+This is a major release from 0.3.3.
+We recommend that all users upgrade to this version.
+
+Enhancements
+~~~~~~~~~~~~
+
+* Splits ``ModelChain`` into a ``SingleDiode`` chain and a ``SAPM`` chain.
+  (:issue:`151`)
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -44,7 +44,7 @@ def basic_chain(times, latitude, longitude,
         Use decimal degrees notation.
 
     module_parameters : None, dict or Series
-        Module parameters as defined by the SAPM, CEC, or other.
+        Module parameters as defined by the SAPM.
 
     inverter_parameters : None, dict or Series
         Inverter parameters as defined by the CEC.
@@ -375,6 +375,7 @@ class SAPM(ModelChain):
     """
     Uses the SAPM to calculate cell temperature, DC power and AC power.
     """
+
     def run_model(self, times, irradiance=None, weather=None):
         """
         Run the model.
@@ -477,11 +478,7 @@ class SingleDiode(ModelChain):
 
         self.dc = self.dc.fillna(0)
 
-        voltages = ['v_mp', 'v_oc']
-        self.dc[voltages] *= self.system.series_modules
-        currents = ['i_mp', 'i_sc', 'i_x', 'i_xx']
-        self.dc[currents] *= self.system.parallel_modules
-        self.dc['p_mp'] = self.dc['v_mp'] * self.dc['i_mp']
+        self.dc = self.system.scale_voltage_current_power(self.dc)
 
         self.ac = self.system.snlinverter(self.dc['v_mp'], self.dc['p_mp'])
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -400,7 +400,8 @@ class SAPM(ModelChain):
         -------
         self
 
-        Assigns attributes: temps, dc, ac
+        Assigns attributes: times, solar_position, airmass, irradiance,
+        total_irrad, weather, aoi, temps, dc, ac.
         """
         self.prepare_inputs(times, irradiance, weather)
 
@@ -449,7 +450,8 @@ class SingleDiode(ModelChain):
         -------
         self
 
-        Assigns attributes: temps, dc, ac
+        Assigns attributes: times, solar_position, airmass, irradiance,
+        total_irrad, weather, aoi, temps, dc, ac.
         """
 
         self.prepare_inputs(times, irradiance, weather)

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -286,7 +286,8 @@ class ModelChain(object):
 
     def prepare_inputs(self, times, irradiance=None, weather=None):
         """
-        Run the model.
+        Prepare the solar position, irradiance, and weather inputs to
+        the model.
 
         Parameters
         ----------
@@ -368,6 +369,7 @@ class ModelChain(object):
         """
         A stub function meant to be subclassed.
         """
+
         raise NotImplementedError(
             'you must subclass ModelChain and implement this method')
 
@@ -376,12 +378,23 @@ class SAPM(ModelChain):
     """
     Uses the SAPM to calculate cell temperature, DC power and AC power.
     """
-    def run_model(self):
+    def run_model(self, times, irradiance=None, weather=None):
         """
         Run the model.
 
         Parameters
         ----------
+        times : DatetimeIndex
+            Times at which to evaluate the model.
+
+        irradiance : None or DataFrame
+            If None, calculates clear sky data.
+            Columns must be 'dni', 'ghi', 'dhi'.
+
+        weather : None or DataFrame
+            If None, assumes air temperature is 20 C and
+            wind speed is 0 m/s.
+            Columns must be 'wind_speed', 'temp_air'.
 
         Returns
         -------
@@ -389,7 +402,7 @@ class SAPM(ModelChain):
 
         Assigns attributes: temps, dc, ac
         """
-
+        self.prepare_inputs(times, irradiance, weather)
 
         self.temps = self.system.sapm_celltemp(self.total_irrad['poa_global'],
                                                self.weather['wind_speed'],
@@ -414,12 +427,23 @@ class SingleDiode(ModelChain):
     and the SAPM models to calculate cell temperature and AC power.
     """
 
-    def run_model(self):
+    def run_model(self, times, irradiance=None, weather=None):
         """
         Run the model.
 
         Parameters
         ----------
+        times : DatetimeIndex
+            Times at which to evaluate the model.
+
+        irradiance : None or DataFrame
+            If None, calculates clear sky data.
+            Columns must be 'dni', 'ghi', 'dhi'.
+
+        weather : None or DataFrame
+            If None, assumes air temperature is 20 C and
+            wind speed is 0 m/s.
+            Columns must be 'wind_speed', 'temp_air'.
 
         Returns
         -------
@@ -428,6 +452,7 @@ class SingleDiode(ModelChain):
         Assigns attributes: temps, dc, ac
         """
 
+        self.prepare_inputs(times, irradiance, weather)
 
         self.temps = self.system.sapm_celltemp(self.total_irrad['poa_global'],
                                                self.weather['wind_speed'],

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -8,8 +8,10 @@ from pvlib.pvsystem import PVSystem
 from pvlib.tracking import SingleAxisTracker
 from pvlib.location import Location
 
-from pandas.util.testing import assert_series_equal, assert_frame_equal
-from nose.tools import with_setup, raises
+from pandas.util.testing import assert_series_equal
+from nose.tools import raises
+
+from . import incompatible_conda_linux_py3
 
 # should store this test data locally, but for now...
 sam_data = {}
@@ -93,7 +95,7 @@ def singlediode_setup():
 def test_ModelChain_creation():
     system = PVSystem()
     location = Location(32.2, -111, altitude=700)
-    mc = ModelChain(system, location)
+    ModelChain(system, location)
 
 
 def test_orientation_strategy():
@@ -113,7 +115,7 @@ def run_orientation_strategy(strategy, expected):
 
     # the || accounts for the coercion of 'None' to None
     assert (mc.orientation_strategy == strategy or
-            mc.orientation_strategy == None)
+            mc.orientation_strategy is None)
     assert system.surface_tilt == expected[0]
     assert system.surface_azimuth == expected[1]
 
@@ -126,11 +128,12 @@ def test_run_model_ModelChain():
     mc.run_model()
 
 
+@incompatible_conda_linux_py3
 def test_run_model():
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     expected = {}
     expected[SAPM] = \
-        pd.Series(np.array([  1.82033564e+02,  -2.00000000e-02]), index=times)
+        pd.Series(np.array([1.82033564e+02,  -2.00000000e-02]), index=times)
     expected[SingleDiode] = \
         pd.Series(np.array([179.720353871, np.nan]), index=times)
 
@@ -142,13 +145,14 @@ def test_run_model():
         yield run_test, mc
 
 
+@incompatible_conda_linux_py3
 def test_run_model_with_irradiance():
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     irradiance = pd.DataFrame(
         {'dni': [900, 0], 'ghi': [600, 50], 'dhi': [150, 50]}, index=times)
     expected = {}
     expected[SAPM] = \
-        pd.Series(np.array([  1.90054749e+02,  -2.00000000e-02]), index=times)
+        pd.Series(np.array([1.90054749e+02,  -2.00000000e-02]), index=times)
     expected[SingleDiode] = \
         pd.Series(np.array([186.979595403, 7.89417460232]), index=times)
 
@@ -160,12 +164,13 @@ def test_run_model_with_irradiance():
         yield run_test, mc
 
 
+@incompatible_conda_linux_py3
 def test_run_model_with_weather():
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     weather = pd.DataFrame({'wind_speed': 5, 'temp_air': 10}, index=times)
     expected = {}
     expected[SAPM] = \
-        pd.Series(np.array([  1.99952400e+02,  -2.00000000e-02]), index=times)
+        pd.Series(np.array([1.99952400e+02,  -2.00000000e-02]), index=times)
     expected[SingleDiode] = \
         pd.Series(np.array([198.13564009, np.nan]), index=times)
 
@@ -209,10 +214,9 @@ def test_basic_chain_required():
     latitude = 32
     longitude = -111
     altitude = 700
-    modules = sam_data['sandiamod']
-    module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
-    inverters = sam_data['cecinverter']
-    inverter_parameters = inverters['ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_']
+
+    module_parameters = get_sapm_module_parameters()
+    inverter_parameters = get_cec_inverter_parameters()
 
     dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                     module_parameters, inverter_parameters,
@@ -224,20 +228,18 @@ def test_basic_chain_alt_az():
                              end='20160101 1800-0700', freq='6H')
     latitude = 32.2
     longitude = -111
-    altitude = 700
     surface_tilt = 0
     surface_azimuth = 0
-    modules = sam_data['sandiamod']
-    module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
-    inverters = sam_data['cecinverter']
-    inverter_parameters = inverters['ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_']
+
+    module_parameters = get_sapm_module_parameters()
+    inverter_parameters = get_cec_inverter_parameters()
 
     dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                     module_parameters, inverter_parameters,
                                     surface_tilt=surface_tilt,
                                     surface_azimuth=surface_azimuth)
 
-    expected = pd.Series(np.array([  1.14490928477e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([1.14490928477e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -248,17 +250,15 @@ def test_basic_chain_strategy():
     latitude = 32.2
     longitude = -111
     altitude = 700
-    modules = sam_data['sandiamod']
-    module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
-    inverters = sam_data['cecinverter']
-    inverter_parameters = inverters['ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_']
 
-    dc, ac = modelchain.basic_chain(times, latitude, longitude,
-                                    module_parameters, inverter_parameters,
-                                    orientation_strategy='south_at_latitude_tilt',
-                                    altitude=altitude)
+    module_parameters = get_sapm_module_parameters()
+    inverter_parameters = get_cec_inverter_parameters()
 
-    expected = pd.Series(np.array([  1.82033563543e+02,  -2.00000000e-02]),
+    dc, ac = modelchain.basic_chain(
+        times, latitude, longitude, module_parameters, inverter_parameters,
+        orientation_strategy='south_at_latitude_tilt', altitude=altitude)
+
+    expected = pd.Series(np.array([1.82033563543e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -271,10 +271,9 @@ def test_basic_chain_altitude_pressure():
     altitude = 700
     surface_tilt = 0
     surface_azimuth = 0
-    modules = sam_data['sandiamod']
-    module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
-    inverters = sam_data['cecinverter']
-    inverter_parameters = inverters['ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_']
+
+    module_parameters = get_sapm_module_parameters()
+    inverter_parameters = get_cec_inverter_parameters()
 
     dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                     module_parameters, inverter_parameters,
@@ -282,7 +281,7 @@ def test_basic_chain_altitude_pressure():
                                     surface_azimuth=surface_azimuth,
                                     pressure=93194)
 
-    expected = pd.Series(np.array([  1.15771428788e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([1.15771428788e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -292,6 +291,6 @@ def test_basic_chain_altitude_pressure():
                                     surface_azimuth=surface_azimuth,
                                     altitude=altitude)
 
-    expected = pd.Series(np.array([  1.15771428788e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([1.15771428788e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)


### PR DESCRIPTION
Continuing from #151...

I refactored ``ModelChain`` into a parent ``ModelChain`` class with subclasses ``SAPM`` and ``SingleDiode``. In doing so, I moved some solar position, irradiance, and weather prep work into ``ModelChain.prepare_inputs``. ``prepare_inputs`` is called during ``run_model``. 

I also rebased this code on the changes that added support for ``SingleAxisTracker`` and voltage/current/power scaling.

I think that this is close to ready, but would appreciate testing and comments.