### PR TITLE
add optional ivcurve calculation to singlediode

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.0.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.0.txt
@@ -51,6 +51,8 @@ Enhancements
 * Add solarposition.nrel_earthsun_distance function and option to
   calculate extraterrestrial radiation using the NREL solar position
   algorithm. (:issue:`211`, :issue:`215`)
+* pvsystem.singlediode can now calculate IV curves if a user supplies
+  an ivcurve_pnts keyword argument. (:issue:`83`)
 * Includes SAM data files in the distribution. (:issue:`52`)
 
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -453,8 +453,8 @@ def test_singlediode_floats_ivcurve():
 
 @requires_scipy
 def test_singlediode_series_ivcurve(cec_module_params):
-    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
-    poa_data = pd.Series([0, 800], index=times)
+    times = pd.DatetimeIndex(start='2015-06-01', periods=3, freq='6H')
+    poa_data = pd.Series([0, 400, 800], index=times)
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
                                          poa_data,
                                          temp_cell=25,
@@ -465,19 +465,21 @@ def test_singlediode_series_ivcurve(cec_module_params):
 
     out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3)
 
-    expected = OrderedDict([('i_sc', array([        nan,  6.00675648])),
-             ('i_mp', array([       nan,  5.285947])),
-             ('v_oc', array([         nan,  10.29530483])),
-             ('v_mp', array([        nan,  8.415971])),
-             ('p_mp', array([         nan,  44.486373])),
-             ('i_x', array([        nan,  5.74622046])),
-             ('i_xx', array([        nan,  3.90008])),
-             ('i',
-              array([[        nan,         nan,         nan],
-       [ 6.00726296,  5.74622046,  0.        ]])),
+    expected = OrderedDict([('i_sc', array([        nan,  3.01054475,  6.00675648])),
+             ('v_oc', array([         nan,   9.96886962,  10.29530483])),
+             ('i_mp', array([        nan,  2.65191983,  5.28594672])),
+             ('v_mp', array([        nan,  8.33392491,  8.4159707 ])),
+             ('p_mp', array([         nan,  22.10090078,  44.48637274])),
+             ('i_x', array([        nan,  2.88414114,  5.74622046])),
+             ('i_xx', array([        nan,  2.04340914,  3.90007956])),
              ('v',
               array([[         nan,          nan,          nan],
-       [  0.        ,   5.14765242,  10.29530483]]))])
+       [  0.        ,   4.98443481,   9.96886962],
+       [  0.        ,   5.14765242,  10.29530483]])),
+             ('i',
+              array([[             nan,              nan,              nan],
+       [  3.01079860e+00,   2.88414114e+00,   3.10862447e-14],
+       [  6.00726296e+00,   5.74622046e+00,   0.00000000e+00]]))])
 
     for k, v in out.items():
         assert_allclose(expected[k], v, atol=1e-2)

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -466,12 +466,12 @@ def test_singlediode_series_ivcurve(cec_module_params):
     out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3)
 
     expected = OrderedDict([('i_sc', array([        nan,  6.00675648])),
-             ('i_mp', array([       nan,  5.6129056])),
+             ('i_mp', array([       nan,  5.285947])),
              ('v_oc', array([         nan,  10.29530483])),
-             ('v_mp', array([        nan,  7.25364707])),
-             ('p_mp', array([         nan,  40.71403625])),
+             ('v_mp', array([        nan,  8.415971])),
+             ('p_mp', array([         nan,  44.486373])),
              ('i_x', array([        nan,  5.74622046])),
-             ('i_xx', array([        nan,  4.97138154])),
+             ('i_xx', array([        nan,  3.90008])),
              ('i',
               array([[        nan,         nan,         nan],
        [ 6.00726296,  5.74622046,  0.        ]])),
@@ -480,7 +480,7 @@ def test_singlediode_series_ivcurve(cec_module_params):
        [  0.        ,   5.14765242,  10.29530483]]))])
 
     for k, v in out.items():
-        assert_allclose(expected[k], v, atol=3)
+        assert_allclose(expected[k], v, atol=1e-2)
 
 
 def test_scale_voltage_current_power(sam_data):


### PR DESCRIPTION
This PR adds an IV curve calculation feature to pvsystem.singlediode. 

As discussed in #83, the singlediode API remains unchanged for timeseries analysis: series in yields dataframe out. Scalar and array input still yield dict output (well, now an OrderedDict). 

Setting the new ivcurve_pnts keyword argument to a non-zero number will always yield an OrderedDict. The dict will also include the keys i and v. The values will be arrays with dimension one greater than the input data (1d arrays for scalar input, 2d arrays for array/series input).

Hopefully that makes sense. The idea is that it "just works".

Example usage below.

Closes #83.

```python
In [197]: times = pd.DatetimeIndex(start='2015-06-01', end='2015-06-02', freq='3H', tz='America/Phoenix')

In [198]: tus = pvlib.location.Location(32, -110)

In [199]: cs = tus.get_clearsky(times)

In [200]: cec_module_params = pvsystem.retrieve_sam('cecmod')['Example_Module']

In [201]:     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
     ...:                                          cs['ghi'],
     ...:                                          temp_cell=25,
     ...:                                          alpha_isc=cec_module_params['alpha_sc'],
     ...:                                          module_parameters=cec_module_params,
     ...:                                          EgRef=1.121,
     ...:                                          dEgdT=-0.0002677)

In [202]: sd = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=100)

In [203]: for i, v, poa in zip(sd['i'], sd['v'], cs['ghi']):
     ...:     plt.plot(v, i, label='{:.0f}'.format(poa))
     ...:

In [204]: plt.ylabel('current (A)'); plt.xlabel('voltage (V)')
Out[204]: <matplotlib.text.Text at 0x1068fdd68>

In [205]: plt.ylim(0, None); plt.xlim(0, None)
Out[205]: (0, 12.0)

In [206]: plt.legend()
Out[206]: <matplotlib.legend.Legend at 0x1068fcc88>
```

![ivcurveexample](https://cloud.githubusercontent.com/assets/4383303/17030855/4f4c854a-4f26-11e6-8d82-304fab44e568.png)

I would add the 5 IV curve points to the plot, but this PR does not include the fix in #222. 

