### PR TITLE
Making the irradiation and weather DataFrame of the ModelChain more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,12 @@ coverage.xml
 # Translations
 *.mo
 
-# Mr Developer
+# IDE's (Mr Developer, pydev, pycharm...)
 .mr.developer.cfg
 .project
 .pydevproject
+.spyderproject
+.idea/
 
 # Rope
 .ropeproject

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.4.2.txt
 .. include:: whatsnew/v0.4.1.txt
 .. include:: whatsnew/v0.4.0.txt
 .. include:: whatsnew/v0.3.3.txt

--- a/docs/sphinx/source/whatsnew/v0.4.2.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.2.txt
@@ -6,6 +6,12 @@ v0.4.2 ()
 This is a minor release from 0.4.0. ....
 
 
+Bug fixes
+~~~~~~~~~
+
+* Fixed typo in __repr__ method of ModelChain and in its regarding test. (commit: b691358b)
+
+
 API Changes
 ~~~~~~~~~~~
 

--- a/docs/sphinx/source/whatsnew/v0.4.2.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.2.txt
@@ -1,0 +1,24 @@
+.. _whatsnew_0420:
+
+v0.4.2 ()
+------------------------
+
+This is a minor release from 0.4.0. ....
+
+
+API Changes
+~~~~~~~~~~~
+
+* The run_model method of the ModelChain will use the weather parameter of all weather data instead of splitting it to irradiation and weather. The irradiation parameter still works but will be removed soon.(:issue:`239`)
+
+
+Enhancements
+~~~~~~~~~~~~
+
+* Adding a complete_irradiance method to the ModelChain to make it possible to calculate missing irradiation data from the existing columns [beta] (:issue:`239`)
+
+
+Code Contributors
+~~~~~~~~~~~~~~~~~
+
+* Uwe Krien

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -673,6 +673,12 @@ class ModelChain(object):
 
         Assigns attributes: times, solar_position, airmass, total_irrad, aoi
         """
+        # Add columns that does not exist and overwrite existing columns
+        # Maybe there is a more elegant way to do this. Any ideas?
+        if weather is not None:
+            self.weather = self.weather.combine_first(weather)
+            self.weather.update(weather)
+
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.
         # **** Begin ****

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -652,7 +652,7 @@ class ModelChain(object):
                                    self.weather.dni *
                                    tools.cosd(self.solar_position.zenith))
 
-    def prepare_inputs(self, times, irradiance=None, weather=None):
+    def prepare_inputs(self, times=None, irradiance=None, weather=None):
         """
         Prepare the solar position, irradiance, and weather inputs to
         the model.
@@ -695,13 +695,8 @@ class ModelChain(object):
                 self.weather[column] = irradiance.pop(column)
         # **** End ****
 
-        # Add columns that does not exist and overwrite existing columns
-        # Maybe there is a more elegant way to do this. Any ideas?
-        if weather is not None:
-            self.weather = self.weather.combine_first(weather)
-            self.weather.update(weather)
-
-        self.times = times
+        if times is not None:
+            self.times = times
 
         self.solar_position = self.location.get_solarposition(self.times)
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -323,7 +323,7 @@ class ModelChain(object):
 
     def __repr__(self):
         return ('ModelChain for: ' + str(self.system) +
-                ' orientation_startegy: ' + str(self.orientation_strategy) +
+                ' orientation_strategy: ' + str(self.orientation_strategy) +
                 ' clearsky_model: ' + str(self.clearsky_model) +
                 ' transposition_model: ' + str(self.transposition_model) +
                 ' solar_position_method: ' + str(self.solar_position_method) +

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -605,7 +605,7 @@ class ModelChain(object):
             fd*self.total_irrad['poa_diffuse'])
         return self
 
-    def prepare_irradiance(self, dni_determination_method='dirint'):
+    def complete_irradiance(self, dni_determination_method='dirint'):
         """
 
         Parameters

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -686,11 +686,7 @@ class ModelChain(object):
         # Add columns that does not exist and overwrite existing columns
         # Maybe there is a more elegant way to do this. Any ideas?
         if weather is not None:
-            if self.weather is None:
-                self.weather = weather
-            else:
-                self.weather = self.weather.combine_first(weather)
-                self.weather.update(weather)
+            self.weather = weather
 
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -679,7 +679,11 @@ class ModelChain(object):
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.
         # **** Begin ****
+        wrn_txt = "The irradiance parameter will be removed soon."
+        wrn_txt += "Please use the weather parameter to pass a DataFrame with "
+        wrn_txt += "irradiance (ghi, dni, dhi), wind speed and temp_air"
         if irradiance is not None:
+            warnings.warn(wrn_txt, FutureWarning)
             for column in irradiance.columns:
                 weather[column] = irradiance.pop(column)
         # **** End ****

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -711,6 +711,10 @@ class ModelChain(object):
                 zenith_data=self.solar_position['apparent_zenith'],
                 airmass_data=self.airmass['airmass_absolute'])
 
+        if not {'ghi', 'dni', 'dhi'} <= set(self.weather.columns):
+            ValueError(
+                "Uncompleted irradiance data set. Please check you input data")
+
         # PVSystem.get_irradiance and SingleAxisTracker.get_irradiance
         # have different method signatures, so use partial to handle
         # the differences.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -637,12 +637,16 @@ class ModelChain(object):
         self.aoi = self.system.get_aoi(self.solar_position['apparent_zenith'],
                                        self.solar_position['azimuth'])
 
-        if irradiance is None:
-            irradiance = self.location.get_clearsky(
+        if irradiance:
+            self.irradiance = irradiance
+        else:
+            self.irradiance = weather
+
+        if not self.irradiance:
+            self.irradiance = self.location.get_clearsky(
                 self.solar_position.index, self.clearsky_model,
                 zenith_data=self.solar_position['apparent_zenith'],
                 airmass_data=self.airmass['airmass_absolute'])
-        self.irradiance = irradiance
 
         # PVSystem.get_irradiance and SingleAxisTracker.get_irradiance
         # have different method signatures, so use partial to handle

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -667,7 +667,8 @@ class ModelChain(object):
             Times at which to evaluate the model. Can be None if attribute
             `times` is already set.
         weather : None or DataFrame
-            If None, assumes air temperature is 20 C, wind speed is 0 m/s and
+            If None, the weather attribute is used. If the weather attribute is
+            also None assumes air temperature is 20 C, wind speed is 0 m/s and
             irradiation calculated from clear sky data.
             Column names must be 'wind_speed', 'temp_air', 'dni', 'ghi', 'dhi'.
             Do not pass incomplete irradiation data.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -11,8 +11,7 @@ import logging
 import warnings
 import pandas as pd
 
-from pvlib import (solarposition, pvsystem, clearsky, atmosphere, tools,
-                   irradiance)
+from pvlib import (solarposition, pvsystem, clearsky, atmosphere, tools)
 from pvlib.tracking import SingleAxisTracker
 import pvlib.irradiance  # avoid name conflict with full import
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -628,9 +628,10 @@ class ModelChain(object):
 
         Returns
         -------
-        pandas.DataFrame
-            Containing the missing column of the data sets passed with the
-            weather DataFrame.
+        self
+
+        Assigns attributes: times, weather
+
         Examples
         --------
         This example does not work until the parameters `my_system`,
@@ -674,6 +675,8 @@ class ModelChain(object):
             self.weather.loc[:, 'dhi'] = (
                 self.weather.ghi - self.weather.dni *
                 tools.cosd(self.solar_position.zenith))
+
+        return self
 
     def prepare_inputs(self, times=None, irradiance=None, weather=None):
         """

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -685,14 +685,6 @@ class ModelChain(object):
         self.aoi = self.system.get_aoi(self.solar_position['apparent_zenith'],
                                        self.solar_position['azimuth'])
 
-        if irradiance:
-            self.irradiance = irradiance
-        else:
-            self.irradiance = weather
-
-        if self.irradiance:
-            self.prepare_irradiance(**kwargs)
-
         if not self.irradiance:
             self.irradiance = self.location.get_clearsky(
                 self.solar_position.index, self.clearsky_model,

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -631,6 +631,22 @@ class ModelChain(object):
         pandas.DataFrame
             Containing the missing column of the data sets passed with the
             weather DataFrame.
+        Examples
+        --------
+        This example does not work until the parameters `my_system`,
+        `my_location`, `my_datetime` and `my_weather` are not defined properly
+        but shows the basic idea how this method can be used.
+
+        >>> from pvlib.modelchain import ModelChain
+
+        >>> # my_weather containing 'dhi' and 'ghi'.
+        >>> mc = ModelChain(my_system, my_location)  # doctest: +SKIP
+        >>> mc.complete_irradiance(my_datetime, my_weather)  # doctest: +SKIP
+        >>> mc.run_model()  # doctest: +SKIP
+
+        >>> # my_weather containing 'dhi', 'ghi' and 'dni'.
+        >>> mc = ModelChain(my_system, my_location)  # doctest: +SKIP
+        >>> mc.run_model(my_datetime, my_weather)  # doctest: +SKIP
         """
         if weather is not None:
             self.weather = weather

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -702,7 +702,7 @@ class ModelChain(object):
         if irradiance is not None:
             warnings.warn(wrn_txt, FutureWarning)
             for column in irradiance.columns:
-                self.weather[column] = irradiance.pop(column)
+                self.weather[column] = irradiance[column]
         # **** End ****
 
         if times is not None:

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -671,8 +671,7 @@ class ModelChain(object):
         -------
         self
 
-        Assigns attributes: times, solar_position, airmass, irradiance,
-        total_irrad, weather, aoi
+        Assigns attributes: times, solar_position, airmass, total_irrad, aoi
         """
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -318,6 +318,8 @@ class ModelChain(object):
         self.orientation_strategy = orientation_strategy
 
         self.weather = pd.DataFrame()
+        self.times = None
+        self.solar_position = None
 
     def __repr__(self):
         return ('ModelChain for: ' + str(self.system) +

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -666,6 +666,8 @@ class ModelChain(object):
         times : DatetimeIndex
             Times at which to evaluate the model. Can be None if attribute
             `times` is already set.
+        irradiance : None or DataFrame
+            This parameter is deprecated. Please use `weather` instead.
         weather : None or DataFrame
             If None, the weather attribute is used. If the weather attribute is
             also None assumes air temperature is 20 C, wind speed is 0 m/s and

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -612,13 +612,13 @@ class ModelChain(object):
         Determine the missing irradiation columns. Only two of the following
         data columns (dni, ghi, dhi) are needed to calculate the missing data.
 
-        This function is not save at the moment. Results can be too high or
+        This function is not safe at the moment. Results can be too high or
         negative. Please contribute and help to improve this function on
         https://github.com/pvlib/pvlib-python
 
         Parameters
         ----------
-        times : datetime index
+        times : DatetimeIndex
             Date and time index of the irradiation data
         weather : pandas.DataFrame
             Table with at least two columns containing one of the following data
@@ -629,16 +629,15 @@ class ModelChain(object):
         pandas.DataFrame
             Containing the missing column of the data sets passed with the
             weather DataFrame.
-
         """
         self.weather = weather
         self.times = times
         self.solar_position = self.location.get_solarposition(self.times)
         icolumns = set(self.weather.columns)
-        wrn_txt = "This function is not save at the moment.\n"
-        wrn_txt += "Results can be too high or negative.\n"
-        wrn_txt += "Help to improve this function on github."
-        wrn_txt += "https://github.com/pvlib/pvlib-python"
+        wrn_txt = ("This function is not safe at the moment.\n" +
+                   "Results can be too high or negative.\n" +
+                   "Help to improve this function on github:\n" +
+                   "https://github.com/pvlib/pvlib-python \n")
         warnings.warn(wrn_txt, UserWarning)
         if {'ghi', 'dhi'} <= icolumns and 'dni' not in icolumns:
             logging.debug('Estimate dni from ghi and dhi')
@@ -696,9 +695,10 @@ class ModelChain(object):
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.
         # **** Begin ****
-        wrn_txt = "The irradiance parameter will be removed soon.\n"
-        wrn_txt += "Please use the weather parameter to pass a DataFrame with "
-        wrn_txt += "irradiance (ghi, dni, dhi), wind speed and temp_air"
+        wrn_txt = ("The irradiance parameter will be removed soon.\n" +
+                   "Please use the weather parameter to pass a DataFrame " +
+                   "with irradiance (ghi, dni, dhi), wind speed and " +
+                   "temp_air.\n")
         if irradiance is not None:
             warnings.warn(wrn_txt, FutureWarning)
             for column in irradiance.columns:

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -742,8 +742,10 @@ class ModelChain(object):
                 airmass_data=self.airmass['airmass_absolute'])
 
         if not {'ghi', 'dni', 'dhi'} <= set(self.weather.columns):
-            ValueError(
-                "Uncompleted irradiance data set. Please check you input data")
+            raise ValueError(
+                "Uncompleted irradiance data set. Please check you input " +
+                "data.\nData set needs to have 'dni', 'dhi' and 'ghi'.\n" +
+                "Detected data: {0}".format(list(self.weather.columns)))
 
         # PVSystem.get_irradiance and SingleAxisTracker.get_irradiance
         # have different method signatures, so use partial to handle

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -676,7 +676,7 @@ class ModelChain(object):
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.
         # **** Begin ****
-        wrn_txt = "The irradiance parameter will be removed soon."
+        wrn_txt = "The irradiance parameter will be removed soon.\n"
         wrn_txt += "Please use the weather parameter to pass a DataFrame with "
         wrn_txt += "irradiance (ghi, dni, dhi), wind speed and temp_air"
         if irradiance is not None:
@@ -702,7 +702,6 @@ class ModelChain(object):
                                        self.solar_position['azimuth'])
 
         if not any([x in ['ghi', 'dni', 'dhi'] for x in self.weather.columns]):
-            print('any is True')
             self.weather[['ghi', 'dni', 'dhi']] = self.location.get_clearsky(
                 self.solar_position.index, self.clearsky_model,
                 zenith_data=self.solar_position['apparent_zenith'],

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -607,7 +607,7 @@ class ModelChain(object):
             fd*self.total_irrad['poa_diffuse'])
         return self
 
-    def complete_irradiance(self, times, weather):
+    def complete_irradiance(self, times=None, weather=None):
         """
         Determine the missing irradiation columns. Only two of the following
         data columns (dni, ghi, dhi) are needed to calculate the missing data.
@@ -619,10 +619,12 @@ class ModelChain(object):
         Parameters
         ----------
         times : DatetimeIndex
-            Date and time index of the irradiation data
+            Times at which to evaluate the model. Can be None if attribute
+            `times` is already set.
         weather : pandas.DataFrame
             Table with at least two columns containing one of the following data
-            sets: dni, dhi, ghi
+            sets: dni, dhi, ghi. Can be None if attribute `weather` is already
+            set.
 
         Returns
         -------
@@ -630,8 +632,10 @@ class ModelChain(object):
             Containing the missing column of the data sets passed with the
             weather DataFrame.
         """
-        self.weather = weather
-        self.times = times
+        if weather is not None:
+            self.weather = weather
+        if times is not None:
+            self.times = times
         self.solar_position = self.location.get_solarposition(self.times)
         icolumns = set(self.weather.columns)
         wrn_txt = ("This function is not safe at the moment.\n" +

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -617,40 +617,38 @@ class ModelChain(object):
         -------
 
         """
-        if tools.check_df(self.irradiance, ['ghi'], not_exist=['dhi', 'dni']):
+        icolumns = self.weather.columns
+
+        if {'ghi'} <= icolumns and not {'dhi', 'dni'} <= icolumns:
             if dni_determination_method == 'dirint':
-                return_value = irradiance.dirint(self.irradiance.ghi,
+                return_value = irradiance.dirint(self.weather.ghi,
                                                  self.solar_position.zenith,
                                                  self.times)
-                self.irradiance['dhi'] = return_value
+                self.weather['dhi'] = return_value
             elif dni_determination_method == 'disc':
-                return_value = irradiance.disc(self.irradiance.ghi,
+                return_value = irradiance.disc(self.weather.ghi,
                                                self.solar_position.zenith,
                                                self.times)
-                self.irradiance['dni'] = return_value.dni
+                self.weather['dni'] = return_value.dni
             elif dni_determination_method == 'erbs':
-                return_value = irradiance.erbs(self.irradiance.ghi,
+                return_value = irradiance.erbs(self.weather.ghi,
                                                self.solar_position.zenith,
                                                self.times)
-                self.irradiance['dni'] = return_value.dni
-                self.irradiance['dhi'] = return_value.dhi
+                self.weather['dni'] = return_value.dni
+                self.weather['dhi'] = return_value.dhi
 
-
-        if tools.check_df(self.irradiance, ['ghi', 'dhi'], not_exist=['dni']):
-            self.irradiance['dni'] = ((self.irradiance.ghi -
-                                       self.irradiance.dhi) /
-                                      tools.cosd(self.solar_position.zenith))
-
-        elif tools.check_df(self.irradiance, ['dni', 'dhi'], not_exist=['ghi']):
-            self.irradiance['ghi'] = (self.irradiance.dni *
-                                      tools.cosd(self.solar_position.zenith) +
-                                      self.irradiance.dhi)
-        elif tools.check_df(self.irradiance, ['dni', 'ghi'], not_exist=['dhi']):
-            self.irradiance['dhi'] = (self.irradiance.ghi -
-                                      self.irradiance.dni *
-                                      tools.cosd(self.solar_position.zenith))
-        else:
-            self.irradiance = None
+        if {'ghi', 'dhi'} <= icolumns and not {'dni'} <= icolumns:
+            self.weather['dni'] = ((self.weather.ghi -
+                                    self.weather.dhi) /
+                                   tools.cosd(self.solar_position.zenith))
+        elif {'dni', 'dhi'} <= icolumns and not {'ghi'} <= icolumns:
+            self.weather['ghi'] = (self.weather.dni *
+                                   tools.cosd(self.solar_position.zenith) +
+                                   self.weather.dhi)
+        elif {'dni', 'ghi'} <= icolumns and not {'dhi'} <= icolumns:
+            self.weather['dhi'] = (self.weather.ghi -
+                                   self.weather.dni *
+                                   tools.cosd(self.solar_position.zenith))
 
     def prepare_inputs(self, times, irradiance=None, weather=None):
         """

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -660,14 +660,16 @@ class ModelChain(object):
         Parameters
         ----------
         times : DatetimeIndex
-            Times at which to evaluate the model.
-        irradiance : None or DataFrame
-            If None, calculates clear sky data.
-            Columns must be 'dni', 'ghi', 'dhi'.
+            Times at which to evaluate the model. Can be None if attribute
+            `times` is already set.
         weather : None or DataFrame
-            If None, assumes air temperature is 20 C and
-            wind speed is 0 m/s.
-            Columns must be 'wind_speed', 'temp_air'.
+            If None, assumes air temperature is 20 C, wind speed is 0 m/s and
+            irradiation calculated from clear sky data.
+            Column names must be 'wind_speed', 'temp_air', 'dni', 'ghi', 'dhi'.
+            Do not pass incomplete irradiation data.
+            Use method
+            :py:meth:`~pvlib.modelchain.ModelChain.complete_irradiance`
+            instead.
 
         Returns
         -------
@@ -765,15 +767,14 @@ class ModelChain(object):
         ----------
         times : DatetimeIndex
             Times at which to evaluate the model.
-
-        irradiance : None or DataFrame
-            If None, calculates clear sky data.
-            Columns must be 'dni', 'ghi', 'dhi'.
-
         weather : None or DataFrame
-            If None, assumes air temperature is 20 C and
-            wind speed is 0 m/s.
-            Columns must be 'wind_speed', 'temp_air'.
+            If None, assumes air temperature is 20 C, wind speed is 0 m/s and
+            irradiation calculated from clear sky data.
+            Column names must be 'wind_speed', 'temp_air', 'dni', 'ghi', 'dhi'.
+            Do not pass incomplete irradiation data.
+            Use method
+            :py:meth:`~pvlib.modelchain.ModelChain.complete_irradiance`
+            instead.
 
         Returns
         -------

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -768,14 +768,17 @@ class ModelChain(object):
             self.weather['temp_air'] = 20
         return self
 
-    def run_model(self, times, irradiance=None, weather=None):
+    def run_model(self, times=None, irradiance=None, weather=None):
         """
         Run the model.
 
         Parameters
         ----------
         times : DatetimeIndex
-            Times at which to evaluate the model.
+            Times at which to evaluate the model. Can be None if attribute
+            `times` is already set.
+        irradiance : None or DataFrame
+            This parameter is deprecated. Please use `weather` instead.
         weather : None or DataFrame
             If None, assumes air temperature is 20 C, wind speed is 0 m/s and
             irradiation calculated from clear sky data.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -706,10 +706,10 @@ class ModelChain(object):
 
         Assigns attributes: times, solar_position, airmass, total_irrad, aoi
         """
-        # Add columns that does not exist and overwrite existing columns
-        # Maybe there is a more elegant way to do this. Any ideas?
         if weather is not None:
             self.weather = weather
+        if self.weather is None:
+            self.weather = pd.DataFrame()
 
         # The following part could be removed together with the irradiance
         # parameter at version v0.5 or v0.6.
@@ -735,15 +735,7 @@ class ModelChain(object):
         self.aoi = self.system.get_aoi(self.solar_position['apparent_zenith'],
                                        self.solar_position['azimuth'])
 
-        use_clearsky = False
-        if self.weather is None:
-            use_clearsky = True
-            self.weather = pd.DataFrame()
-        else:
-            if not any([x in ['ghi', 'dni', 'dhi'] for x in self.weather.columns]):
-                use_clearsky = True
-
-        if use_clearsky:
+        if not any([x in ['ghi', 'dni', 'dhi'] for x in self.weather.columns]):
             self.weather[['ghi', 'dni', 'dhi']] = self.location.get_clearsky(
                 self.solar_position.index, self.clearsky_model,
                 zenith_data=self.solar_position['apparent_zenith'],

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -682,7 +682,7 @@ class ModelChain(object):
         if irradiance is not None:
             warnings.warn(wrn_txt, FutureWarning)
             for column in irradiance.columns:
-                weather[column] = irradiance.pop(column)
+                self.weather[column] = irradiance.pop(column)
         # **** End ****
 
         # Add columns that does not exist and overwrite existing columns

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -415,3 +415,60 @@ def test_ModelChain___repr__(system, location):
     'orientation_startegy: south_at_latitude_tilt clearsky_model: '+
     'ineichen transposition_model: haydavies solar_position_method: '+
     'nrel_numpy airmass_model: kastenyoung1989')
+
+
+@requires_scipy
+def test_weather_irradiance_input(system, location):
+    """Test will raise a warning and should be removed in future versions."""
+    mc = ModelChain(system, location)
+    times = pd.date_range('2012-06-01 12:00:00', periods=2, freq='H')
+    i = pd.DataFrame({'dni': [2, 3], 'dhi': [4, 6], 'ghi': [9, 5]}, index=times)
+    w = pd.DataFrame({'wind_speed': [11, 5], 'temp_air': [30, 32]}, index=times)
+    mc.run_model(times, irradiance=i, weather=w)
+
+    assert_series_equal(mc.weather['dni'],
+                        pd.Series([2, 3], index=times, name='dni'))
+    assert_series_equal(mc.weather['wind_speed'],
+                        pd.Series([11, 5], index=times, name='wind_speed'))
+
+
+@requires_scipy
+def test_complete_irradiance_clean_run(system, location):
+    """The DataFrame should not change if all columns are passed"""
+    mc = ModelChain(system, location)
+    times = pd.date_range('2010-07-05 9:00:00', periods=2, freq='H')
+    i = pd.DataFrame({'dni': [2, 3], 'dhi': [4, 6], 'ghi': [9, 5]}, index=times)
+
+    mc.complete_irradiance(times, weather=i)
+
+    assert_series_equal(mc.weather['dni'],
+                        pd.Series([2, 3], index=times, name='dni'))
+    assert_series_equal(mc.weather['dhi'],
+                        pd.Series([4, 6], index=times, name='dhi'))
+    assert_series_equal(mc.weather['ghi'],
+                        pd.Series([9, 5], index=times, name='ghi'))
+
+
+@requires_scipy
+def test_complete_irradiance(system, location):
+    """Check calculations"""
+    mc = ModelChain(system, location)
+    times = pd.date_range('2010-07-05 9:00:00', periods=2, freq='H')
+    i = pd.DataFrame({'dni': [30.354455, 77.22822],
+                      'dhi': [372.103976116, 497.087579068],
+                      'ghi': [356.543700, 465.44400]}, index=times)
+
+    mc.complete_irradiance(times, weather=i[['ghi', 'dni']])
+    assert_series_equal(mc.weather['dhi'],
+                        pd.Series([372.103976116, 497.087579068],
+                                  index=times, name='dhi'))
+
+    mc.complete_irradiance(times, weather=i[['dhi', 'dni']])
+    assert_series_equal(mc.weather['ghi'],
+                        pd.Series([356.543700, 465.44400],
+                                  index=times, name='ghi'))
+
+    mc.complete_irradiance(times, weather=i[['dhi', 'ghi']])
+    assert_series_equal(mc.weather['dni'],
+                        pd.Series([30.354455, 77.22822],
+                                  index=times, name='dni'))

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -102,7 +102,7 @@ def test_run_model_with_irradiance(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     irradiance = pd.DataFrame({'dni':900, 'ghi':600, 'dhi':150},
                               index=times)
-    ac = mc.run_model(times, irradiance=irradiance).ac
+    ac = mc.run_model(times, weather=irradiance).ac
 
     expected = pd.Series(np.array([  1.90054749e+02,  -2.00000000e-02]),
                          index=times)
@@ -114,7 +114,7 @@ def test_run_model_perez(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     irradiance = pd.DataFrame({'dni':900, 'ghi':600, 'dhi':150},
                               index=times)
-    ac = mc.run_model(times, irradiance=irradiance).ac
+    ac = mc.run_model(times, weather=irradiance).ac
 
     expected = pd.Series(np.array([  190.194545796,  -2.00000000e-02]),
                          index=times)
@@ -127,7 +127,7 @@ def test_run_model_gueymard_perez(system, location):
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
     irradiance = pd.DataFrame({'dni':900, 'ghi':600, 'dhi':150},
                               index=times)
-    ac = mc.run_model(times, irradiance=irradiance).ac
+    ac = mc.run_model(times, weather=irradiance).ac
 
     expected = pd.Series(np.array([  190.194760203,  -2.00000000e-02]),
                          index=times)

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -412,7 +412,7 @@ def test_ModelChain___repr__(system, location):
 
     assert mc.__repr__() == ('ModelChain for: PVSystem with tilt:32.2 and '+
     'azimuth: 180 with Module: None and Inverter: None '+
-    'orientation_startegy: south_at_latitude_tilt clearsky_model: '+
+    'orientation_strategy: south_at_latitude_tilt clearsky_model: '+
     'ineichen transposition_model: haydavies solar_position_method: '+
     'nrel_numpy airmass_model: kastenyoung1989')
 


### PR DESCRIPTION
This is the PR for #233. It is just a proposal. I am still not sure if this approach makes sense.

There are two changes:
 * The weather DataFrame can contain the irradiation columns and will be used instead of the irradiance DataFrame if no irradiance DataFrame is passed to the method.

* The irradiance (or weather) DataFrame does not have to contain all types of irradiance (ghi, dni, dhi) but just two of them or only `ghi`.

The new  `tools.check_df` function (does not exist so far) should check if some columns in the DataFrame exist and some do not and returns True or False. If this function doesn't make sense we could change the if condition to:
```python
# Using the function
if tools.check_df(self.irradiance, ['col1', 'col2'], not_exist=['col3'])

# Using the normal if condition
if (self.irradiance['col1'] is None and 
    self.irradiance['col2'] is None and
    self.irradiance['col3'] is not None):
```

The prepare_irradiance method makes it more convenient to pass weather data to the ModelChain but it blows up the code. So what do you think?

This is just a proposal to get some feedback some work is still missing:
 * adapt documentation

 * add new docstring / adept docstring of existing methods

 * write / adapt tests (my problem is that I have already 111 errors with the actual master branch)

 * write `tools.check_df` function (@gnn Could you write an efficient way to do it?) or adept if clause

 * adapt "whatsnew"-file

@gnn could you have a look from the programming point of view? 