### PR TITLE
rename series_modules to modules_per_string and parallel_modules to strings_per_inverter

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.3.3.txt
+++ b/docs/sphinx/source/whatsnew/v0.3.3.txt
@@ -6,6 +6,14 @@ v0.3.3 (May xx, 2016)
 This is a minor release from 0.3.2.
 We recommend that all users upgrade to this version.
 
+
+API Changes
+~~~~~~~~~~~
+
+* Renamed ``series_modules`` to ``modules_per_string`` and
+  ``parallel_modules`` to ``strings_per_inverter``. (:issue:`176`)
+
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/docs/tutorials/pvsystem.ipynb
+++ b/docs/tutorials/pvsystem.ipynb
@@ -121,8 +121,8 @@
        " 'latitude': 55.317,\n",
        " 'longitude': -160.517,\n",
        " 'name': '\"SAND POINT\"',\n",
-       " 'parallel_modules': 5,\n",
-       " 'series_modules': 5,\n",
+       " 'strings_per_inverter': 5,\n",
+       " 'modules_per_string': 5,\n",
        " 'surface_azimuth': 0,\n",
        " 'surface_tilt': 0,\n",
        " 'tz': -9.0}"
@@ -152,8 +152,8 @@
        " 'latitude': 25.8,\n",
        " 'longitude': -80.26666666666667,\n",
        " 'name': 'MIAMI',\n",
-       " 'parallel_modules': 5,\n",
-       " 'series_modules': 5,\n",
+       " 'strings_per_inverter': 5,\n",
+       " 'modules_per_string': 5,\n",
        " 'surface_azimuth': 0,\n",
        " 'surface_tilt': 0,\n",
        " 'tz': -5}"

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -55,8 +55,8 @@ def test_systemdef_tmy3():
                 'latitude': 55.317,
                 'longitude': -160.517,
                 'name': '"SAND POINT"',
-                'parallel_modules': 5,
-                'series_modules': 5,
+                'strings_per_inverter': 5,
+                'modules_per_string': 5,
                 'surface_azimuth': 0,
                 'surface_tilt': 0}
     assert_equals(expected, pvsystem.systemdef(tmy3_metadata, 0, 0, .1, 5, 5))
@@ -68,8 +68,8 @@ def test_systemdef_tmy2():
                 'latitude': 25.8,
                 'longitude': -80.26666666666667,
                 'name': 'MIAMI',
-                'parallel_modules': 5,
-                'series_modules': 5,
+                'strings_per_inverter': 5,
+                'modules_per_string': 5,
                 'surface_azimuth': 0,
                 'surface_tilt': 0}
     assert_equals(expected, pvsystem.systemdef(tmy2_metadata, 0, 0, .1, 5, 5))
@@ -81,8 +81,8 @@ def test_systemdef_dict():
                 'latitude': 37.8,
                 'longitude': -122.3,
                 'name': 'Oakland',
-                'parallel_modules': 5,
-                'series_modules': 5,
+                'strings_per_inverter': 5,
+                'modules_per_string': 5,
                 'surface_azimuth': 0,
                 'surface_tilt': 5}
     assert_equals(expected, pvsystem.systemdef(meta, 5, 0, .1, 5, 5))
@@ -314,7 +314,7 @@ def test_PVSystem_scale_voltage_current_power():
         np.array([[6, 4.5, 20, 16, 72, 1.5, 4.5]]),
         columns=['i_sc', 'i_mp', 'v_oc', 'v_mp', 'p_mp', 'i_x', 'i_xx'],
         index=[0])
-    system = pvsystem.PVSystem(series_modules=2, parallel_modules=3)
+    system = pvsystem.PVSystem(modules_per_string=2, strings_per_inverter=3)
     out = system.scale_voltage_current_power(data)
 
 


### PR DESCRIPTION
As discussed in #176, this PR renames series_modules to modules_per_string and parallel_modules to strings_per_inverter. I'll merge it in a day or two unless there are new objections. 