### PR TITLE
remove unnecessary module argument from singlediode function

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -11,7 +11,10 @@ the API changes.
 API Changes
 ~~~~~~~~~~~
 
-* In ``pvlib.irradiance.perez``, renamed argument ``modelt`` to ``model`` (:issue:`196`)
+* Remove unneeded module argument from singlediode function. (:issue:`200`)
+* In ``pvlib.irradiance.perez``, renamed argument ``modelt`` to ``model``.
+ (:issue:`196`)
+
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -350,8 +350,7 @@ class PVSystem(object):
         -------
         See pvsystem.singlediode for details
         """
-        return singlediode(self.module_parameters, photocurrent,
-                           saturation_current,
+        return singlediode(photocurrent, saturation_current,
                            resistance_series, resistance_shunt, nNsVth)
 
     def i_from_v(self, resistance_shunt, resistance_series, nNsVth, voltage,
@@ -1334,9 +1333,9 @@ def sapm_celltemp(poa_global, wind_speed, temp_air,
     return pd.DataFrame({'temp_cell': temp_cell, 'temp_module': temp_module})
 
 
-def singlediode(module, photocurrent, saturation_current,
-                resistance_series, resistance_shunt, nNsVth):
-    '''
+def singlediode(photocurrent, saturation_current, resistance_series,
+                resistance_shunt, nNsVth):
+    r'''
     Solve the single-diode model to obtain a photovoltaic IV curve.
 
     Singlediode solves the single diode equation [1]
@@ -1357,9 +1356,6 @@ def singlediode(module, photocurrent, saturation_current,
 
     Parameters
     ----------
-    module : dict or Series
-        A dict-like object defining the SAPM performance parameters.
-
     photocurrent : float or Series
         Light-generated current (photocurrent) in amperes under desired
         IV curve conditions. Often abbreviated ``I_L``.
@@ -1439,7 +1435,7 @@ def singlediode(module, photocurrent, saturation_current,
               'i_0': saturation_current,
               'i_l': photocurrent}
 
-    p_mp, v_mp = _golden_sect_DataFrame(params, 0, module['V_oc_ref']*1.14,
+    p_mp, v_mp = _golden_sect_DataFrame(params, 0, v_oc*1.14,
                                         _pwr_optfcn)
 
     # Invert the Power-Current curve. Find the current where the inverted power

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1435,8 +1435,7 @@ def singlediode(photocurrent, saturation_current, resistance_series,
               'i_0': saturation_current,
               'i_l': photocurrent}
 
-    p_mp, v_mp = _golden_sect_DataFrame(params, 0, v_oc*1.14,
-                                        _pwr_optfcn)
+    p_mp, v_mp = _golden_sect_DataFrame(params, 0, v_oc*1.14, _pwr_optfcn)
 
     # Invert the Power-Current curve. Find the current where the inverted power
     # is minimized. This is i_mp. Start the optimization at v_oc/2

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1,12 +1,14 @@
 import inspect
 import os
 import datetime
+from functools import partial
 
 import numpy as np
 from numpy import nan
 import pandas as pd
 
 from nose.tools import assert_equals, assert_almost_equals
+from numpy.testing import assert_allclose
 from pandas.util.testing import assert_series_equal, assert_frame_equal
 from numpy.testing import assert_allclose
 
@@ -268,14 +270,18 @@ def test_singlediode_series():
                                          module_parameters=module_parameters,
                                          EgRef=1.121,
                                          dEgdT=-0.0002677)
-    out = pvsystem.singlediode(module_parameters, IL, I0, Rs, Rsh, nNsVth)
+    out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth)
     assert isinstance(out, pd.DataFrame)
+
+
+def assert_allclose_atol_01(*args):
+    return assert_allclose(*args, atol=0.02)
 
 
 def test_singlediode_floats():
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]
-    out = pvsystem.singlediode(module_parameters, 7, 6e-7, .1, 20, .5)
+    out = pvsystem.singlediode(7, 6e-7, .1, 20, .5)
     expected = {'i_xx': 4.2685798754011426,
                 'i_mp': 6.1390251797935704,
                 'v_oc': 8.1063001465863085,
@@ -285,7 +291,7 @@ def test_singlediode_floats():
                 'v_mp': 6.221535886625464}
     assert isinstance(out, dict)
     for k, v in out.items():
-        yield assert_almost_equals, expected[k], v, 3
+        yield assert_allclose_atol_01, expected[k], v
 
 
 def test_PVSystem_singlediode_floats():
@@ -303,7 +309,7 @@ def test_PVSystem_singlediode_floats():
                 'v_mp': 6.221535886625464}
     assert isinstance(out, dict)
     for k, v in out.items():
-        yield assert_almost_equals, expected[k], v, 3
+        yield assert_allclose_atol_01, expected[k], v
 
 
 def test_scale_voltage_current_power():

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1,7 +1,6 @@
 import inspect
 import os
 import datetime
-from functools import partial
 
 import numpy as np
 from numpy import nan
@@ -274,6 +273,7 @@ def test_singlediode_series():
     assert isinstance(out, pd.DataFrame)
 
 
+# nose didn't like it when I tried to use partial (wholmgren)
 def assert_allclose_atol_01(*args):
     return assert_allclose(*args, atol=0.02)
 


### PR DESCRIPTION
closes #200.

Note that the numerical solution for v_mp and p_mp changes by less than 0.02 (absolute units) for the test module.