### PR TITLE
Issue244: Fix for isinstance str in python 3.

### DIFF
--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -63,7 +63,7 @@ class Location(object):
         self.latitude = latitude
         self.longitude = longitude
 
-        if isinstance(tz, str):
+        if isinstance(tz, basestring):
             self.tz = tz
             self.pytz = pytz.timezone(tz)
         elif isinstance(tz, datetime.tzinfo):

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -24,7 +24,7 @@ def test_location_all():
 
 
 @pytest.mark.parametrize('tz', [
-    aztz, 'America/Phoenix',  -7, -7.0,
+    aztz, 'America/Phoenix',  -7, -7.0, u'Etc/GMT+7',
 ])
 def test_location_tz(tz):
     Location(32.2, -111, tz)


### PR DESCRIPTION
location timezone support for python3 newstr and unicode args
