### PR TITLE
refactor sapm to be consistent with matlab

### DIFF
--- a/docs/sphinx/source/package_overview.rst
+++ b/docs/sphinx/source/package_overview.rst
@@ -104,9 +104,10 @@ to accomplish our system modeling goal:
                                                    model='haydavies')
         temps = pvlib.pvsystem.sapm_celltemp(total_irrad['poa_global'],
                                              wind_speed, temp_air)
-        dc = pvlib.pvsystem.sapm(module, total_irrad['poa_direct'],
-                                 total_irrad['poa_diffuse'], temps['temp_cell'],
-                                 am_abs, aoi)
+        effective_irradiance = pvlib.pvsystem.sapm_effective_irradiance(
+            module, total_irrad['poa_direct'], total_irrad['poa_diffuse'],
+            am_abs, aoi)
+        dc = pvlib.pvsystem.sapm(module, effective_irradiance, temps['temp_cell'])
         ac = pvlib.pvsystem.snlinverter(inverter, dc['v_mp'], dc['p_mp'])
         annual_energy = ac.sum()
         energies[name] = annual_energy
@@ -240,11 +241,10 @@ object to accomplish our modeling goal:
         aoi = localized_system.get_aoi(solar_position['apparent_zenith'],
                                        solar_position['azimuth'])
         airmass = localized_system.get_airmass(solar_position=solar_position)
-        dc = localized_system.sapm(total_irrad['poa_direct'],
-                                   total_irrad['poa_diffuse'],
-                                   temps['temp_cell'],
-                                   airmass['airmass_absolute'],
-                                   aoi)
+        effective_irradiance = localized_system.sapm_effective_irradiance(
+            total_irrad['poa_direct'], total_irrad['poa_diffuse'],
+            airmass['airmass_absolute'], aoi)
+        dc = localized_system.sapm(effective_irradiance, temps['temp_cell'])
         ac = localized_system.snlinverter(dc['v_mp'], dc['p_mp'])
         annual_energy = ac.sum()
         energies[name] = annual_energy

--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -18,6 +18,11 @@ API Changes
   in addition to arrays and Series. Furthermore, these functions no
   longer promote scalar or array input to Series output.
   Also applies to atmosphere.relativeairmass. (:issue:`201`, :issue:`214`)
+* Updated to pvsystem.sapm to be consistent with the PVLIB MATLAB API.
+  pvsystem.sapm now takes an effective irradiance argument instead of
+  POA irradiances, airmass, and AOI. Implements closely related
+  sapm_spectral_loss, sapm_aoi_loss, and sapm_effective_irradiance
+  functions, as well as PVSystem methods. (:issue:`198`, :issue:`205`)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -3,9 +3,10 @@
 v0.4.0 (July xx, 2016)
 -----------------------
 
-This is a major release from 0.3.3.
-We recommend that all users upgrade to this version after reviewing
-the API changes.
+This is a major release from 0.3.3. We recommend that all users upgrade
+to this version after reviewing the API Changes. Please see the Bug
+Fixes for changes that will result in slightly different modeling
+results.
 
 
 API Changes
@@ -22,7 +23,8 @@ API Changes
   pvsystem.sapm now takes an effective irradiance argument instead of
   POA irradiances, airmass, and AOI. Implements closely related
   sapm_spectral_loss, sapm_aoi_loss, and sapm_effective_irradiance
-  functions, as well as PVSystem methods. (:issue:`198`, :issue:`205`)
+  functions, as well as PVSystem methods.
+  (:issue:`198`, :issue:`205`, :issue:`218`)
 
 
 Enhancements
@@ -48,6 +50,10 @@ Bug fixes
   by less than 1 part in 1000. (:issue:`211`)
 * irradiance.extraradiation now raises a ValueError for invalid method
   input. It previously failed silently. (:issue:`215`)
+* The sapm_aoi_loss function (previously internal to sapm) now clips the
+  output to be between 0 and 1. Previous output could be up to ~1% larger
+  than 1 for AOI of ~30 degrees. Therefore, power calculations with the
+  SAPM model chain will also change. (:issue:`218`)
 
 
 Documentation

--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -23,7 +23,9 @@ API Changes
   pvsystem.sapm now takes an effective irradiance argument instead of
   POA irradiances, airmass, and AOI. Implements closely related
   sapm_spectral_loss, sapm_aoi_loss, and sapm_effective_irradiance
-  functions, as well as PVSystem methods.
+  functions, as well as PVSystem methods. The sapm_aoi_loss function
+  includes an optional argument to apply an upper limit to the output
+  (output can be ~1% larger than 1 for AOI of ~30 degrees).
   (:issue:`198`, :issue:`205`, :issue:`218`)
 
 
@@ -50,10 +52,6 @@ Bug fixes
   by less than 1 part in 1000. (:issue:`211`)
 * irradiance.extraradiation now raises a ValueError for invalid method
   input. It previously failed silently. (:issue:`215`)
-* The sapm_aoi_loss function (previously internal to sapm) now clips the
-  output to be between 0 and 1. Previous output could be up to ~1% larger
-  than 1 for AOI of ~30 degrees. Therefore, power calculations with the
-  SAPM model chain will also change. (:issue:`218`)
 
 
 Documentation

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1413,7 +1413,7 @@ def sapm_spectral_loss(module, airmass_absolute):
     return spectral_loss
 
 
-def sapm_aoi_loss(module, aoi):
+def sapm_aoi_loss(module, aoi, upper=None):
     """
     Calculates the SAPM angle of incidence loss coefficient, F2.
 
@@ -1428,17 +1428,41 @@ def sapm_aoi_loss(module, aoi):
         Angle of incidence in degrees. Negative input angles will return
         nan values.
 
+    upper : None or float
+        Upper limit on the results.
+
     Returns
     -------
     F2 : numeric
         The SAPM angle of incidence loss coefficient.
+
+    Notes
+    -----
+    The SAPM traditionally does not define an upper limit on the AOI
+    loss function and values slightly exceeding 1 may exist for moderate
+    angles of incidence (15-40 degrees). However, users may consider
+    imposing an upper limit of 1.
+
+    References
+    ----------
+    [1] King, D. et al, 2004, "Sandia Photovoltaic Array Performance
+    Model", SAND Report 3535, Sandia National Laboratories, Albuquerque,
+    NM.
+
+    [2] B.H. King et al, "Procedure to Determine Coefficients for the
+    Sandia Array Performance Model (SAPM)," SAND2016-5284, Sandia
+    National Laboratories (2016).
+
+    [3] B.H. King et al, "Recent Advancements in Outdoor Measurement
+    Techniques for Angle of Incidence Effects," 42nd IEEE PVSC (2015).
+    DOI: 10.1109/PVSC.2015.7355849
     """
 
     aoi_coeff = [module['B5'], module['B4'], module['B3'], module['B2'],
                  module['B1'], module['B0']]
 
     aoi_loss = np.polyval(aoi_coeff, aoi)
-    aoi_loss = np.clip(aoi_loss, 0, 1)
+    aoi_loss = np.clip(aoi_loss, 0, upper)
     aoi_loss = np.where(aoi < 0, np.nan, aoi_loss)
 
     if isinstance(aoi, pd.Series):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1384,7 +1384,8 @@ def sapm_spectral_loss(module, airmass_absolute):
     ----------
     module : dict-like
         A dict, Series, or DataFrame defining the SAPM performance
-        parameters. See the :py:func:`sapm` notes section for more details.
+        parameters. See the :py:func:`sapm` notes section for more
+        details.
 
     airmass_absolute : numeric
         Absolute airmass
@@ -1420,10 +1421,12 @@ def sapm_aoi_loss(module, aoi):
     ----------
     module : dict-like
         A dict, Series, or DataFrame defining the SAPM performance
-        parameters. See the :py:func:`sapm` notes section for more details.
+        parameters. See the :py:func:`sapm` notes section for more
+        details.
 
     aoi : numeric
-        Angle of incidence in degrees.
+        Angle of incidence in degrees. Negative input angles will return
+        nan values.
 
     Returns
     -------
@@ -1436,6 +1439,7 @@ def sapm_aoi_loss(module, aoi):
 
     aoi_loss = np.polyval(aoi_coeff, aoi)
     aoi_loss = np.clip(aoi_loss, 0, 1)
+    aoi_loss = np.where(aoi < 0, np.nan, aoi_loss)
 
     if isinstance(aoi, pd.Series):
         aoi_loss = pd.Series(aoi_loss, aoi.index)
@@ -1447,14 +1451,15 @@ def sapm_effective_irradiance(module, poa_direct, poa_diffuse,
                               airmass_absolute, aoi,
                               reference_irradiance=1000):
     """
-    Calculates the SAPM effective irradiance using the SAPM
-    spectral loss and SAPM angle of incidence loss functions.
+    Calculates the SAPM effective irradiance using the SAPM spectral
+    loss and SAPM angle of incidence loss functions.
 
     Parameters
     ----------
     module : dict-like
         A dict, Series, or DataFrame defining the SAPM performance
-        parameters. See the :py:func:`sapm` notes section for more details.
+        parameters. See the :py:func:`sapm` notes section for more
+        details.
 
     poa_direct : numeric
         The direct irradiance incident upon the module.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1393,12 +1393,18 @@ def sapm_spectral_loss(module, airmass_absolute):
     -------
     F1 : numeric
         The SAPM spectral loss coefficient.
+
+    Notes
+    -----
+    nan airmass values will result in 0 output.
     """
 
     am_coeff = [module['A4'], module['A3'], module['A2'], module['A1'],
                 module['A0']]
 
     spectral_loss = np.maximum(0, np.polyval(am_coeff, airmass_absolute))
+
+    spectral_loss = np.where(np.isnan(spectral_loss), 0, spectral_loss)
 
     if isinstance(airmass_absolute, pd.Series):
         spectral_loss = pd.Series(spectral_loss, airmass_absolute.index)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -288,8 +288,7 @@ class PVSystem(object):
                                  self.module_parameters['EgRef'],
                                  self.module_parameters['dEgdT'], **kwargs)
 
-    def sapm(self, poa_direct, poa_diffuse,
-             temp_cell, airmass_absolute, aoi, **kwargs):
+    def sapm(self, effective_irradiance, temp_cell, **kwargs):
         """
         Use the :py:func:`sapm` function, the input parameters,
         and ``self.module_parameters`` to calculate
@@ -319,10 +318,8 @@ class PVSystem(object):
         -------
         See pvsystem.sapm for details
         """
-        return sapm(self.module_parameters, poa_direct, poa_diffuse,
-                    temp_cell, airmass_absolute, aoi)
+        return sapm(self.module_parameters, effective_irradiance, temp_cell)
 
-    # model now specified by self.racking_model
     def sapm_celltemp(self, irrad, wind, temp):
         """Uses :py:func:`sapm_celltemp` to calculate module and cell
         temperatures based on ``self.racking_model`` and
@@ -337,6 +334,75 @@ class PVSystem(object):
         See pvsystem.sapm_celltemp for details
         """
         return sapm_celltemp(irrad, wind, temp, self.racking_model)
+
+    def sapm_spectral_loss(self, airmass_absolute):
+        """
+        Use the :py:func:`sapm_spectral_loss` function, the input
+        parameters, and ``self.module_parameters`` to calculate F1.
+
+        Parameters
+        ----------
+        airmass_absolute : numeric
+            Absolute airmass.
+
+        Returns
+        -------
+        F1 : numeric
+            The SAPM spectral loss coefficient.
+        """
+        return sapm_spectral_loss(self.module_parameters, airmass_absolute)
+
+    def sapm_aoi_loss(self, aoi):
+        """
+        Use the :py:func:`sapm_aoi_loss` function, the input parameters,
+        and ``self.module_parameters`` to calculate F2.
+
+        Parameters
+        ----------
+        aoi : numeric
+            Angle of incidence in degrees.
+
+        Returns
+        -------
+        F2 : numeric
+            The SAPM angle of incidence loss coefficient.
+        """
+        return sapm_aoi_loss(self.module_parameters, aoi)
+
+    def sapm_effective_irradiance(self, poa_direct, poa_diffuse,
+                                  airmass_absolute, aoi,
+                                  reference_irradiance=1000):
+        """
+        Use the :py:func:`sapm_effective_irradiance` function, the input
+        parameters, and ``self.module_parameters`` to calculate
+        effective irradiance.
+
+        Parameters
+        ----------
+        poa_direct : numeric
+            The direct irradiance incident upon the module.
+
+        poa_diffuse : numeric
+            The diffuse irradiance incident on module.
+
+        airmass_absolute : numeric
+            Absolute airmass.
+
+        aoi : numeric
+            Angle of incidence in degrees.
+
+        reference_irradiance : numeric
+            Reference irradiance by which to divide the input irradiance.
+
+        Returns
+        -------
+        effective_irradiance : numeric
+            The SAPM effective irradiance.
+        """
+        return sapm_effective_irradiance(self.module_parameters,
+                                         poa_direct, poa_diffuse,
+                                         airmass_absolute, aoi,
+                                         reference_irradiance)
 
     def singlediode(self, photocurrent, saturation_current,
                     resistance_series, resistance_shunt, nNsVth):
@@ -1084,7 +1150,7 @@ def _parse_raw_sam_df(csvdata):
     return df
 
 
-def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
+def sapm(module, effective_irradiance, temp_cell):
     '''
     The Sandia PV Array Performance Model (SAPM) generates 5 points on a
     PV module's I-V curve (Voc, Isc, Ix, Ixx, Vmp/Imp) according to
@@ -1092,24 +1158,15 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
 
     Parameters
     ----------
-    module : Series or dict
-        A DataFrame defining the SAPM performance parameters. See the
-        notes section for more details.
+    module : dict-like
+        A dict, Series, or DataFrame defining the SAPM performance
+        parameters. See the notes section for more details.
 
-    poa_direct : Series
-        The direct irradiance incident upon the module (W/m^2).
+    effective_irradiance : numeric
+        Effective irradiance (suns).
 
-    poa_diffuse : Series
-        The diffuse irradiance incident on module.
-
-    temp_cell : Series
+    temp_cell : numeric
         The cell temperature (degrees C).
-
-    airmass_absolute : Series
-        Absolute airmass.
-
-    aoi : Series
-        Angle of incidence (degrees).
 
     Returns
     -------
@@ -1124,7 +1181,6 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
           curve for modeling curve shape
         * i_xx : Current at module V = 0.5(Voc+Vmp), defines 5th point on
           I-V curve for modeling curve shape
-        * effective_irradiance : Effective irradiance
 
     Notes
     -----
@@ -1184,60 +1240,44 @@ def sapm(module, poa_direct, poa_diffuse, temp_cell, airmass_absolute, aoi):
     kb = 1.38066e-23  # Boltzmann's constant in units of J/K
     E0 = 1000
 
-    am_coeff = [module['A4'], module['A3'], module['A2'], module['A1'],
-                module['A0']]
-    aoi_coeff = [module['B5'], module['B4'], module['B3'], module['B2'],
-                 module['B1'], module['B0']]
-
-    F1 = np.polyval(am_coeff, airmass_absolute)
-    F2 = np.polyval(aoi_coeff, aoi)
-
-    # Ee is the "effective irradiance"
-    Ee = F1 * ((poa_direct*F2 + module['FD']*poa_diffuse) / E0)
-    Ee.fillna(0, inplace=True)
-    Ee = Ee.clip_lower(0)
-
     Bvmpo = module['Bvmpo'] + module['Mbvmp']*(1 - Ee)
     Bvoco = module['Bvoco'] + module['Mbvoc']*(1 - Ee)
     delta = module['N'] * kb * (temp_cell + 273.15) / q
 
-    dfout = pd.DataFrame(index=Ee.index)
+    out = OrderedDict()
 
-    dfout['i_sc'] = (
-        module['Isco'] * Ee * (1 + module['Aisc']*(temp_cell - T0))
-                    )
+    out['i_sc'] = (
+        module['Isco'] * Ee * (1 + module['Aisc']*(temp_cell - T0)))
 
-    dfout['i_mp'] = (
+    out['i_mp'] = (
         module['Impo'] * (module['C0']*Ee + module['C1']*(Ee**2)) *
-        (1 + module['Aimp']*(temp_cell - T0))
-                     )
+        (1 + module['Aimp']*(temp_cell - T0)))
 
-    dfout['v_oc'] = (
+    out['v_oc'] = np.maximum(0, (
         module['Voco'] + module['Cells_in_Series']*delta*np.log(Ee) +
-        Bvoco*(temp_cell - T0)
-                     ).clip_lower(0)
+        Bvoco*(temp_cell - T0)))
 
-    dfout['v_mp'] = (
+    out['v_mp'] = np.maximum(0, (
         module['Vmpo'] +
         module['C2']*module['Cells_in_Series']*delta*np.log(Ee) +
         module['C3']*module['Cells_in_Series']*((delta*np.log(Ee)) ** 2) +
-        Bvmpo*(temp_cell - T0)
-                     ).clip_lower(0)
+        Bvmpo*(temp_cell - T0)))
 
-    dfout['p_mp'] = dfout['i_mp'] * dfout['v_mp']
+    out['p_mp'] = dfout['i_mp'] * dfout['v_mp']
 
-    dfout['i_x'] = (module['IXO'] *
-                    (module['C4']*Ee + module['C5']*(Ee**2)) *
-                    (1 + module['Aisc']*(temp_cell - T0)))
+    out['i_x'] = (
+        module['IXO'] * (module['C4']*Ee + module['C5']*(Ee**2)) *
+        (1 + module['Aisc']*(temp_cell - T0)))
 
     # the Ixx calculation in King 2004 has a typo (mixes up Aisc and Aimp)
-    dfout['i_xx'] = (module['IXXO'] *
-                     (module['C6']*Ee + module['C7']*(Ee**2)) *
-                     (1 + module['Aisc']*(temp_cell - T0)))
+    out['i_xx'] = (
+        module['IXXO'] * (module['C6']*Ee + module['C7']*(Ee**2)) *
+        (1 + module['Aisc']*(temp_cell - T0)))
 
-    dfout['effective_irradiance'] = Ee
+    if isinstance(out['i_sc'], pd.Series):
+        out = pd.DataFrame(out)
 
-    return dfout
+    return out
 
 
 def sapm_celltemp(poa_global, wind_speed, temp_air,
@@ -1331,6 +1371,104 @@ def sapm_celltemp(poa_global, wind_speed, temp_air,
     temp_cell = temp_module + (poa_global / E0)*(deltaT)
 
     return pd.DataFrame({'temp_cell': temp_cell, 'temp_module': temp_module})
+
+
+def sapm_spectral_loss(module, airmass_absolute):
+    """
+    Calculates the SAPM spectral loss coefficient, F1.
+
+    Parameters
+    ----------
+    module : dict-like
+        A dict, Series, or DataFrame defining the SAPM performance
+        parameters. See the :py:func:`sapm` notes section for more details.
+
+    airmass_absolute : numeric
+        Absolute airmass
+
+    Returns
+    -------
+    F1 : numeric
+        The SAPM spectral loss coefficient.
+    """
+
+    am_coeff = [module['A4'], module['A3'], module['A2'], module['A1'],
+                module['A0']]
+
+    spectral_loss = np.maximum(0, np.polyval(am_coeff, airmass_absolute))
+
+    return spectral_loss
+
+
+def sapm_aoi_loss(module, aoi):
+    """
+    Calculates the SAPM angle of incidence loss coefficient, F2.
+
+    Parameters
+    ----------
+    module : dict-like
+        A dict, Series, or DataFrame defining the SAPM performance
+        parameters. See the :py:func:`sapm` notes section for more details.
+
+    aoi : numeric
+        Angle of incidence in degrees.
+
+    Returns
+    -------
+    F2 : numeric
+        The SAPM angle of incidence loss coefficient.
+    """
+
+    aoi_coeff = [module['B5'], module['B4'], module['B3'], module['B2'],
+                 module['B1'], module['B0']]
+
+    aoi_loss = np.maximum(0, np.polyval(aoi_coeff, aoi))
+
+    return aoi_loss
+
+
+def sapm_effective_irradiance(module, poa_direct, poa_diffuse,
+                              airmass_absolute, aoi,
+                              reference_irradiance=1000):
+    """
+    Calculates the SAPM effective irradiance using the SAPM
+    spectral loss and SAPM angle of incidence loss functions.
+
+    Parameters
+    ----------
+    module : dict-like
+        A dict, Series, or DataFrame defining the SAPM performance
+        parameters. See the :py:func:`sapm` notes section for more details.
+
+    poa_direct : numeric
+        The direct irradiance incident upon the module.
+
+    poa_diffuse : numeric
+        The diffuse irradiance incident on module.
+
+    airmass_absolute : numeric
+        Absolute airmass.
+
+    aoi : numeric
+        Angle of incidence in degrees.
+
+    reference_irradiance : numeric
+        Reference irradiance by which to divide the input irradiance.
+
+    Returns
+    -------
+    effective_irradiance : numeric
+        The SAPM effective irradiance.
+    """
+
+    F1 = sapm_spectral_loss(module, airmass_absolute)
+    F2 = sapm_aoi_loss(module, aoi)
+
+    E0 = reference_irradiance
+
+    Ee = F1 * (poa_direct*F2 + module['FD']*poa_diffuse) / E0
+
+    return aoi_loss
 
 
 def singlediode(photocurrent, saturation_current, resistance_series,

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1434,7 +1434,8 @@ def sapm_aoi_loss(module, aoi):
     aoi_coeff = [module['B5'], module['B4'], module['B3'], module['B2'],
                  module['B1'], module['B0']]
 
-    aoi_loss = np.maximum(0, np.polyval(aoi_coeff, aoi))
+    aoi_loss = np.polyval(aoi_coeff, aoi)
+    aoi_loss = np.clip(aoi_loss, 0, 1)
 
     if isinstance(aoi, pd.Series):
         aoi_loss = pd.Series(aoi_loss, aoi.index)

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -65,7 +65,7 @@ def test_run_model(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     ac = mc.run_model(times).ac
 
-    expected = pd.Series(np.array([180.865917827,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  1.82033564e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -77,7 +77,7 @@ def test_run_model_with_irradiance(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([188.973621919,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  1.90054749e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -89,7 +89,7 @@ def test_run_model_perez(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([189.113386374,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  190.194545796,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -102,7 +102,7 @@ def test_run_model_gueymard_perez(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([189.11359739,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  190.194760203,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -114,7 +114,7 @@ def test_run_model_with_weather(system, location):
     weather = pd.DataFrame({'wind_speed':5, 'temp_air':10}, index=times)
     ac = mc.run_model(times, weather=weather).ac
 
-    expected = pd.Series(np.array([198.675352078,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  1.99952400e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -127,7 +127,7 @@ def test_run_model_tracker(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     ac = mc.run_model(times).ac
 
-    expected = pd.Series(np.array([120.623924959,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  121.421719,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -202,7 +202,7 @@ def test_basic_chain_strategy(sam_data):
                                     orientation_strategy='south_at_latitude_tilt',
                                     altitude=altitude)
 
-    expected = pd.Series(np.array([180.865917827,  -2.00000000e-02]),
+    expected = pd.Series(np.array([  1.82033563543e+02,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -65,7 +65,7 @@ def test_run_model(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     ac = mc.run_model(times).ac
 
-    expected = pd.Series(np.array([  1.82033564e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([180.865917827,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -77,7 +77,7 @@ def test_run_model_with_irradiance(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([  1.90054749e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([188.973621919,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -89,7 +89,7 @@ def test_run_model_perez(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([  190.194545796,  -2.00000000e-02]),
+    expected = pd.Series(np.array([189.113386374,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -102,7 +102,7 @@ def test_run_model_gueymard_perez(system, location):
                               index=times)
     ac = mc.run_model(times, irradiance=irradiance).ac
 
-    expected = pd.Series(np.array([  190.194760203,  -2.00000000e-02]),
+    expected = pd.Series(np.array([189.11359739,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
@@ -114,7 +114,7 @@ def test_run_model_with_weather(system, location):
     weather = pd.DataFrame({'wind_speed':5, 'temp_air':10}, index=times)
     ac = mc.run_model(times, weather=weather).ac
 
-    expected = pd.Series(np.array([  1.99952400e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([198.675352078,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -127,7 +127,7 @@ def test_run_model_tracker(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     ac = mc.run_model(times).ac
 
-    expected = pd.Series(np.array([  121.421719,  -2.00000000e-02]),
+    expected = pd.Series(np.array([120.623924959,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
@@ -202,7 +202,7 @@ def test_basic_chain_strategy(sam_data):
                                     orientation_strategy='south_at_latitude_tilt',
                                     altitude=altitude)
 
-    expected = pd.Series(np.array([  1.82033563543e+02,  -2.00000000e-02]),
+    expected = pd.Series(np.array([180.865917827,  -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -203,7 +203,7 @@ def test_PVSystem_sapm(sapm_module_params):
 
 @pytest.mark.parametrize('airmass,expected', [
     (1.5, 1.00028714375),
-    (np.array([[10, np.nan]]), np.array([[0.999535, np.nan]])),
+    (np.array([[10, np.nan]]), np.array([[0.999535, 0]])),
     (pd.Series([5]), pd.Series([1.0387675]))
 ])
 def test_sapm_spectral_loss(sapm_module_params, airmass, expected):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -193,6 +193,18 @@ def test_PVSystem_sapm(sam_data):
     assert_frame_equal(sapm, expected)
 
 
+def test_sapm_spectral_loss(sam_data):
+    assert False
+
+
+def test_sapm_aoi_loss(sam_data):
+    assert False
+
+
+def test_sapm_effective_irradiance(sam_data):
+    assert False
+
+
 def test_calcparams_desoto(sam_data):
     module = 'Example_Module'
     module_parameters = sam_data['cecmod'][module]

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -240,6 +240,14 @@ def test_sapm_aoi_loss(sapm_module_params, aoi, expected):
         assert_allclose(out, expected, atol=1e-4)
 
 
+def test_sapm_aoi_loss_limits():
+    module_parameters = {'B0': 5, 'B1': 0, 'B2': 0, 'B3': 0, 'B4': 0, 'B5': 0}
+    assert pvsystem.sapm_aoi_loss(module_parameters, 1) == 1
+
+    module_parameters = {'B0': -5, 'B1': 0, 'B2': 0, 'B3': 0, 'B4': 0, 'B5': 0}
+    assert pvsystem.sapm_aoi_loss(module_parameters, 1) == 0
+
+
 def test_PVSystem_sapm_aoi_loss(sapm_module_params):
     system = pvsystem.PVSystem(module_parameters=sapm_module_params)
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import datetime
+from collections import OrderedDict
 
 import numpy as np
 from numpy import nan
@@ -139,70 +140,149 @@ def sam_data():
     return data
 
 
-def test_sapm(sam_data):
-    modules = sam_data['sandiamod']
-    module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
-    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
-    irrad_data = pd.DataFrame({'dni':[0,1000], 'ghi':[0,600], 'dhi':[0,100]},
-                              index=times)
-    am = pd.Series([0, 2.25], index=times)
-    aoi = pd.Series([180, 30], index=times)
-
-    sapm = pvsystem.sapm(module_parameters, irrad_data['dni'],
-                         irrad_data['dhi'], 25, am, aoi)
-
-    expected = pd.DataFrame(np.array(
-    [[   0.        ,    0.        ,    0.        ,    0.        ,
-           0.        ,    0.        ,    0.        ,    0.        ],
-       [   5.74526799,    5.12194115,   59.67914031,   48.41924255,
-         248.00051089,    5.61787615,    3.52581308,    1.12848138]]),
-        columns=['i_sc', 'i_mp', 'v_oc', 'v_mp', 'p_mp', 'i_x', 'i_xx',
-                 'effective_irradiance'],
-        index=times)
-
-    assert_frame_equal(sapm, expected)
-
-    # just make sure it works with a dict input
-    sapm = pvsystem.sapm(module_parameters.to_dict(), irrad_data['dni'],
-                         irrad_data['dhi'], 25, am, aoi)
-
-
-def test_PVSystem_sapm(sam_data):
+@pytest.fixture(scope="session")
+def sapm_module_params(sam_data):
     modules = sam_data['sandiamod']
     module = 'Canadian_Solar_CS5P_220M___2009_'
     module_parameters = modules[module]
-    system = pvsystem.PVSystem(module=module,
-                               module_parameters=module_parameters)
-    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
-    irrad_data = pd.DataFrame({'dni':[0,1000], 'ghi':[0,600], 'dhi':[0,100]},
-                              index=times)
-    am = pd.Series([0, 2.25], index=times)
-    aoi = pd.Series([180, 30], index=times)
+    return module_parameters
 
-    sapm = system.sapm(irrad_data['dni'], irrad_data['dhi'], 25, am, aoi)
+
+def test_sapm(sapm_module_params):
+
+    times = pd.DatetimeIndex(start='2015-01-01', periods=5, freq='12H')
+    effective_irradiance = pd.Series([-1, 0.5, 1.1, np.nan, 1], index=times)
+    temp_cell = pd.Series([10, 25, 50, 25, np.nan], index=times)
+
+    out = pvsystem.sapm(sapm_module_params, effective_irradiance, temp_cell)
 
     expected = pd.DataFrame(np.array(
-    [[   0.        ,    0.        ,    0.        ,    0.        ,
-           0.        ,    0.        ,    0.        ,    0.        ],
-       [   5.74526799,    5.12194115,   59.67914031,   48.41924255,
-         248.00051089,    5.61787615,    3.52581308,    1.12848138]]),
-        columns=['i_sc', 'i_mp', 'v_oc', 'v_mp', 'p_mp', 'i_x', 'i_xx',
-                 'effective_irradiance'],
+      [[  -5.0608322 ,   -4.65037767,           nan,           nan,
+                  nan,   -4.91119927,   -4.15367716],
+       [   2.545575  ,    2.28773882,   56.86182059,   47.21121608,
+         108.00693168,    2.48357383,    1.71782772],
+       [   5.65584763,    5.01709903,   54.1943277 ,   42.51861718,
+         213.32011294,    5.52987899,    3.48660728],
+       [          nan,           nan,           nan,           nan,
+                  nan,           nan,           nan],
+       [          nan,           nan,           nan,           nan,
+                  nan,           nan,           nan]]),
+        columns=['i_sc', 'i_mp', 'v_oc', 'v_mp', 'p_mp', 'i_x', 'i_xx'],
         index=times)
 
-    assert_frame_equal(sapm, expected)
+    assert_frame_equal(out, expected, check_less_precise=4)
+
+    out = pvsystem.sapm(sapm_module_params, 1, 25)
+
+    expected = OrderedDict()
+    expected['i_sc'] = 5.09115
+    expected['i_mp'] = 4.5462909092579995
+    expected['v_oc'] = 59.260800000000003
+    expected['v_mp'] = 48.315600000000003
+    expected['p_mp'] = 219.65677305534581
+    expected['i_x'] = 4.9759899999999995
+    expected['i_xx'] = 3.1880204359100004
+
+    for k, v in expected.items():
+        assert_allclose(out[k], v, atol=1e-4)
+
+    # just make sure it works with a dict input
+    pvsystem.sapm(sapm_module_params.to_dict(), effective_irradiance,
+                  temp_cell)
 
 
-def test_sapm_spectral_loss(sam_data):
-    assert False
+def test_PVSystem_sapm(sapm_module_params):
+    system = pvsystem.PVSystem(module_parameters=sapm_module_params)
+
+    times = pd.DatetimeIndex(start='2015-01-01', periods=5, freq='12H')
+    effective_irradiance = pd.Series([-1, 0.5, 1.1, np.nan, 1], index=times)
+    temp_cell = pd.Series([10, 25, 50, 25, np.nan], index=times)
+
+    out = system.sapm(effective_irradiance, temp_cell)
 
 
-def test_sapm_aoi_loss(sam_data):
-    assert False
+@pytest.mark.parametrize('airmass,expected', [
+    (1.5, 1.00028714375),
+    (np.array([[10, np.nan]]), np.array([[0.999535, np.nan]])),
+    (pd.Series([5]), pd.Series([1.0387675]))
+])
+def test_sapm_spectral_loss(sapm_module_params, airmass, expected):
+
+    out = pvsystem.sapm_spectral_loss(sapm_module_params, airmass)
+
+    if isinstance(airmass, pd.Series):
+        assert_series_equal(out, expected, check_less_precise=4)
+    else:
+        assert_allclose(out, expected, atol=1e-4)
 
 
-def test_sapm_effective_irradiance(sam_data):
-    assert False
+def test_PVSystem_sapm_spectral_loss(sapm_module_params):
+    system = pvsystem.PVSystem(module_parameters=sapm_module_params)
+
+    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
+    airmass = pd.Series([1, 10], index=times)
+
+    out = system.sapm_spectral_loss(airmass)
+
+
+@pytest.mark.parametrize('aoi,expected', [
+    (45, 0.9975036250000002),
+    (np.array([[45, 100, np.nan]]), np.array([[0.997504, 0, np.nan]])),
+    (pd.Series([80]), pd.Series([0.597472]))
+])
+def test_sapm_aoi_loss(sapm_module_params, aoi, expected):
+
+    out = pvsystem.sapm_aoi_loss(sapm_module_params, aoi)
+
+    if isinstance(aoi, pd.Series):
+        assert_series_equal(out, expected, check_less_precise=4)
+    else:
+        assert_allclose(out, expected, atol=1e-4)
+
+
+def test_PVSystem_sapm_aoi_loss(sapm_module_params):
+    system = pvsystem.PVSystem(module_parameters=sapm_module_params)
+
+    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
+    aoi = pd.Series([45, 10], index=times)
+
+    out = system.sapm_aoi_loss(aoi)
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    ([1000, 100, 5, 45, 1000], 1.1400510967821877),
+    ([np.array([np.nan, 1000, 1000]),
+      np.array([100, np.nan, 100]),
+      np.array([1.1, 1.1, 1.1]),
+      np.array([10, 10, 10]),
+      1000],
+     np.array([np.nan, np.nan, 1.081157])),
+    ([pd.Series([1000]), pd.Series([100]), pd.Series([1.1]),
+      pd.Series([10]), 1370],
+     pd.Series([0.789166]))
+])
+def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
+
+    out = pvsystem.sapm_effective_irradiance(sapm_module_params, *test_input)
+
+    if isinstance(test_input, pd.Series):
+        assert_series_equal(out, expected, check_less_precise=4)
+    else:
+        assert_allclose(out, expected, atol=1e-4)
+
+
+def test_PVSystem_sapm_effective_irradiance(sapm_module_params):
+    system = pvsystem.PVSystem(module_parameters=sapm_module_params)
+
+    poa_direct = np.array([np.nan, 1000, 1000])
+    poa_diffuse = np.array([100, np.nan, 100])
+    airmass_absolute = np.array([1.1, 1.1, 1.1])
+    aoi = np.array([10, 10, 10])
+    reference_irradiance = 1000
+
+    out = system.sapm_effective_irradiance(
+        poa_direct, poa_diffuse, airmass_absolute,
+        aoi, reference_irradiance=reference_irradiance)
 
 
 def test_calcparams_desoto(sam_data):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -227,7 +227,8 @@ def test_PVSystem_sapm_spectral_loss(sapm_module_params):
 
 @pytest.mark.parametrize('aoi,expected', [
     (45, 0.9975036250000002),
-    (np.array([[-30, 30, 100, np.nan]]), np.array([[np.nan, 1., 0, np.nan]])),
+    (np.array([[-30, 30, 100, np.nan]]),
+     np.array([[np.nan, 1.007572, 0, np.nan]])),
     (pd.Series([80]), pd.Series([0.597472]))
 ])
 def test_sapm_aoi_loss(sapm_module_params, aoi, expected):
@@ -242,7 +243,10 @@ def test_sapm_aoi_loss(sapm_module_params, aoi, expected):
 
 def test_sapm_aoi_loss_limits():
     module_parameters = {'B0': 5, 'B1': 0, 'B2': 0, 'B3': 0, 'B4': 0, 'B5': 0}
-    assert pvsystem.sapm_aoi_loss(module_parameters, 1) == 1
+    assert pvsystem.sapm_aoi_loss(module_parameters, 1) == 5
+
+    module_parameters = {'B0': 5, 'B1': 0, 'B2': 0, 'B3': 0, 'B4': 0, 'B5': 0}
+    assert pvsystem.sapm_aoi_loss(module_parameters, 1, upper=1) == 1
 
     module_parameters = {'B0': -5, 'B1': 0, 'B2': 0, 'B3': 0, 'B4': 0, 'B5': 0}
     assert pvsystem.sapm_aoi_loss(module_parameters, 1) == 0

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -227,7 +227,7 @@ def test_PVSystem_sapm_spectral_loss(sapm_module_params):
 
 @pytest.mark.parametrize('aoi,expected', [
     (45, 0.9975036250000002),
-    (np.array([[45, 100, np.nan]]), np.array([[0.997504, 0, np.nan]])),
+    (np.array([[-30, 30, 100, np.nan]]), np.array([[np.nan, 1., 0, np.nan]])),
     (pd.Series([80]), pd.Series([0.597472]))
 ])
 def test_sapm_aoi_loss(sapm_module_params, aoi, expected):


### PR DESCRIPTION
I updated to pvsystem.sapm to be consistent with the PVLIB MATLAB API. pvsystem.sapm now takes an effective irradiance argument instead of POA irradiances, airmass, and AOI. It also implements closely related sapm_spectral_loss, sapm_aoi_loss, and sapm_effective_irradiance functions, as well as PVSystem methods. See the changed files for details.

I need to write some tests for the new functions and methods. I also need to update ModelChain. It might break some documentation, too.

Let me know if you have any comments or concerns.

closed #198, closes #205 