### PR TITLE
remove skip decorators for linux+python3 and pandas 0.18.0

### DIFF
--- a/docs/sphinx/source/installation.rst
+++ b/docs/sphinx/source/installation.rst
@@ -224,29 +224,15 @@ Compatibility
 pvlib-python is compatible with Python versions 2.7, 3.4, 3.5 and Pandas
 versions 0.13.1 or newer.
 
-There are several problems with Continuum's Anaconda packages that may
-impact pvlib users.
+There have been several problems with Continuum's Anaconda packages that
+have impacted pvlib users. The current problems that we're aware of are
+listed below:
 
-For Linux + Python 3 users: Continuum's Python 3.x SciPy conda packages
-have a few bugs related to complex arithmetic. The most common place for
-these bugs to show up when using pvlib-python is in calculating IV curve
-parameters using the ``singlediode`` function. We reported `the
-issue <https://github.com/ContinuumIO/anaconda-issues/issues/425>`_ to
-Continuum and are waiting for it to be fixed. In the meantime, you can
-compile your own SciPy distribution, or you can use this hack on Python
-3.3 and 3.4 (not 3.5): Downgrade your NumPy to 1.8 and SciPy to 0.14,
-then install whatever version of pandas you want but without
-dependencies. The conda commands for this are:
-
-``conda install numpy=1.8 scipy=0.14``
-
-``conda install pandas --no-deps``
-
-For Windows + Python 2.7 users: Continuum's Python 2.7 SciPy 0.16.1,
-0.17.0, 0.17.1 packages are not compiled properly and will crash your
-Python interpreter if you use our Linke turbidity lookup function. See
-`Anaconda issue 650
-<https://github.com/ContinuumIO/anaconda-issues/issues/650>`_ for more.
+#. For Windows + Python 2.7 users: Continuum's Python 2.7 SciPy 0.16.1,
+   0.17.0, 0.17.1 packages are not compiled properly and will crash your
+   Python interpreter if you use our Linke turbidity lookup function. See
+   `Anaconda issue 650
+   <https://github.com/ContinuumIO/anaconda-issues/issues/650>`_ for more.
 
 Note that our Numba-accelerated solar position algorithms have more
 specific version requirements that will be resolved by the Numba

--- a/docs/sphinx/source/whatsnew/v0.3.3.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.3.txt
@@ -34,6 +34,13 @@ Documentation
   (:issue:`182`)
 
 
+Other
+~~~~~
+
+* Removed test skip decorator functions for Linux + Python 3 and for
+  pandas 0.18.0. (:issue:`187`)
+
+
 Contributors
 ~~~~~~~~~~~~
 

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -50,21 +50,6 @@ def incompatible_conda_linux_py3(test):
     return out
 
 
-def incompatible_pandas_0180(test):
-    """
-    Test won't work on pandas 0.18.0 due to pandas/numpy issue with
-    np.round.
-    """
-
-    if pd.__version__ == '0.18.0':
-        out = unittest.skip(
-            'error on pandas 0.18.0 due to pandas/numpy round')(test)
-    else:
-        out = test
-
-    return out
-
-
 def incompatible_pandas_0131(test):
     """
     Test won't work on pandas 0.18.0 due to pandas/numpy issue with

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from nose.tools import assert_equals, assert_almost_equals
 from pandas.util.testing import assert_series_equal, assert_frame_equal
-from . import incompatible_pandas_0180
 
 from pvlib import tmy
 from pvlib import pvsystem
@@ -189,7 +188,6 @@ def test_PVSystem_sapm():
     assert_frame_equal(sapm, expected)
 
 
-@incompatible_pandas_0180
 def test_calcparams_desoto():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]
@@ -211,7 +209,6 @@ def test_calcparams_desoto():
     assert_almost_equals(nNsVth, 0.473)
 
 
-@incompatible_pandas_0180
 def test_PVSystem_calcparams_desoto():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module].copy()

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from nose.tools import assert_equals, assert_almost_equals
 from pandas.util.testing import assert_series_equal, assert_frame_equal
-from . import incompatible_conda_linux_py3, incompatible_pandas_0180
+from . import incompatible_pandas_0180
 
 from pvlib import tmy
 from pvlib import pvsystem
@@ -232,13 +232,11 @@ def test_PVSystem_calcparams_desoto():
     assert_almost_equals(nNsVth, 0.473)
 
 
-@incompatible_conda_linux_py3
 def test_i_from_v():
     output = pvsystem.i_from_v(20, .1, .5, 40, 6e-7, 7)
     assert_almost_equals(-299.746389916, output, 5)
 
 
-@incompatible_conda_linux_py3
 def test_PVSystem_i_from_v():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]
@@ -264,7 +262,6 @@ def test_singlediode_series():
     assert isinstance(out, pd.DataFrame)
 
 
-@incompatible_conda_linux_py3
 def test_singlediode_floats():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]
@@ -281,7 +278,6 @@ def test_singlediode_floats():
         assert_almost_equals(expected[k], v, 5)
 
 
-@incompatible_conda_linux_py3
 def test_PVSystem_singlediode_floats():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]


### PR DESCRIPTION
scipy/scipy#6074 fixed a bug that caused the lambertw, and thus our singlediode function, to fail on Python 3 on linux. Thanks scipy devs! This PR removes the decorator function that skipped that test on the linux/py3 Travis-CI builds. See #109, #90 for the history.

There was also a bug in pandas 0.18.0 that required a test decorator. In principle this could be kept, but I'd prefer to avoid accumulating crap like this in the test suite. See #130 for the history.