### PR TITLE
add clear sky documentation page

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,7 @@ dependencies:
     - mock  # needed for local python 2.7 builds
     - numpy
     - scipy=0.16.0
+    - nomkl
     - pandas
     - pytz
     - ephem

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,6 +5,7 @@ dependencies:
     - numpy
     - scipy
     - pandas
+    - nomkl
     - pytz
     - ephem
     - numba

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,8 +3,7 @@ dependencies:
     - python=2.7
     - mock  # needed for local python 2.7 builds
     - numpy
-    - scipy=0.16.0
-    - nomkl
+    - scipy
     - pandas
     - pytz
     - ephem

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,7 @@
 name: pvlibdocs
+channels:
+    - conda-forge
+    - conda-forge/label/rc
 dependencies:
     - python=2.7
     - mock  # needed for local python 2.7 builds
@@ -11,7 +14,7 @@ dependencies:
     - ipython=4.0.1
     - ipywidgets
     - numpydoc
-    - matplotlib
+    - matplotlib=2.0.0*
     - seaborn
     - sphinx=1.3.5  # same versions as rtd
     - sphinx_rtd_theme=0.1.7

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,6 +13,6 @@ dependencies:
     - numpydoc
     - matplotlib
     - seaborn
-    - sphinx=1.3.5  # same versions as rtd
-    - sphinx_rtd_theme=0.1.7
-    - docutils=0.12
+    - sphinx  #=1.3.5  # same versions as rtd
+    - sphinx_rtd_theme  #=0.1.7
+    - docutils  #=0.12

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,9 +3,8 @@ dependencies:
     - python=2.7
     - mock  # needed for local python 2.7 builds
     - numpy
-    - scipy
+    - scipy=0.16.0
     - pandas
-    - nomkl
     - pytz
     - ephem
     - numba

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,6 @@
 name: pvlibdocs
-channels:
-    - conda-forge
-    - conda-forge/label/rc
 dependencies:
-    - python=2.7
+    - python=3.5
     - mock  # needed for local python 2.7 builds
     - numpy
     - scipy
@@ -14,7 +11,7 @@ dependencies:
     - ipython=4.0.1
     - ipywidgets
     - numpydoc
-    - matplotlib=2.0.0*
+    - matplotlib
     - seaborn
     - sphinx=1.3.5  # same versions as rtd
     - sphinx_rtd_theme=0.1.7

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: pvlibdocs
 dependencies:
-    - python=3.5
+    - python=2.7
     - mock  # needed for local python 2.7 builds
     - numpy
     - scipy
@@ -8,11 +8,11 @@ dependencies:
     - pytz
     - ephem
     - numba
-    - ipython  #=4.0.1
+    - ipython=4.0.1
     - ipywidgets
     - numpydoc
     - matplotlib
     - seaborn
-    - sphinx  #=1.3.5  # same versions as rtd
-    - sphinx_rtd_theme  #=0.1.7
-    - docutils  #=0.12
+    - sphinx=1.3.5  # same versions as rtd
+    - sphinx_rtd_theme=0.1.7
+    - docutils=0.12

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - pytz
     - ephem
     - numba
-    - ipython=4.0.1
+    - ipython  #=4.0.1
     - ipywidgets
     - numpydoc
     - matplotlib

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -141,7 +141,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: month = 1
 
-    In [1]: linke_turbidity_table[:, :, month-1]
+    In [1]: linke_turbidity_table
 
     In [1]: plt.figure();
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -27,8 +27,6 @@ clear sky algorithms and input data.
 We'll need these imports for the examples below.
 
 .. ipython::
-    :okexcept:
-    :okwarning:
 
     import itertools
     import matplotlib.pyplot as plt
@@ -60,7 +58,6 @@ attenuation. The time input must be a :py:class:`pandas.DatetimeIndex`,
 while the atmospheric attenuation inputs may be constants or arrays.
 
 .. ipython::
-    :verbatim:
 
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
     times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
@@ -76,7 +73,6 @@ model keyword argument and propagates additional arguments to the
 functions that do the computation.
 
 .. ipython::
-    :verbatim:
 
     cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
     cs.plot()
@@ -85,7 +81,6 @@ functions that do the computation.
     plt.ylabel('Irradiance $W/m^2$');
 
 .. ipython::
-    :verbatim:
 
     cs = tus.get_clearsky(times, model='simplified_solis',
                           aod700=0.2, precipitable_water=3)
@@ -156,7 +151,6 @@ relatively close so that you can get a better sense of the spatial
 variability of the data set.
 
 .. ipython::
-    :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
     plt.figure();
@@ -169,7 +163,6 @@ variability of the data set.
     plt.ylabel('Linke Turbidity');
 
 .. ipython::
-    :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
     pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1')
@@ -186,7 +179,6 @@ Examples
 A clear sky time series using basic pvlib functions.
 
 .. ipython::
-    :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
     times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
@@ -214,7 +206,6 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 Grid with a clear sky irradiance for a few turbidity values.
 
 .. ipython::
-    :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
     solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
@@ -296,7 +287,6 @@ Examples
 A clear sky time series using basic pvlib functions.
 
 .. ipython::
-    :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
     times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
@@ -324,7 +314,6 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 Irradiance as a function of solar elevation.
 
 .. ipython::
-    :verbatim:
 
     apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
     aod700 = 0.1
@@ -345,7 +334,6 @@ Irradiance as a function of solar elevation.
 Grid with a clear sky irradiance for a few PW and AOD values.
 
 .. ipython::
-    :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
     solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -65,7 +65,7 @@ while the atmospheric attenuation inputs may be constants or arrays.
     times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
                              freq='1min', tz=tus.tz)
     cs = tus.get_clearsky(times)  # ineichen with climatology table by default
-    cs.plot();
+    cs.plot()
     plt.ylabel('Irradiance $W/m^2$');
     @savefig location-basic.png width=6in
     plt.title('Ineichen, climatological turbidity');
@@ -77,7 +77,7 @@ functions that do the computation.
 .. ipython:: python
 
     cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
-    cs.plot();
+    cs.plot()
     plt.title('Ineichen, linke_turbidity=3');
     @savefig location-ineichen.png width=6in
     plt.ylabel('Irradiance $W/m^2$');
@@ -86,7 +86,7 @@ functions that do the computation.
 
     cs = tus.get_clearsky(times, model='simplified_solis',
                           aod700=0.2, precipitable_water=3)
-    cs.plot();
+    cs.plot()
     plt.title('Simplfied Solis, aod700=0.2, precipitable_water=3');
     @savefig location-solis.png width=6in
     plt.ylabel('Irradiance $W/m^2$');
@@ -156,10 +156,10 @@ variability of the data set.
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
     plt.figure();
-    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1');
-    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2');
-    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix');
-    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque');
+    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1')
+    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2')
+    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix')
+    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque')
     plt.legend();
     @savefig turbidity-no-interp.png width=6in
     plt.ylabel('Linke Turbidity');
@@ -167,10 +167,10 @@ variability of the data set.
 .. ipython:: python
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
-    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1');
-    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2');
-    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix');
-    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque');
+    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1')
+    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2')
+    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix')
+    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque')
     plt.legend();
     @savefig turbidity-yes-interp.png width=6in
     plt.ylabel('Linke Turbidity');
@@ -195,7 +195,7 @@ A clear sky time series using basic pvlib functions.
 
     # an input is a pandas Series, so solis is a DataFrame
     ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
-    ax = ineichen.plot();
+    ax = ineichen.plot()
     ax.set_ylabel('Irradiance $W/m^2$');
     ax.legend(loc=2);
     @savefig ineichen-vs-time-climo.png width=6in
@@ -303,7 +303,7 @@ A clear sky time series using basic pvlib functions.
     # an input is a Series, so solis is a DataFrame
     solis = clearsky.simplified_solis(apparent_elevation, aod700, precipitable_water,
                                       pressure, dni_extra)
-    ax = solis.plot();
+    ax = solis.plot()
     ax.set_ylabel('Irradiance $W/m^2$');
     ax.legend(loc=2);
     @savefig solis-vs-time-0.1-1.png width=6in
@@ -349,7 +349,7 @@ Grid with a clear sky irradiance for a few PW and AOD values.
     fig, axes = plt.subplots(ncols=2, nrows=2, sharex=True, sharey=True, squeeze=True)
     axes = axes.flatten()
 
-    [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)];
+    [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)]
 
     @savefig solis-grid.png width=10in
     plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,8 +136,6 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
-.. code-block:: python
-
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
 
@@ -147,7 +145,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
 
-    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[1+month]);
+    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
 
     In [1]: plt.colorbar(shrink=0.5);
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -192,8 +192,7 @@ A clear sky time series using basic pvlib functions.
     dni_extra = pvlib.irradiance.extraradiation(apparent_zenith.index.dayofyear)
 
     # an input is a pandas Series, so solis is a DataFrame
-    ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity,
-                                 altitude, dni_extra)
+    ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
     ax = ineichen.plot();
     ax.set_ylabel('Irradiance $W/m^2$');
     ax.legend(loc=2);
@@ -348,10 +347,7 @@ Grid with a clear sky irradiance for a few PW and AOD values.
     fig, axes = plt.subplots(ncols=2, nrows=2, sharex=True, sharey=True, squeeze=True)
     axes = axes.flatten()
 
-    for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes):
-        solis = clearsky.simplified_solis(apparent_elevation, aod, pw,
-                                          pressure, dni_extra)
-        solis.plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw))
+    [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)];
 
     @savefig solis-grid.png width=10in
     plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,10 +136,10 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
-.. code-block:: python
-
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
+
+    In [1]: linke_turbidity_table
 
     In [1]: month = 1
 
@@ -152,6 +152,8 @@ the year. You could run it in a loop to create plots for all months.
     In [1]: plt.colorbar(shrink=0.5);
 
     In [1]: plt.tight_layout();
+
+.. code-block:: python
 
     @savefig turbidity-1.png width=10in
     In [1]: plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -122,7 +122,7 @@ pvlib includes a file with monthly climatological turbidity values for
 the globe. The code below creates turbidity maps for a few months of
 the year. You could run it in a loop to create plots for all months.
 
-.. ipython::
+.. code-block:: python
 
     In [1]: import calendar
 
@@ -154,7 +154,7 @@ the year. You could run it in a loop to create plots for all months.
     @savefig turbidity-1.png width=10in
     In [1]: plt.show();
 
-.. ipython::
+.. code-block:: python
 
     In [1]: month = 7
 
@@ -181,7 +181,7 @@ Southwest U.S. with and without interpolation. We chose points that are
 relatively close so that you can get a better sense of the spatial
 variability of the data set.
 
-.. ipython::
+.. code-block:: python
 
     In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
 
@@ -200,7 +200,7 @@ variability of the data set.
     @savefig turbidity-no-interp.png width=6in
     In [1]: plt.ylabel('Linke Turbidity');
 
-.. ipython::
+.. code-block:: python
 
     In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -143,15 +143,17 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: linke_turbidity_table
 
+.. code-block:: python
+
     In [1]: plt.figure();
 
-    #In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
 
-    #In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
+    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
 
-    #In [1]: plt.colorbar(shrink=0.5);
+    In [1]: plt.colorbar(shrink=0.5);
 
-    #In [1]: plt.tight_layout();
+    In [1]: plt.tight_layout();
 
     @savefig turbidity-jan.png width=10in
     In [1]: plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,7 +138,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: mat['LinkeTurbidity'][:].astype('float')
+    In [1]: np.array(mat['LinkeTurbidity'], dtype='float')
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -141,6 +141,8 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: month = 1
 
+.. code-block:: python
+
     In [1]: linke_turbidity_table
 
 .. code-block:: python

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -60,6 +60,7 @@ attenuation. The time input must be a :py:class:`pandas.DatetimeIndex`,
 while the atmospheric attenuation inputs may be constants or arrays.
 
 .. ipython:: python
+    :verbatim:
 
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
     times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
@@ -75,6 +76,7 @@ model keyword argument and propagates additional arguments to the
 functions that do the computation.
 
 .. ipython:: python
+    :verbatim:
 
     cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
     cs.plot()
@@ -83,6 +85,7 @@ functions that do the computation.
     plt.ylabel('Irradiance $W/m^2$');
 
 .. ipython:: python
+    :verbatim:
 
     cs = tus.get_clearsky(times, model='simplified_solis',
                           aod700=0.2, precipitable_water=3)
@@ -153,6 +156,7 @@ relatively close so that you can get a better sense of the spatial
 variability of the data set.
 
 .. ipython:: python
+    :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
     plt.figure();
@@ -165,6 +169,7 @@ variability of the data set.
     plt.ylabel('Linke Turbidity');
 
 .. ipython:: python
+    :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
     pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1')
@@ -181,6 +186,7 @@ Examples
 A clear sky time series using basic pvlib functions.
 
 .. ipython:: python
+    :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
     times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
@@ -208,6 +214,7 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 Grid with a clear sky irradiance for a few turbidity values.
 
 .. ipython:: python
+    :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
     solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
@@ -289,6 +296,7 @@ Examples
 A clear sky time series using basic pvlib functions.
 
 .. ipython:: python
+    :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
     times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
@@ -316,6 +324,7 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 Irradiance as a function of solar elevation.
 
 .. ipython:: python
+    :verbatim:
 
     apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
     aod700 = 0.1
@@ -336,6 +345,7 @@ Irradiance as a function of solar elevation.
 Grid with a clear sky irradiance for a few PW and AOD values.
 
 .. ipython:: python
+    :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
     solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -139,7 +139,7 @@ the year. You could run it in a loop to create plots for all months.
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity']  # / 20.   # crashes on rtd
 
-    In [1]: months = 1
+    In [1]: month = 1
 
     In [1]: plt.figure();
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -55,7 +55,7 @@ functions that do the computation.
     cs.plot();
     plt.title('Ineichen, linke_turbidity=3');
     @savefig location-ineichen.png width=6in
-    plt.ylabel('Irradiance $W/m^2$')
+    plt.ylabel('Irradiance $W/m^2$');
 
 .. ipython:: python
 
@@ -76,8 +76,9 @@ The model parameterizes irradiance in terms of the Linke turbidity.
 Turbidity
 ^^^^^^^^^
 
-The code below creates turbidity plots for a few months of the year.
-You could run it in a loop to create plots for all months.
+pvlib includes a file with monthly climatological turbidity values for
+the globe. The code below creates turbidity maps for a few months of
+the year. You could run it in a loop to create plots for all months.
 
 .. ipython:: python
 
@@ -107,15 +108,20 @@ You could run it in a loop to create plots for all months.
     @savefig turbidity-7.png width=10in
     plt.colorbar();
 
-
-Here's a plot of selected areas in the Southwest U.S. We have
-intentionally shown points that are relatively close so that you can get
-a sense of the variability of the data set.
+The :py:func:`~pvlib.clearsky.lookup_linke_turbidity` function takes a
+time, latitude, and longitude and gets the corresponding climatological
+turbidity value for that time at those coordinates. By default, the
+:py:func:`~pvlib.clearsky.lookup_linke_turbidity` function will linearly
+interpolate turbidity from month to month. This removes discontinuities
+in multi-month PV models. Here's a plot of a few locations in the
+Southwest U.S. with and without interpolation. We have intentionally
+shown points that are relatively close so that you can get a sense of
+the variability of the data set.
 
 .. ipython:: python
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
-    plt.figure()
+    plt.figure();
     pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1');
     pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2');
     pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix');
@@ -123,11 +129,6 @@ a sense of the variability of the data set.
     plt.legend();
     @savefig turbidity-no-interp.png width=6in
     plt.ylabel('Linke Turbidity');
-
-By default, the :py:func:`~pvlib.clearsky.lookup_linke_turbidity`
-function will linearly interpolate turbidity from month to month. This
-removes discontinuities in multi-month PV models. See the source code
-for details.
 
 .. ipython:: python
 
@@ -147,7 +148,7 @@ Arizona. Here are links to an
 `ipynb notebook
 <https://forecasting.energy.arizona.edu/media/ineichen_vs_mcclear.ipynb>`_
 and its `html rendering
-<https://forecasting.uaren.org/media/ineichen_vs_mcclear.html>`_.
+<https://forecasting.energy.arizona.edu/media/ineichen_vs_mcclear.html>`_.
 
 
 Simplified Solis

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -26,7 +26,7 @@ clear sky algorithms and input data.
 
 We'll need these imports for the examples below.
 
-.. ipython:: python
+.. ipython::
     :okexcept:
     :okwarning:
 
@@ -59,7 +59,7 @@ only specify the most important parameters: time and atmospheric
 attenuation. The time input must be a :py:class:`pandas.DatetimeIndex`,
 while the atmospheric attenuation inputs may be constants or arrays.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
@@ -75,7 +75,7 @@ The :py:meth:`~pvlib.location.Location.get_clearsky` method accepts a
 model keyword argument and propagates additional arguments to the
 functions that do the computation.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
@@ -84,7 +84,7 @@ functions that do the computation.
     @savefig location-ineichen.png width=6in
     plt.ylabel('Irradiance $W/m^2$');
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     cs = tus.get_clearsky(times, model='simplified_solis',
@@ -114,7 +114,7 @@ pvlib includes a file with monthly climatological turbidity values for
 the globe. The code below creates turbidity maps for a few months of
 the year. You could run it in a loop to create plots for all months.
 
-.. ipython:: python
+.. ipython::
 
     import calendar
     import os
@@ -135,7 +135,7 @@ the year. You could run it in a loop to create plots for all months.
     @savefig turbidity-1.png width=10in
     plt.show();
 
-.. ipython:: python
+.. ipython::
 
     month = 7
     plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
@@ -155,7 +155,7 @@ Southwest U.S. with and without interpolation. We chose points that are
 relatively close so that you can get a better sense of the spatial
 variability of the data set.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
@@ -168,7 +168,7 @@ variability of the data set.
     @savefig turbidity-no-interp.png width=6in
     plt.ylabel('Linke Turbidity');
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
@@ -185,7 +185,7 @@ Examples
 
 A clear sky time series using basic pvlib functions.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
@@ -213,7 +213,7 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 
 Grid with a clear sky irradiance for a few turbidity values.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
@@ -295,7 +295,7 @@ Examples
 
 A clear sky time series using basic pvlib functions.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
@@ -323,7 +323,7 @@ DataFrame output. The keys are 'ghi', 'dni', and 'dhi'.
 
 Irradiance as a function of solar elevation.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
@@ -344,7 +344,7 @@ Irradiance as a function of solar elevation.
 
 Grid with a clear sky irradiance for a few PW and AOD values.
 
-.. ipython:: python
+.. ipython::
     :verbatim:
 
     times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
@@ -366,7 +366,7 @@ Grid with a clear sky irradiance for a few PW and AOD values.
 
 Contour plots of irradiance as a function of both PW and AOD.
 
-.. ipython:: python
+.. ipython::
 
     aod700 = np.linspace(0, 0.5, 101)
     precipitable_water = np.linspace(0, 10, 101)
@@ -396,7 +396,7 @@ Contour plots of irradiance as a function of both PW and AOD.
         fig.colorbar(imf, label='{} (W/m**2)'.format(key))
         ax.set_title('{}, elevation={}'.format(key, apparent_elevation))
 
-.. ipython:: python
+.. ipython::
 
     plot_solis('ghi')
     @savefig solis-ghi.png width=10in

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -145,15 +145,13 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: plt.figure();
 
-    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    #In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
 
     In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
 
     In [1]: plt.colorbar(shrink=0.5);
 
     In [1]: plt.tight_layout();
-
-.. code-block:: python
 
     @savefig turbidity-1.png width=10in
     In [1]: plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -39,13 +39,11 @@ We'll need these imports for the examples below.
 
     In [1]: sns.set_color_codes()
 
-    In [2]: import pvlib
+    In [1]: import pvlib
 
-    In [3]: import pvlib.clearsky as clearsky
+    In [1]: from pvlib import clearsky, atmosphere
 
-    In [4]: from pvlib import atmosphere
-
-    In [5]: from pvlib.location import Location
+    In [1]: from pvlib.location import Location
 
 
 .. _location:
@@ -65,14 +63,13 @@ while the atmospheric attenuation inputs may be constants or arrays.
 
 .. ipython::
 
-    In [5]: tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    In [1]: tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
 
-    In [1]: times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
-                             freq='1min', tz=tus.tz)
+    In [1]: times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04', freq='1min', tz=tus.tz)
 
     In [1]: cs = tus.get_clearsky(times)  # ineichen with climatology table by default
 
-    In [1]: cs.plot()
+    In [1]: cs.plot();
 
     In [1]: plt.ylabel('Irradiance $W/m^2$');
 
@@ -85,20 +82,25 @@ functions that do the computation.
 
 .. ipython::
 
-    cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
-    cs.plot()
-    plt.title('Ineichen, linke_turbidity=3');
+    In [1]: cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
+
+    In [1]: cs.plot();
+
+    In [1]: plt.title('Ineichen, linke_turbidity=3');
+
     @savefig location-ineichen.png width=6in
-    plt.ylabel('Irradiance $W/m^2$');
+    In [1]: plt.ylabel('Irradiance $W/m^2$');
 
 .. ipython::
 
-    cs = tus.get_clearsky(times, model='simplified_solis',
-                          aod700=0.2, precipitable_water=3)
-    cs.plot()
-    plt.title('Simplfied Solis, aod700=0.2, precipitable_water=3');
+    In [1]: cs = tus.get_clearsky(times, model='simplified_solis', aod700=0.2, precipitable_water=3)
+
+    In [1]: cs.plot();
+
+    In [1]: plt.title('Simplfied Solis, aod700=0.2, precipitable_water=3');
+
     @savefig location-solis.png width=6in
-    plt.ylabel('Irradiance $W/m^2$');
+    In [1]: plt.ylabel('Irradiance $W/m^2$');
 
 
 See the sections below for more detail on the clear sky models.

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -1,0 +1,269 @@
+.. _clearsky:
+
+Clear sky
+=========
+
+Clear sky expectations are essential to many PV modeling tasks.
+Here, we briefly review the clear sky modeling capabilities of pvlib-python.
+
+.. ipython:: python
+
+    import datetime
+    import itertools
+    import pandas as pd
+    import matplotlib.pyplot as plt
+
+    # seaborn makes the plots look nicer
+    import seaborn as sns
+    sns.set_color_codes()
+
+    import pvlib
+    from pvlib import clearsky
+    from pvlib import atmosphere
+    from pvlib.location import Location
+
+
+Location
+--------
+
+The easiest way to get clear sky data is to use a
+:py:class:`~pvlib.location.Location` object's
+:py:meth:`~pvlib.location.Location.get_clearsky` method. The
+:py:meth:`~pvlib.location.Location.get_clearsky` method does the dirty
+work of calculating solar position, extraterrestrial irradiance,
+airmass, and atmospheric pressure, as appropriate, leaving the user to
+only specify the most important parameters. We encourage users to
+examine the source code.
+
+.. ipython:: python
+
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04', freq='1min', tz=tus.tz)
+    cs = tus.get_clearsky(times)  # ineichen with lookup table by default
+    cs.plot();
+    plt.ylabel('Irradiance $W/m^2$');
+    @savefig location-basic.png width=6in
+    plt.title('Ineichen, climatological turbidity');
+
+The :py:meth:`~pvlib.location.Location.get_clearsky` method accepts a
+model keyword argument and propagates additional arguments to the
+functions that do the computation.
+
+.. ipython:: python
+
+    cs = tus.get_clearsky(times, model='ineichen', linke_turbidity=3)
+    cs.plot();
+    plt.title('Ineichen, linke_turbidity=3');
+    @savefig location-ineichen.png width=6in
+    plt.ylabel('Irradiance $W/m^2$')
+
+.. ipython:: python
+
+    cs = tus.get_clearsky(times, model='simplified_solis',
+                          aod700=0.2, precipitable_water=3)
+    cs.plot();
+    plt.title('Simplfied Solis, aod700=0.2, precipitable_water=3');
+    @savefig location-solis.png width=6in
+    plt.ylabel('Irradiance $W/m^2$');
+
+
+Ineichen
+--------
+
+The Ineichen and Perez (2002) model has proven to be a popular model.
+The model parameterizes irradiance in terms of the Linke turbidity.
+
+Turbidity
+^^^^^^^^^
+
+The code below creates turbidity plots for a few months of the year.
+You could run it in a loop to create plots for all months.
+
+.. ipython:: python
+
+    import calendar
+    import os
+    import scipy.io
+
+    pvlib_path = os.path.dirname(os.path.abspath(pvlib.clearsky.__file__))
+    filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
+
+    mat = scipy.io.loadmat(filepath)
+    linke_turbidity_table = mat['LinkeTurbidity'] / 20
+
+    month = 1
+    plt.figure(figsize=(20,10));
+    plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    plt.title(calendar.month_name[1+month]);
+    @savefig turbidity-1.png width=10in
+    plt.colorbar();
+
+.. ipython:: python
+
+    month = 7
+    plt.figure(figsize=(20,10));
+    plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    plt.title(calendar.month_name[month]);
+    @savefig turbidity-7.png width=10in
+    plt.colorbar();
+
+
+Here's a plot of selected areas in the Southwest U.S. We have
+intentionally shown points that are relatively close so that you can get
+a sense of the variability of the data set.
+
+.. ipython:: python
+
+    times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
+    plt.figure()
+    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1');
+    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2');
+    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix');
+    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque');
+    plt.legend();
+    @savefig turbidity-no-interp.png width=6in
+    plt.ylabel('Linke Turbidity');
+
+By default, the :py:func:`~pvlib.clearsky.lookup_linke_turbidity`
+function will linearly interpolate turbidity from month to month. This
+removes discontinuities in multi-month PV models. See the source code
+for details.
+
+.. ipython:: python
+
+    times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
+    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1');
+    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2');
+    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix');
+    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque');
+    plt.legend();
+    @savefig turbidity-yes-interp.png width=6in
+    plt.ylabel('Linke Turbidity');
+
+Will Holmgren did some rough analysis comparing pvlib's ineichen model
+to `SoDa's McClear service
+<http://www.soda-pro.com/web-services/radiation/cams-mcclear>`_ in
+Arizona. Here are links to an
+`ipynb notebook
+<https://forecasting.energy.arizona.edu/media/ineichen_vs_mcclear.ipynb>`_
+and its `html rendering
+<https://forecasting.uaren.org/media/ineichen_vs_mcclear.html>`_.
+
+
+Simplified Solis
+----------------
+
+The Simplified Solis model parameterizes irradiance in terms of
+precipitable water and aerosol optical depth.
+
+Ground based aerosol data can be obtained from
+`Aeronet <http://aeronet.gsfc.nasa.gov>`_. Precipitable water can be obtained
+from `ESRL <http://gpsmet.noaa.gov/cgi-bin/gnuplots/rti.cgi>`_.
+
+.. ipython:: python
+
+    aod700 = 0.1
+    precipitable_water = 1
+    apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
+    pressure = 101325
+    dni_extra = 1364
+
+    solis = clearsky.simplified_solis(apparent_elevation, aod700,
+                                      precipitable_water, pressure, dni_extra)
+    ax = solis.plot()
+    ax.set_xlabel('apparent elevation (deg)');
+    ax.set_ylabel('irradiance (W/m**2)');
+    @savefig solis-vs-elevation.png width=6in
+    ax.legend(loc=2);
+
+
+.. ipython:: python
+
+    from pvlib.location import Location
+
+    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    times = pd.date_range(start=datetime.datetime(2014,1,1), end=datetime.datetime(2014,1,2), freq='1Min').tz_localize(tus.tz)
+    solpos = pvlib.solarposition.get_solarposition(times, tus.latitude, tus.longitude)
+    ephem_data = solpos
+
+    aod700 = 0.1
+    precipitable_water = 1
+    apparent_elevation = solpos['apparent_elevation']
+    pressure = pvlib.atmosphere.alt2pres(tus.altitude)
+    dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
+
+    solis = clearsky.simplified_solis(apparent_elevation, aod700, precipitable_water, pressure, dni_extra)
+    @savefig solis-vs-time.png width=6in
+    solis.plot();
+
+
+
+.. ipython:: python
+
+    times = pd.date_range(start=datetime.datetime(2014,9,1), end=datetime.datetime(2014,9,2), freq='1Min').tz_localize(tus.tz)
+    solpos = pvlib.solarposition.get_solarposition(times, tus.latitude, tus.longitude)
+    ephem_data = solpos
+
+    apparent_elevation = solpos['apparent_elevation']
+    pressure = pvlib.atmosphere.alt2pres(tus.altitude)
+    dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
+
+    aod700 = [0.01, 0.1]
+    precipitable_water = [0.5, 5]
+
+    for aod, pw in itertools.product(aod700, precipitable_water):
+        solis = clearsky.simplified_solis(apparent_elevation, aod, pw,
+                                          pressure, dni_extra)
+        fig, ax = plt.subplots()
+        solis.plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw))
+        ax.set_ylim(0, 1100)
+        file = 'aod{}_pw{}.png'.format(aod, pw)
+        @savefig file width=6in
+        plt.show()
+
+
+.. ipython:: python
+
+    aod700 = np.linspace(0, 0.5, 101)
+    precipitable_water = np.linspace(0, 10, 101)
+    apparent_elevation = 70
+    pressure = 101325
+    dni_extra = 1364
+
+    aod700, precipitable_water = np.meshgrid(aod700, precipitable_water)
+
+    solis = clearsky.simplified_solis(apparent_elevation, aod700,
+                                      precipitable_water, pressure,
+                                      dni_extra)
+    cmap = plt.get_cmap('viridis')
+    n = 15
+    vmin = None
+    vmax = None
+
+    def plot_solis(key):
+        irrad = solis[key]
+        fig, ax = plt.subplots(figsize=(12,9))
+        im = ax.contour(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
+        imf = ax.contourf(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
+        ax.set_xlabel('AOD')
+        ax.set_ylabel('Precipitable water (cm)')
+        ax.clabel(im, colors='k', fmt='%.0f')
+        fig.colorbar(imf, label='{} (W/m**2)'.format(key))
+        ax.set_title('{}, elevation={}'.format(key, apparent_elevation))
+
+.. ipython:: python
+
+    plot_solis('ghi')
+    @savefig solis-ghi.png width=6in
+    plt.show()
+
+    plot_solis('dni')
+    @savefig solis-dni.png width=6in
+    plt.show()
+
+    plot_solis('dhi')
+    @savefig solis-dhi.png width=6in
+    plt.show()
+
+We encourage users to compare the pvlib implementation to Ineichen's
+`Excel tool <http://www.unige.ch/energie/fr/equipe/ineichen/solis-tool/>`_.

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -124,34 +124,52 @@ the year. You could run it in a loop to create plots for all months.
 
 .. ipython::
 
-    import calendar
-    import os
-    import scipy.io
+    In [1]: import calendar
 
-    pvlib_path = os.path.dirname(os.path.abspath(pvlib.clearsky.__file__))
-    filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
+    In [1]: import os
 
-    mat = scipy.io.loadmat(filepath)
+    In [1]: import scipy.io
+
+    In [1]: pvlib_path = os.path.dirname(os.path.abspath(pvlib.clearsky.__file__))
+
+    In [1]: filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
+
+    In [1]: mat = scipy.io.loadmat(filepath)
+
     # data is in units of 20 x turbidity
-    linke_turbidity_table = mat['LinkeTurbidity'] / 20.
+    In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
 
-    month = 1
-    plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
-    plt.title('Linke turbidity, ' + calendar.month_name[1+month]);
-    plt.colorbar(shrink=0.5);
-    plt.tight_layout();
+    In [1]: month = 1
+
+    In [1]: plt.figure();
+
+    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+
+    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[1+month]);
+
+    In [1]: plt.colorbar(shrink=0.5);
+
+    In [1]: plt.tight_layout();
+
     @savefig turbidity-1.png width=10in
-    plt.show();
+    In [1]: plt.show();
 
 .. ipython::
 
-    month = 7
-    plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
-    plt.title('Linke turbidity, ' + calendar.month_name[month]);
-    plt.colorbar(shrink=0.5);
-    plt.tight_layout();
+    In [1]: month = 7
+
+    In [1]: plt.figure();
+
+    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+
+    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
+
+    In [1]: plt.colorbar(shrink=0.5);
+
+    In [1]: plt.tight_layout();
+
     @savefig turbidity-7.png width=10in
-    plt.show();
+    In [1]: plt.show();
 
 The :py:func:`~pvlib.clearsky.lookup_linke_turbidity` function takes a
 time, latitude, and longitude and gets the corresponding climatological
@@ -165,26 +183,41 @@ variability of the data set.
 
 .. ipython::
 
-    times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
-    plt.figure();
-    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1')
-    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2')
-    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix')
-    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque')
-    plt.legend();
+    In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
+
+    In [1]: plt.figure();
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque');
+
+    In [1]: plt.legend();
+
     @savefig turbidity-no-interp.png width=6in
-    plt.ylabel('Linke Turbidity');
+    In [1]: plt.ylabel('Linke Turbidity');
 
 .. ipython::
 
-    times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
-    pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1')
-    pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2')
-    pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix')
-    pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque')
-    plt.legend();
+    In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
+
+    In [1]: plt.figure();
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix');
+
+    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque');
+
+    In [1]: plt.legend();
+
     @savefig turbidity-yes-interp.png width=6in
-    plt.ylabel('Linke Turbidity');
+    In [1]: plt.ylabel('Linke Turbidity');
 
 Examples
 ^^^^^^^^
@@ -193,24 +226,37 @@ A clear sky time series using basic pvlib functions.
 
 .. ipython::
 
-    latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
-    times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
-    solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+    In [1]: latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
 
-    apparent_zenith = solpos['apparent_zenith']
-    airmass = pvlib.atmosphere.relativeairmass(apparent_zenith)
-    pressure = pvlib.atmosphere.alt2pres(altitude)
-    airmass = pvlib.atmosphere.absoluteairmass(airmass, pressure)
-    linke_turbidity = pvlib.clearsky.lookup_linke_turbidity(times, latitude, longitude)
-    dni_extra = pvlib.irradiance.extraradiation(apparent_zenith.index.dayofyear)
+    In [1]: times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
+
+    In [1]: solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+
+    In [1]: apparent_zenith = solpos['apparent_zenith']
+
+    In [1]: airmass = pvlib.atmosphere.relativeairmass(apparent_zenith)
+
+    In [1]: pressure = pvlib.atmosphere.alt2pres(altitude)
+
+    In [1]: airmass = pvlib.atmosphere.absoluteairmass(airmass, pressure)
+
+    In [1]: linke_turbidity = pvlib.clearsky.lookup_linke_turbidity(times, latitude, longitude)
+
+    In [1]: dni_extra = pvlib.irradiance.extraradiation(apparent_zenith.index.dayofyear)
 
     # an input is a pandas Series, so solis is a DataFrame
-    ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
-    ax = ineichen.plot()
-    ax.set_ylabel('Irradiance $W/m^2$');
-    ax.legend(loc=2);
+    In [1]: ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
+
+    In [1]: plt.figure();
+
+    In [1]: ax = ineichen.plot()
+
+    In [1]: ax.set_ylabel('Irradiance $W/m^2$');
+
+    In [1]: ax.legend(loc=2);
+
     @savefig ineichen-vs-time-climo.png width=6in
-    plt.show();
+    In [1]: plt.show();
 
 The input data types determine the returned output type. Array input
 results in an OrderedDict of array output, and Series input results in a
@@ -220,30 +266,38 @@ Grid with a clear sky irradiance for a few turbidity values.
 
 .. ipython::
 
-    times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
-    solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+    In [1]: times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
 
-    apparent_zenith = solpos['apparent_zenith']
-    airmass = pvlib.atmosphere.relativeairmass(apparent_zenith)
-    pressure = pvlib.atmosphere.alt2pres(altitude)
-    airmass = pvlib.atmosphere.absoluteairmass(airmass, pressure)
-    linke_turbidity = pvlib.clearsky.lookup_linke_turbidity(times, latitude, longitude)
-    print('climatological linke_turbidity = {}'.format(linke_turbidity.mean()))
-    dni_extra = pvlib.irradiance.extraradiation(apparent_zenith.index.dayofyear)
+    In [1]: solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
 
-    linke_turbidities = [linke_turbidity.mean(), 2, 4]
+    In [1]: apparent_zenith = solpos['apparent_zenith']
 
-    fig, axes = plt.subplots(ncols=3, nrows=1, sharex=True, sharey=True, squeeze=True)
-    axes = axes.flatten()
+    In [1]: airmass = pvlib.atmosphere.relativeairmass(apparent_zenith)
 
-    for linke_turbidity, ax in zip(linke_turbidities, axes):
-        ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity,
-                                     altitude, dni_extra)
-        ineichen.plot(ax=ax, title='Linke turbidity = {:0.1f}'.format(linke_turbidity))
-        ax.legend(loc=1)
+    In [1]: pressure = pvlib.atmosphere.alt2pres(altitude)
+
+    In [1]: airmass = pvlib.atmosphere.absoluteairmass(airmass, pressure)
+
+    In [1]: linke_turbidity = pvlib.clearsky.lookup_linke_turbidity(times, latitude, longitude)
+
+    In [1]: print('climatological linke_turbidity = {}'.format(linke_turbidity.mean()))
+
+    In [1]: dni_extra = pvlib.irradiance.extraradiation(apparent_zenith.index.dayofyear)
+
+    In [1]: linke_turbidities = [linke_turbidity.mean(), 2, 4]
+
+    In [1]: fig, axes = plt.subplots(ncols=3, nrows=1, sharex=True, sharey=True, squeeze=True, figsize=(12, 6))
+
+    In [1]: axes = axes.flatten()
+
+    In [1]: for linke_turbidity, ax in zip(linke_turbidities, axes):
+       ...:     ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
+       ...:     ineichen.plot(ax=ax, title='Linke turbidity = {:0.1f}'.format(linke_turbidity));
+
+    In [1]: ax.legend(loc=1)
 
     @savefig ineichen-grid.png width=10in
-    plt.show();
+    In [1]: plt.show();
 
 
 
@@ -301,24 +355,34 @@ A clear sky time series using basic pvlib functions.
 
 .. ipython::
 
-    latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
-    times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
-    solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+    In [1]: latitude, longitude, tz, altitude, name = 32.2, -111, 'US/Arizona', 700, 'Tucson'
 
-    apparent_elevation = solpos['apparent_elevation']
-    aod700 = 0.1
-    precipitable_water = 1
-    pressure = pvlib.atmosphere.alt2pres(altitude)
-    dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
+    In [1]: times = pd.date_range(start='2014-01-01', end='2014-01-02', freq='1Min', tz=tz)
+
+    In [1]: solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+
+    In [1]: apparent_elevation = solpos['apparent_elevation']
+
+    In [1]: aod700 = 0.1
+
+    In [1]: precipitable_water = 1
+
+    In [1]: pressure = pvlib.atmosphere.alt2pres(altitude)
+
+    In [1]: dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
 
     # an input is a Series, so solis is a DataFrame
-    solis = clearsky.simplified_solis(apparent_elevation, aod700, precipitable_water,
+    In [1]: solis = clearsky.simplified_solis(apparent_elevation, aod700, precipitable_water,
                                       pressure, dni_extra)
-    ax = solis.plot()
-    ax.set_ylabel('Irradiance $W/m^2$');
-    ax.legend(loc=2);
+
+    In [1]: ax = solis.plot();
+
+    In [1]: ax.set_ylabel('Irradiance $W/m^2$');
+
+    In [1]: ax.legend(loc=2);
+
     @savefig solis-vs-time-0.1-1.png width=6in
-    plt.show();
+    In [1]: plt.show();
 
 The input data types determine the returned output type. Array input
 results in an OrderedDict of array output, and Series input results in a
@@ -328,88 +392,114 @@ Irradiance as a function of solar elevation.
 
 .. ipython::
 
-    apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
-    aod700 = 0.1
-    precipitable_water = 1
-    pressure = 101325
-    dni_extra = 1364
+    In [1]: apparent_elevation = pd.Series(np.linspace(-10, 90, 101))
 
-    solis = clearsky.simplified_solis(apparent_elevation, aod700,
-                                      precipitable_water, pressure, dni_extra)
-    ax = solis.plot()
-    ax.set_xlabel('Apparent elevation (deg)');
-    ax.set_ylabel('Irradiance $W/m^2$');
-    ax.set_title('Irradiance vs Solar Elevation')
+    In [1]: aod700 = 0.1
+
+    In [1]: precipitable_water = 1
+
+    In [1]: pressure = 101325
+
+    In [1]: dni_extra = 1364
+
+    In [1]: solis = clearsky.simplified_solis(apparent_elevation, aod700,
+       ...:                                   precipitable_water, pressure, dni_extra)
+
+    In [1]: ax = solis.plot();
+
+    In [1]: ax.set_xlabel('Apparent elevation (deg)');
+
+    In [1]: ax.set_ylabel('Irradiance $W/m^2$');
+
+    In [1]: ax.set_title('Irradiance vs Solar Elevation')
+
     @savefig solis-vs-elevation.png width=6in
-    ax.legend(loc=2);
+    In [1]: ax.legend(loc=2);
 
 
 Grid with a clear sky irradiance for a few PW and AOD values.
 
 .. ipython::
 
-    times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
-    solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
+    In [1]: times = pd.date_range(start='2014-09-01', end='2014-09-02', freq='1Min', tz=tz)
 
-    apparent_elevation = solpos['apparent_elevation']
-    pressure = pvlib.atmosphere.alt2pres(altitude)
-    dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
-    aod700 = [0.01, 0.1]
-    precipitable_water = [0.5, 5]
+    In [1]: solpos = pvlib.solarposition.get_solarposition(times, latitude, longitude)
 
-    fig, axes = plt.subplots(ncols=2, nrows=2, sharex=True, sharey=True, squeeze=True)
-    axes = axes.flatten()
+    In [1]: apparent_elevation = solpos['apparent_elevation']
 
-    [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)]
+    In [1]: pressure = pvlib.atmosphere.alt2pres(altitude)
+
+    In [1]: dni_extra = pvlib.irradiance.extraradiation(apparent_elevation.index.dayofyear)
+
+    In [1]: aod700 = [0.01, 0.1]
+
+    In [1]: precipitable_water = [0.5, 5]
+
+    In [1]: fig, axes = plt.subplots(ncols=2, nrows=2, sharex=True, sharey=True, squeeze=True)
+
+    In [1]: axes = axes.flatten()
+
+    In [1]: [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)]
 
     @savefig solis-grid.png width=10in
-    plt.show();
+    In [1]: plt.show();
 
 Contour plots of irradiance as a function of both PW and AOD.
 
 .. ipython::
 
-    aod700 = np.linspace(0, 0.5, 101)
-    precipitable_water = np.linspace(0, 10, 101)
-    apparent_elevation = 70
-    pressure = 101325
-    dni_extra = 1364
+    In [1]: aod700 = np.linspace(0, 0.5, 101)
 
-    aod700, precipitable_water = np.meshgrid(aod700, precipitable_water)
+    In [1]: precipitable_water = np.linspace(0, 10, 101)
+
+    In [1]: apparent_elevation = 70
+
+    In [1]: pressure = 101325
+
+    In [1]: dni_extra = 1364
+
+    In [1]: aod700, precipitable_water = np.meshgrid(aod700, precipitable_water)
 
     # inputs are arrays, so solis is an OrderedDict
-    solis = clearsky.simplified_solis(apparent_elevation, aod700,
-                                      precipitable_water, pressure,
-                                      dni_extra)
-    cmap = plt.get_cmap('viridis')
-    n = 15
-    vmin = None
-    vmax = None
+    In [1]: solis = clearsky.simplified_solis(apparent_elevation, aod700,
+       ...:                                   precipitable_water, pressure,
+       ...:                                   dni_extra)
 
-    def plot_solis(key):
-        irrad = solis[key]
-        fig, ax = plt.subplots()
-        im = ax.contour(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
-        imf = ax.contourf(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
-        ax.set_xlabel('AOD')
-        ax.set_ylabel('Precipitable water (cm)')
-        ax.clabel(im, colors='k', fmt='%.0f')
-        fig.colorbar(imf, label='{} (W/m**2)'.format(key))
-        ax.set_title('{}, elevation={}'.format(key, apparent_elevation))
+    In [1]: cmap = plt.get_cmap('viridis')
+
+    In [1]: n = 15
+
+    In [1]: vmin = None
+
+    In [1]: vmax = None
+
+    In [1]: def plot_solis(key):
+       ...:     irrad = solis[key]
+       ...:     fig, ax = plt.subplots()
+       ...:     im = ax.contour(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
+       ...:     imf = ax.contourf(aod700, precipitable_water, irrad[:, :], n, cmap=cmap, vmin=vmin, vmax=vmax)
+       ...:     ax.set_xlabel('AOD')
+       ...:     ax.set_ylabel('Precipitable water (cm)')
+       ...:     ax.clabel(im, colors='k', fmt='%.0f')
+       ...:     fig.colorbar(imf, label='{} (W/m**2)'.format(key))
+       ...:     ax.set_title('{}, elevation={}'.format(key, apparent_elevation))
 
 .. ipython::
 
-    plot_solis('ghi')
+    In [1]: plot_solis('ghi')
+
     @savefig solis-ghi.png width=10in
-    plt.show()
+    In [1]: plt.show()
 
-    plot_solis('dni')
+    In [1]: plot_solis('dni')
+
     @savefig solis-dni.png width=10in
-    plt.show()
+    In [1]: plt.show()
 
-    plot_solis('dhi')
+    In [1]: plot_solis('dhi')
+
     @savefig solis-dhi.png width=10in
-    plt.show()
+    In [1]: plt.show()
 
 
 Validation

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,9 +136,9 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
-    In [1]: mat
-
     In [1]: mat['LinkeTurbidity']
+
+    In [1]: mat['LinkeTurbidity'] / 20.
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,6 +136,8 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
+.. code-block:: python
+
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
 
@@ -181,38 +183,31 @@ Southwest U.S. with and without interpolation. We chose points that are
 relatively close so that you can get a better sense of the spatial
 variability of the data set.
 
-.. code-block:: python
+.. ipython::
 
     In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
 
+    In [1]: sites = [(32, -111, 'Tucson1'), (32.2, -110.9, 'Tucson2'),
+       ...:          (33.5, -112.1, 'Phoenix'), (35.1, -106.6, 'Albuquerque')]
+
     In [1]: plt.figure();
 
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32, -111, interp_turbidity=False).plot(label='Tucson1');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9, interp_turbidity=False).plot(label='Tucson2');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1, interp_turbidity=False).plot(label='Phoenix');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6, interp_turbidity=False).plot(label='Albuquerque');
+    In [1]: for lat, lon, name in sites:
+       ...:     turbidity = pvlib.clearsky.lookup_linke_turbidity(times, lat, lon, interp_turbidity=False)
+       ...:     turbidity.plot(label=name)
 
     In [1]: plt.legend();
 
     @savefig turbidity-no-interp.png width=6in
     In [1]: plt.ylabel('Linke Turbidity');
 
-.. code-block:: python
-
-    In [1]: times = pd.DatetimeIndex(start='2015-01-01', end='2016-01-01', freq='1D')
+.. ipython::
 
     In [1]: plt.figure();
 
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32, -111).plot(label='Tucson1');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 32.2, -110.9).plot(label='Tucson2');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 33.5, -112.1).plot(label='Phoenix');
-
-    In [1]: pvlib.clearsky.lookup_linke_turbidity(times, 35.1, -106.6).plot(label='Albuquerque');
+    In [1]: for lat, lon, name in sites:
+       ...:     turbidity = pvlib.clearsky.lookup_linke_turbidity(times, lat, lon)
+       ...:     turbidity.plot(label=name)
 
     In [1]: plt.legend();
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,6 +138,8 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
+    In [1]: np.array([[1,2],[3,4]], dtype=np.uint8).astype('float')
+
 .. code-block:: python
 
     In [1]: mat['LinkeTurbidity'].astype('float')

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -59,10 +59,10 @@ while the atmospheric attenuation inputs may be constants or arrays.
 
 .. ipython::
 
-    tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
+    In [1]: tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    In [1]: times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
                              freq='1min', tz=tus.tz)
-    cs = tus.get_clearsky(times)  # ineichen with climatology table by default
+    In [1]: cs = tus.get_clearsky(times)  # ineichen with climatology table by default
     cs.plot()
     plt.ylabel('Irradiance $W/m^2$');
     @savefig location-basic.png width=6in

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,16 +136,14 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
+.. code-block:: python
+
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
 
     In [1]: month = 1
 
-.. code-block:: python
-
     In [1]: linke_turbidity_table
-
-.. code-block:: python
 
     In [1]: plt.figure();
 
@@ -157,7 +155,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: plt.tight_layout();
 
-    @savefig turbidity-jan.png width=10in
+    @savefig turbidity-1.png width=10in
     In [1]: plt.show();
 
 .. code-block:: python

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,7 +138,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: np.array([[1,2],[3,4]], dtype=np.uint8).astype('float')
+    In [1]: np.array([[[1,2],[3,4]],[[5,6],[7,8]]], dtype=np.uint8).astype('float')
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -70,11 +70,11 @@ functions that do the computation.
 Ineichen
 --------
 
-The Ineichen and Perez (2002) model has proven to be a popular model.
-The model parameterizes irradiance in terms of the Linke turbidity.
+The Ineichen and Perez (2002) clear sky model parameterizes irradiance
+in terms of the Linke turbidity.
 
-Turbidity
-^^^^^^^^^
+Turbidity data
+^^^^^^^^^^^^^^
 
 pvlib includes a file with monthly climatological turbidity values for
 the globe. The code below creates turbidity maps for a few months of
@@ -141,8 +141,12 @@ the variability of the data set.
     @savefig turbidity-yes-interp.png width=6in
     plt.ylabel('Linke Turbidity');
 
-Will Holmgren did some rough analysis comparing pvlib's ineichen model
-to `SoDa's McClear service
+
+Validation
+^^^^^^^^^^
+
+Will Holmgren compared pvlib's Ineichen model and climatological
+turbidity to `SoDa's McClear service
 <http://www.soda-pro.com/web-services/radiation/cams-mcclear>`_ in
 Arizona. Here are links to an
 `ipynb notebook
@@ -157,9 +161,27 @@ Simplified Solis
 The Simplified Solis model parameterizes irradiance in terms of
 precipitable water and aerosol optical depth.
 
+Aerosol and precipitable water data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are a number of sources for aerosol and precipitable water data
+of varying accuracy, global coverage, and temporal resolution.
 Ground based aerosol data can be obtained from
 `Aeronet <http://aeronet.gsfc.nasa.gov>`_. Precipitable water can be obtained
-from `ESRL <http://gpsmet.noaa.gov/cgi-bin/gnuplots/rti.cgi>`_.
+from `radiosondes <http://weather.uwyo.edu/upperair/sounding.html>`_,
+`ESRL GPS-MET <http://gpsmet.noaa.gov/cgi-bin/gnuplots/rti.cgi>`_, or
+derived from surface relative humidity using the
+:py:func:`pvlib.atmosphere.gueymard94_pw` function.
+Numerous gridded products from satellites, weather models, and climate models
+contain one or both of aerosols and precipitable water.
+
+Note that aerosol optical depth is a function of wavelength, so be sure
+that you understand the aerosol data that you're looking at. The
+Simplified Solis model requires AOD at 700 nm. Models exist to convert
+AOD between different wavelengths, as well as convert Linke turbidity to
+AOD.
+
+
 
 .. ipython:: python
 
@@ -265,6 +287,10 @@ from `ESRL <http://gpsmet.noaa.gov/cgi-bin/gnuplots/rti.cgi>`_.
     plot_solis('dhi')
     @savefig solis-dhi.png width=6in
     plt.show()
+
+
+Validation
+^^^^^^^^^^
 
 We encourage users to compare the pvlib implementation to Ineichen's
 `Excel tool <http://www.unige.ch/energie/fr/equipe/ineichen/solis-tool/>`_.

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -122,7 +122,7 @@ pvlib includes a file with monthly climatological turbidity values for
 the globe. The code below creates turbidity maps for a few months of
 the year. You could run it in a loop to create plots for all months.
 
-.. code-block:: python
+.. ipython::
 
     In [1]: import calendar
 
@@ -135,6 +135,8 @@ the year. You could run it in a loop to create plots for all months.
     In [1]: filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
 
     In [1]: mat = scipy.io.loadmat(filepath)
+
+.. code-block:: python
 
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,26 +136,16 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
-    In [1]: mat['LinkeTurbidity']
-
-    In [1]: np.array([[[1,2],[3,4]],[[5,6],[7,8]]], dtype=np.uint8).astype('float')
-
-.. code-block:: python
-
-    In [1]: mat['LinkeTurbidity'].astype('float')
-
     # data is in units of 20 x turbidity
-    In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
+    In [1]: linke_turbidity_table = mat['LinkeTurbidity']  # / 20.   # crashes on rtd
 
-    In [1]: month = 1
-
-    In [1]: linke_turbidity_table
+    In [1]: months = 1
 
     In [1]: plt.figure();
 
-    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=100);
 
-    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
+    In [1]: plt.title('Linke turbidity x 20, ' + calendar.month_name[month]);
 
     In [1]: plt.colorbar(shrink=0.5);
 
@@ -164,15 +154,13 @@ the year. You could run it in a loop to create plots for all months.
     @savefig turbidity-1.png width=10in
     In [1]: plt.show();
 
-.. code-block:: python
-
     In [1]: month = 7
 
     In [1]: plt.figure();
 
-    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
+    In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=100);
 
-    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
+    In [1]: plt.title('Linke turbidity x 20, ' + calendar.month_name[month]);
 
     In [1]: plt.colorbar(shrink=0.5);
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -28,18 +28,18 @@ We'll need these imports for the examples below.
 
 .. ipython::
 
-    import itertools
-    import matplotlib.pyplot as plt
-    import pandas as pd
+    In [1]: import itertools
+    In [1]: import matplotlib.pyplot as plt
+    In [1]: import pandas as pd
 
     # seaborn makes the plots look nicer
-    #import seaborn as sns
-    #sns.set_color_codes()
+    In [1]: import seaborn as sns
+    In [1]: sns.set_color_codes()
 
-    import pvlib
-    from pvlib import clearsky
-    from pvlib import atmosphere
-    from pvlib.location import Location
+    In [1]: import pvlib
+    In [1]: from pvlib import clearsky
+    In [1]: from pvlib import atmosphere
+    In [1]: from pvlib.location import Location
 
 
 .. _location:

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -286,7 +286,7 @@ Grid with a clear sky irradiance for a few turbidity values.
 
     In [1]: linke_turbidities = [linke_turbidity.mean(), 2, 4]
 
-    In [1]: fig, axes = plt.subplots(ncols=3, nrows=1, sharex=True, sharey=True, squeeze=True, figsize=(12, 6))
+    In [1]: fig, axes = plt.subplots(ncols=3, nrows=1, sharex=True, sharey=True, squeeze=True, figsize=(12, 4))
 
     In [1]: axes = axes.flatten()
 
@@ -294,7 +294,7 @@ Grid with a clear sky irradiance for a few turbidity values.
        ...:     ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
        ...:     ineichen.plot(ax=ax, title='Linke turbidity = {:0.1f}'.format(linke_turbidity));
 
-    In [1]: ax.legend(loc=1)
+    In [1]: ax.legend(loc=1);
 
     @savefig ineichen-grid.png width=10in
     In [1]: plt.show();
@@ -373,7 +373,7 @@ A clear sky time series using basic pvlib functions.
 
     # an input is a Series, so solis is a DataFrame
     In [1]: solis = clearsky.simplified_solis(apparent_elevation, aod700, precipitable_water,
-                                      pressure, dni_extra)
+       ...:                                   pressure, dni_extra)
 
     In [1]: ax = solis.plot();
 
@@ -439,7 +439,7 @@ Grid with a clear sky irradiance for a few PW and AOD values.
 
     In [1]: axes = axes.flatten()
 
-    In [1]: [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)]
+    In [1]: [clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra).plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw)) for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes)];
 
     @savefig solis-grid.png width=10in
     In [1]: plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -149,9 +149,9 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
 
-    In [1]: plt.colorbar(shrink=0.5);
+    #In [1]: plt.colorbar(shrink=0.5);
 
-    In [1]: plt.tight_layout();
+    #In [1]: plt.tight_layout();
 
     @savefig turbidity-1.png width=10in
     In [1]: plt.show();

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -29,6 +29,8 @@ We'll need these imports for the examples below.
 .. ipython:: python
 
     import itertools
+    import matplotlib
+    matplotlib.use('Agg')
     import pandas as pd
     import matplotlib.pyplot as plt
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,6 +138,8 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat
 
+    In [1]: mat['LinkeTurbidity']
+
 .. code-block:: python
 
     # data is in units of 20 x turbidity

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -29,17 +29,23 @@ We'll need these imports for the examples below.
 .. ipython::
 
     In [1]: import itertools
+
     In [1]: import matplotlib.pyplot as plt
+
     In [1]: import pandas as pd
 
     # seaborn makes the plots look nicer
     In [1]: import seaborn as sns
+
     In [1]: sns.set_color_codes()
 
-    In [1]: import pvlib
-    In [1]: from pvlib import clearsky
-    In [1]: from pvlib import atmosphere
-    In [1]: from pvlib.location import Location
+    In [2]: import pvlib
+
+    In [3]: import pvlib.clearsky as clearsky
+
+    In [4]: from pvlib import atmosphere
+
+    In [5]: from pvlib.location import Location
 
 
 .. _location:
@@ -59,14 +65,19 @@ while the atmospheric attenuation inputs may be constants or arrays.
 
 .. ipython::
 
-    In [1]: tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+    In [5]: tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
+
     In [1]: times = pd.DatetimeIndex(start='2016-07-01', end='2016-07-04',
                              freq='1min', tz=tus.tz)
+
     In [1]: cs = tus.get_clearsky(times)  # ineichen with climatology table by default
-    cs.plot()
-    plt.ylabel('Irradiance $W/m^2$');
+
+    In [1]: cs.plot()
+
+    In [1]: plt.ylabel('Irradiance $W/m^2$');
+
     @savefig location-basic.png width=6in
-    plt.title('Ineichen, climatological turbidity');
+    In [1]: plt.title('Ineichen, climatological turbidity');
 
 The :py:meth:`~pvlib.location.Location.get_clearsky` method accepts a
 model keyword argument and propagates additional arguments to the

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -29,15 +29,20 @@ We'll need these imports for the examples below.
 .. ipython:: python
 
     import itertools
+    print('pre mpl import')
     import matplotlib
+    print('pre use agg')
     matplotlib.use('Agg')
+    print('pre pandas')
     import pandas as pd
+    print('pre pyplot')
     import matplotlib.pyplot as plt
 
     # seaborn makes the plots look nicer
     import seaborn as sns
     sns.set_color_codes()
 
+    print('importing pvlib')
     import pvlib
     from pvlib import clearsky
     from pvlib import atmosphere

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,6 +136,8 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat = scipy.io.loadmat(filepath)
 
+    In [1]: mat
+
 .. code-block:: python
 
     # data is in units of 20 x turbidity

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -32,6 +32,8 @@ We'll need these imports for the examples below.
 
     In [1]: import matplotlib.pyplot as plt
 
+    In [1]: import numpy as np
+
     In [1]: import pandas as pd
 
     # seaborn makes the plots look nicer
@@ -138,7 +140,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: mat['LinkeTurbidity'] / 20.
+    In [1]: mat['LinkeTurbidity'].astype(np.float64) / 20.
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,7 +138,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: mat['LinkeTurbidity'].astype('int')
+    In [1]: mat['LinkeTurbidity'][:].astype('float')
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,7 +138,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: mat['LinkeTurbidity'].astype('float')
+    In [1]: mat['LinkeTurbidity'].astype('int')
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -32,8 +32,6 @@ We'll need these imports for the examples below.
 
     In [1]: import matplotlib.pyplot as plt
 
-    In [1]: import numpy as np
-
     In [1]: import pandas as pd
 
     # seaborn makes the plots look nicer
@@ -140,7 +138,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: mat['LinkeTurbidity'].astype(np.float64) / 20.
+    In [1]: mat['LinkeTurbidity'].astype('float')
 
 .. code-block:: python
 

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -139,21 +139,21 @@ the year. You could run it in a loop to create plots for all months.
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.
 
-    In [1]: linke_turbidity_table
-
     In [1]: month = 1
+
+    In [1]: linke_turbidity_table[:, :, month-1]
 
     In [1]: plt.figure();
 
     #In [1]: plt.imshow(linke_turbidity_table[:, :, month-1], vmin=1, vmax=5);
 
-    In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
+    #In [1]: plt.title('Linke turbidity, ' + calendar.month_name[month]);
 
     #In [1]: plt.colorbar(shrink=0.5);
 
     #In [1]: plt.tight_layout();
 
-    @savefig turbidity-1.png width=10in
+    @savefig turbidity-jan.png width=10in
     In [1]: plt.show();
 
 .. code-block:: python

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -27,6 +27,8 @@ clear sky algorithms and input data.
 We'll need these imports for the examples below.
 
 .. ipython:: python
+    :okexcept:
+    :okwarning:
 
     import itertools
     print('pre mpl import')

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -138,9 +138,9 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: mat['LinkeTurbidity']
 
-    In [1]: np.array(mat['LinkeTurbidity'], dtype='float')
-
 .. code-block:: python
+
+    In [1]: mat['LinkeTurbidity'].astype('float')
 
     # data is in units of 20 x turbidity
     In [1]: linke_turbidity_table = mat['LinkeTurbidity'] / 20.

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -31,20 +31,13 @@ We'll need these imports for the examples below.
     :okwarning:
 
     import itertools
-    print('pre mpl import')
-    import matplotlib
-    print('pre use agg')
-    matplotlib.use('Agg')
-    print('pre pandas')
-    import pandas as pd
-    print('pre pyplot')
     import matplotlib.pyplot as plt
+    import pandas as pd
 
     # seaborn makes the plots look nicer
-    import seaborn as sns
-    sns.set_color_codes()
+    #import seaborn as sns
+    #sns.set_color_codes()
 
-    print('importing pvlib')
     import pvlib
     from pvlib import clearsky
     from pvlib import atmosphere

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,6 +29,9 @@ class Mock(MagicMock):
 MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
+# builds the font cache if it does not already exist.
+import matplotlib.pyplot as plt
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,15 +29,6 @@ class Mock(MagicMock):
 MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
-ipython_mplbackend = 'Agg'
-
-# builds the font cache if it does not already exist.
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-
-print('mpl backend: ', matplotlib.get_backend())
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -36,7 +36,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-print(matplotlib.get_backend())
+print('mpl backend: ', matplotlib.get_backend())
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,6 +29,9 @@ class Mock(MagicMock):
 MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
+import pandas as pd
+pd.show_versions()
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -30,6 +30,8 @@ MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # builds the font cache if it does not already exist.
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -32,9 +32,11 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 ipython_mplbackend = 'Agg'
 
 # builds the font cache if it does not already exist.
-# import matplotlib
-# matplotlib.use('Agg')
-# import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+print(matplotlib.get_backend())
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,10 +29,12 @@ class Mock(MagicMock):
 MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
+ipython_mplbackend = None
+
 # builds the font cache if it does not already exist.
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+# import matplotlib
+# matplotlib.use('Agg')
+# import matplotlib.pyplot as plt
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
 MOCK_MODULES = []
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
-ipython_mplbackend = None
+ipython_mplbackend = 'Agg'
 
 # builds the font cache if it does not already exist.
 # import matplotlib

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -75,6 +75,7 @@ Contents
    installation
    contributing
    timetimezones
+   clearsky
    modules
    classes
    comparison_pvlib_matlab

--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -33,6 +33,7 @@ Documentation
 ~~~~~~~~~~~~~
 
 * Added new terms to the variables documentation. (:issue:`195`)
+* Added clear sky documentation page.
 * Fix documentation build warnings. (:issue:`210`)
 
 

--- a/docs/tutorials/irradiance.ipynb
+++ b/docs/tutorials/irradiance.ipynb
@@ -2371,21 +2371,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I wrote a new documentation page for pvlib's clear sky features. The page includes examples for Location.get_clearsky, clearsky.ineichen, and clearsky.simplified_solis. Many of the examples are from old issues and pull requests such as #148 #101. 

Unfortunately, I can't get readthedocs to build this new documentation (link to [failed build](https://readthedocs.org/projects/wholmgren-pvlib-python-new/builds/4179512/)). The build is fragile even on my own machine because line continuation mysteriously doesn't work in some of the .. ipython:: blocks. I've wasted enough time on it for now, so I'm just going to wait and hope that future updates to some combination of rtd/sphinx/ipython/matplotlib solve the problems. I'd appreciate any debugging help if you have experience in this area.

In the meantime, here's a link to the manually built documentation on my server:

https://forecasting.energy.arizona.edu/pvlib/pvlib-python/docs/sphinx/build/html/clearsky.html

Let me know if you have edits and suggestions for how to improve it. 