### PR TITLE
implement PVWatts

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -18,6 +18,7 @@ Enhancements
 
 * Adds the First Solar spectral correction model. (:issue:`115`)
 * Adds the Gueymard 1994 integrated precipitable water model. (:issue:`115`)
+* Adds the PVWatts DC, AC, and system losses model. (:issue:`195`)
 
 
 Bug fixes
@@ -28,6 +29,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+* Added new terms to the variables documentation. (:issue:`195`)
 
 
 Other

--- a/pvlib/data/variables_style_rules.csv
+++ b/pvlib/data/variables_style_rules.csv
@@ -16,6 +16,7 @@ poa_direct;direct/beam irradiation in plane
 poa_diffuse;total diffuse irradiation in plane. sum of ground and sky diffuse.
 poa_global;global irradiation in plane. sum of diffuse and beam projection.
 poa_sky_diffuse;diffuse irradiation in plane from scattered light in the atmosphere (without ground reflected irradiation)
+g_poa_effective;broadband plane of array effective irradiance.
 surface_tilt;tilt angle of the surface
 surface_azimuth;azimuth angle of the surface
 solar_zenith;zenith angle of the sun in degrees
@@ -36,3 +37,10 @@ saturation_current;diode saturation current
 resistance_series;series resistance
 resistance_shunt;shunt resistance
 transposition_factor; the gain ratio of the radiation on inclined plane to global horizontal irradiation: :math:`\frac{poa\_global}{ghi}`
+pdc0; nameplate DC rating
+pdc, dc; dc power
+gamma_pdc; module temperature coefficient. Typically in units of 1/C.
+pac, ac; ac powe.
+eta_inv; inverter efficiency
+eta_inv_ref; reference inverter efficiency
+eta_inv_nom; nominal inverter efficiency

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1877,12 +1877,12 @@ def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
 def pvwatts_losses(soiling=2, shading=3, snow=0, mismatch=2, wiring=2,
                    connections=0.5, lid=1.5, nameplate_rating=1, age=0,
                    availability=3):
-    """
+    r"""
     Implements NREL's PVWatts system loss model [1]_:
 
     .. math::
 
-        L_{total}(%) = 100 [ 1 - \Pi_i ( 1 - \frac{L_i}{100} ) ]
+        L_{total}(\%) = 100 [ 1 - \Pi_i ( 1 - \frac{L_i}{100} ) ]
 
     All parameters must be in units of %. Parameters may be
     array-like, though all array sizes must match.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -406,19 +406,36 @@ class PVSystem(object):
                                            voltage=self.modules_per_string,
                                            current=self.strings_per_inverter)
 
-    def pvwatts_dc(self, irrad_trans, temp_cell):
+    def pvwatts_dc(self, g_poa_effective, temp_cell):
         """
-        Uses :py:func:`pvwatts_dc` to calculate DC power according
-        to the NREL PVWatts model.
+        Calcuates DC power according to the PVWatts model using
+        :py:func:`pvwatts_dc`, `self.module_parameters['pdc0']`, and
+        `self.module_parameters['gamma_pdc']`.
+
+        See :py:func:`pvwatts_dc` for details.
         """
-        return pvwatts_dc(irrad_trans, temp_cell,
+        return pvwatts_dc(g_poa_effective, temp_cell,
                           self.module_parameters['pdc0'],
                           self.module_parameters['gamma_pdc'])
 
+    def pvwatts_losses(self, **kwargs):
+        """
+        Calculates DC power losses according the PVwatts model using
+        :py:func:`pvwatts_losses`. No attributes are used in this
+        calculation, but all keyword arguments will be passed to the
+        function.
+
+        See :py:func:`pvwatts_losses` for details.
+        """
+        return pvwatts_losses(**kwargs)
+
     def pvwatts_ac(self, pdc):
         """
-        Uses :py:func:`pvwatts_ac` to calculate AC power according
-        to the NREL PVWatts model.
+        Calculates AC power according to the PVWatts model using
+        :py:func:`pvwatts_ac`, `self.module_parameters['pdc0']`, and
+        `eta_inv_nom=self.inverter_parameters['eta_inv_nom']`.
+
+        See :py:func:`pvwatts_ac` for details.
         """
         return pvwatts_ac(pdc, self.module_parameters['pdc0'],
                           eta_inv_nom=self.inverter_parameters['eta_inv_nom'])

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -413,7 +413,7 @@ class PVSystem(object):
         """
         return pvwatts_dc(irrad_trans, temp_cell,
                           self.module_parameters['pdc0'],
-                          self.module_parameters['gamma'])
+                          self.module_parameters['gamma_pdc'])
 
     def pvwatts_ac(self, pdc):
         """
@@ -421,7 +421,7 @@ class PVSystem(object):
         to the NREL PVWatts model.
         """
         return pvwatts_ac(pdc, self.module_parameters['pdc0'],
-                          eta_nom=self.inverter_parameters['eta_nom'])
+                          eta_inv_nom=self.inverter_parameters['eta_inv_nom'])
 
     def localize(self, location=None, latitude=None, longitude=None,
                  **kwargs):
@@ -1968,7 +1968,7 @@ def pvwatts_ac(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     pac0 = eta_inv_nom * pdc0
     zeta = pdc / pdc0
 
-    eta = eta_inv_nom / eta_ref * (-0.0162*zeta - 0.0059/zeta + 0.9858)
+    eta = eta_inv_nom / eta_inv_ref * (-0.0162*zeta - 0.0059/zeta + 0.9858)
 
     pac = eta * pdc
     pac = np.minimum(pac0, pac)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1831,12 +1831,12 @@ def scale_voltage_current_power(data, voltage=1, current=1):
 
 
 def pvwatts_dc(irrad_trans, temp_cell, pdc0, gamma, temp_ref=25.):
-    """
+    r"""
     Implements NREL's PVWatts DC power model [1]_.
 
     .. math::
 
-        Pdc = Itr/1000 * Pdc0 ( 1 + gamma (Tcell - Tref))
+        P_{dc} = \frac{I_{tr}}{1000} P_{dc0} ( 1 + \gamma (T_{cell} - T_{ref}))
 
     Parameters
     ----------
@@ -1871,17 +1871,18 @@ def pvwatts_dc(irrad_trans, temp_cell, pdc0, gamma, temp_ref=25.):
 
 
 def pvwatts_ac(pdc, pdc0, eta_nom=0.96, eta_ref=0.9637):
-    """
+    r"""
     Implements NREL's PVWatts inverter model [1]_.
 
     .. math::
 
-        eta = eta_nom / eta_ref * (-0.0162*zeta - 0.0059/zeta + 0.9858)
+        \eta = \frac{\eta_{nom}}{\eta_{ref}} (-0.0162\zeta - \frac{0.0059}{\zeta} + 0.9858)
 
-        Pac = eta*Pdc
-        Pac = Pac0
+    .. math::
 
-    where :math:`zeta=Pdc/Pdc0` and :math:`Pdc0=Pac0/eta_nom`.
+        P_{ac} = \min(\eta P_{dc}, P_{ac0})
+
+    where :math:`\zeta=P_{dc}/P_{dc0}` and :math:`P_{dc0}=P_{ac0}/\eta_{nom}`.
 
     Parameters
     ----------

--- a/pvlib/test/__init__.py
+++ b/pvlib/test/__init__.py
@@ -4,6 +4,7 @@
 import sys
 import platform
 import pandas as pd
+import numpy as np
 
 
 try:
@@ -59,6 +60,22 @@ def incompatible_pandas_0131(test):
     if pd.__version__ == '0.13.1':
         out = unittest.skip(
             'error on pandas 0.13.1 due to pandas/numpy')(test)
+    else:
+        out = test
+
+    return out
+
+
+def needs_numpy_1_10(test):
+    """
+    Test won't work on numpy 1.10.
+    """
+
+    major = int(np.__version__.split('.')[0])
+    minor = int(np.__version__.split('.')[1])
+
+    if major == 1 and minor < 10:
+        out = unittest.skip('needs numpy 1.10')(test)
     else:
         out = test
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -580,9 +580,30 @@ def test_pvwatts_ac_series():
     assert_series_equal(expected, out)
 
 
+def test_pvwatts_losses_default():
+    expected = 14.075660688264469
+    out = pvsystem.pvwatts_losses()
+    assert_allclose(expected, out)
+
+
+@needs_numpy_1_10
+def test_pvwatts_losses_arrays():
+    expected = np.array([nan, 14.934904])
+    age = np.array([nan, 1])
+    out = pvsystem.pvwatts_losses(age=age)
+    assert_allclose(expected, out)
+
+
+def test_pvwatts_losses_series():
+    expected = pd.Series([nan, 14.934904])
+    age = pd.Series([nan, 1])
+    out = pvsystem.pvwatts_losses(age=age)
+    assert_series_equal(expected, out)
+
+
 def make_pvwatts_system():
-    module_parameters = {'pdc0': 100, 'gamma': -0.003}
-    inverter_parameters = {'eta_nom': 0.95}
+    module_parameters = {'pdc0': 100, 'gamma_pdc': -0.003}
+    inverter_parameters = {'eta_inv_nom': 0.95}
     system = pvsystem.PVSystem(module_parameters=module_parameters,
                                inverter_parameters=inverter_parameters)
     return system

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -18,6 +18,8 @@ from pvlib import atmosphere
 from pvlib import solarposition
 from pvlib.location import Location
 
+from . import needs_numpy_1_10
+
 latitude = 32.2
 longitude = -111
 tus = Location(latitude, longitude, 'US/Arizona', 700, 'Tucson')
@@ -533,6 +535,7 @@ def test_pvwatts_dc_scalars():
     assert_allclose(expected, out)
 
 
+@needs_numpy_1_10
 def test_pvwatts_dc_arrays():
     irrad_trans = np.array([np.nan, 900, 900])
     temp_cell = np.array([30, np.nan, 30])
@@ -558,6 +561,7 @@ def test_pvwatts_ac_scalars():
     assert_allclose(expected, out)
 
 
+@needs_numpy_1_10
 def test_pvwatts_ac_arrays():
     pdc = np.array([[np.nan], [50], [100]])
     pdc0 = 100

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -618,6 +618,14 @@ def test_PVSystem_pvwatts_dc():
     assert_series_equal(expected, out)
 
 
+def test_PVSystem_pvwatts_losses():
+    system = make_pvwatts_system()
+    expected = pd.Series([nan, 14.934904])
+    age = pd.Series([nan, 1])
+    out = system.pvwatts_losses(age=age)
+    assert_series_equal(expected, out)
+
+
 def test_PVSystem_pvwatts_ac():
     system = make_pvwatts_system()
     pdc = pd.Series([np.nan, 50, 100])


### PR DESCRIPTION
I implemented the PVWatts module and inverter models as described in http://pvwatts.nrel.gov/downloads/pvwattsv5.pdf

I originally proposed something like this for ModelChains in #143, and @cwhanse wisely suggested adding PVWatts. It's probably best to first add the basic functions so that they don't get tied up in ModelChain land.

I'm looking for feedback on the function signatures and variable names so that we can try to maintain consistency throughout the library. I've mostly used the exact names from the PVWatts documentation, but we should consider changing at least a few of them. Keep in mind that we do have a [variable/style guide](http://pvlib-python.readthedocs.io/en/latest/variables_style_rules.html), but also that it's not set in stone:

* irrad_trans: Short for irradiance_transmitted, long for Itr. There are some other functions ~~(e.g. calcparams_desoto)~~ that currently use poa_global but that perhaps should use this instead.
* pdc: I might prefer this to e.g. power_dc
* pdc0: I prefer this to e.g. power_dc_0.
* gamma: I might prefer temp_coeff or temp_co.
* eta, eta_nom, eta_ref: I'd consider dc_ac_ratio_* or similar.

To do:
- [x] add notes to whats new
- [x] add new terms to style guide