### PR TITLE
change authors, clean up setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ pvlib-python
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.50141.svg)](http://dx.doi.org/10.5281/zenodo.50141)
 
 
-pvlib-python is a community supported tool that provides a set of functions and classes for simulating the performance of photovoltaic energy systems.
-The toolbox was originally developed in MATLAB at Sandia National Laboratories and it implements many of the models and methods developed at the Labs.
-More information on Sandia Labs PV performance modeling programs can be found at https://pvpmc.sandia.gov/.
-We collaborate with the PVLIB-MATLAB project, but operate independently of it.
+PVLIB Python is a community supported tool that provides a set of
+functions and classes for simulating the performance of photovoltaic
+energy systems. PVLIB Python was originally ported from the PVLIB MATLAB
+toolbox developed at Sandia National Laboratories and it implements many
+of the models and methods developed at the Labs. More information on
+Sandia Labs PV performance modeling programs can be found at
+https://pvpmc.sandia.gov/. We collaborate with the PVLIB MATLAB project,
+but operate independently of it.
 
 
 Documentation

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -1,12 +1,14 @@
 pvlib-python
 ========================================
 
-pvlib-python provides a set of documented functions for simulating the
-performance of photovoltaic energy systems. The toolbox was originally
-developed in MATLAB at Sandia National Laboratories and it implements
-many of the models and methods developed at the Labs. More information
-on Sandia Labs PV performance modeling programs can be found at
-https://pvpmc.sandia.gov/.
+PVLIB Python is a community supported tool that provides a set of
+functions and classes for simulating the performance of photovoltaic
+energy systems. PVLIB Python was originally ported from the PVLIB MATLAB
+toolbox developed at Sandia National Laboratories and it implements many
+of the models and methods developed at the Labs. More information on
+Sandia Labs PV performance modeling programs can be found at
+https://pvpmc.sandia.gov/. We collaborate with the PVLIB MATLAB project,
+but operate independently of it.
 
 The source code for pvlib-python is hosted on `github
 <https://github.com/pvlib/pvlib-python>`_.

--- a/docs/sphinx/source/whatsnew/v0.3.3.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.3.txt
@@ -32,6 +32,8 @@ Documentation
 * Fix version number in 0.3.2 whatsnew file.
 * Shorten README.md file and move information to official documentation.
   (:issue:`182`)
+* Change authors to *PVLIB Python Developers* and clean up setup.py.
+  (:issue:`184`)
 
 
 Contributors

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,31 @@ except ImportError:
 import versioneer
 
 
-DESCRIPTION = 'The PVLIB toolbox provides a set of functions for simulating the performance of photovoltaic energy systems.'
-LONG_DESCRIPTION = break # fix me
+DESCRIPTION = ('A set of functions and classes for simulating the ' +
+               'performance of photovoltaic energy systems.')
+LONG_DESCRIPTION = """
+PVLIB Python is a community supported tool that provides a set of
+functions and classes for simulating the performance of photovoltaic
+energy systems. The toolbox was originally developed in MATLAB at Sandia
+National Laboratories and it implements many of the models and methods
+developed at the Labs. More information on Sandia Labs PV performance
+modeling programs can be found at https://pvpmc.sandia.gov/. We
+collaborate with the PVLIB-MATLAB project, but operate independently of
+it.
+
+We need your help to make pvlib-python a great tool!
+
+Documentation: http://pvlib-python.readthedocs.io
+
+Source code: https://github.com/pvlib/pvlib-python
+"""
 
 DISTNAME = 'pvlib'
 LICENSE = 'BSD 3-Clause'
 AUTHOR = 'PVLIB Python Developers'
 MAINTAINER_EMAIL = 'holmgren@email.arizona.edu'
 URL = 'https://github.com/pvlib/pvlib-python'
+
 INSTALL_REQUIRES = ['numpy >= 1.8.2',
                     'pandas >= 0.13.1',
                     'pytz',
@@ -45,10 +62,6 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-# check python version.
-if not sys.version_info[:2] in ((2,7), (3,3), (3,4), (3,5)):
-   sys.exit('%s requires Python 2.7, 3.3, or 3.4' % DISTNAME)
-
 setuptools_kwargs = {
     'zip_safe': False,
     'scripts': [],
@@ -69,14 +82,14 @@ if all(map(os.path.exists, spa_all_file_paths)):
     print('all spa_c files found')
     PACKAGES.append('pvlib.spa_c_files')
 
-    spa_ext = Extension('pvlib.spa_c_files.spa_py', 
+    spa_ext = Extension('pvlib.spa_c_files.spa_py',
                         sources=spa_sources, depends=spa_depends)
     extensions.append(spa_ext)
 else:
     print('WARNING: spa_c files not detected. ' +
           'See installation instructions for more information.')
 
- 
+
 setup(name=DISTNAME,
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,20 @@ except ImportError:
 import versioneer
 
 
-DESCRIPTION = 'The PVLIB toolbox provides a set functions for simulating the performance of photovoltaic energy systems.'
-LONG_DESCRIPTION = open('README.md').read()
+DESCRIPTION = 'The PVLIB toolbox provides a set of functions for simulating the performance of photovoltaic energy systems.'
+LONG_DESCRIPTION = break # fix me
 
 DISTNAME = 'pvlib'
-LICENSE = 'The BSD 3-Clause License'
-AUTHOR = 'Dan Riley, Clifford Hanson, Rob Andrews, Will Holmgren, github contributors'
+LICENSE = 'BSD 3-Clause'
+AUTHOR = 'PVLIB Python Developers'
 MAINTAINER_EMAIL = 'holmgren@email.arizona.edu'
 URL = 'https://github.com/pvlib/pvlib-python'
+INSTALL_REQUIRES = ['numpy >= 1.8.2',
+                    'pandas >= 0.13.1',
+                    'pytz',
+                    'six',
+                    ]
+TESTS_REQUIRE = ['nose']
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -45,11 +51,6 @@ if not sys.version_info[:2] in ((2,7), (3,3), (3,4), (3,5)):
 
 setuptools_kwargs = {
     'zip_safe': False,
-    'install_requires': ['numpy >= 1.8.2',
-                         'pandas >= 0.13.1',
-                         'pytz',
-                         'six',
-                         ],
     'scripts': [],
     'include_package_data': True
 }
@@ -80,6 +81,8 @@ setup(name=DISTNAME,
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       packages=PACKAGES,
+      install_requires=INSTALL_REQUIRES,
+      tests_require=TESTS_REQUIRE,
       ext_modules=extensions,
       description=DESCRIPTION,
       long_description=LONG_DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ DESCRIPTION = ('A set of functions and classes for simulating the ' +
 LONG_DESCRIPTION = """
 PVLIB Python is a community supported tool that provides a set of
 functions and classes for simulating the performance of photovoltaic
-energy systems. The toolbox was originally developed in MATLAB at Sandia
-National Laboratories and it implements many of the models and methods
-developed at the Labs. More information on Sandia Labs PV performance
-modeling programs can be found at https://pvpmc.sandia.gov/. We
-collaborate with the PVLIB-MATLAB project, but operate independently of
-it.
+energy systems. PVLIB Python was originally ported from the PVLIB MATLAB
+toolbox developed at Sandia National Laboratories and it implements many
+of the models and methods developed at the Labs. More information on
+Sandia Labs PV performance modeling programs can be found at
+https://pvpmc.sandia.gov/. We collaborate with the PVLIB MATLAB project,
+but operate independently of it.
 
 We need your help to make pvlib-python a great tool!
 


### PR DESCRIPTION
Important! This changes the author list from 

'Dan Riley, Clifford Hanson, Rob Andrews, Will Holmgren, github contributors'

to

'PVLIB Python Developers'

This is how most Python projects with more than one contributor do it. I also want to avoid arguments about who should be a named author and who shouldn't be.

For context, the author list for the first release of pvlib python was 'Dan Riley, Clifford Hanson, Rob Andrews'. I added myself and 'github contributors' at some point. 

See #184 or the diff for a list of additional minor changes.

cc  @cwhanse @Calama-Consulting @Heliolytics

closes #184.