### PR TITLE
fix incompatibility with pandas 0.19 and solar position calculations

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.1.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.1.txt
@@ -13,6 +13,8 @@ Bug fixes
 * Fixed an error in the irradiance.klucher transposition model.
   The error was introduced in version 0.4.0. (:issue:`228`)
 * Update RAP forecast model variable names. (:issue:`241`)
+* Fix incompatibility with pandas 0.19 and solar position calculations.
+  (:issue:`246`)
 
 
 Documentation

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -317,7 +317,11 @@ def spa_python(time, latitude, longitude,
         except (TypeError, ValueError):
             time = pd.DatetimeIndex([time, ])
 
-    unixtime = time.astype(np.int64)/10**9
+    try:
+        # pandas 0.19 and greater
+        unixtime = time.astype(np.int64).values/10**9
+    except AttributeError:
+        unixtime = time.astype(np.int64)/10**9
 
     spa = _spa_python_import(how)
 
@@ -390,7 +394,7 @@ def get_sun_rise_set_transit(time, latitude, longitude, how='numpy',
 
     # must convert to midnight UTC on day of interest
     utcday = pd.DatetimeIndex(time.date).tz_localize('UTC')
-    unixtime = utcday.astype(np.int64)/10**9
+    unixtime = np.array(utcday.astype(np.int64)/10**9)
 
     spa = _spa_python_import(how)
 
@@ -813,7 +817,7 @@ def nrel_earthsun_distance(time, how='numpy', delta_t=None, numthreads=4):
         except (TypeError, ValueError):
             time = pd.DatetimeIndex([time, ])
 
-    unixtime = time.astype(np.int64)/10**9
+    unixtime = np.array(time.astype(np.int64)/10**9)
 
     spa = _spa_python_import(how)
 

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -317,11 +317,7 @@ def spa_python(time, latitude, longitude,
         except (TypeError, ValueError):
             time = pd.DatetimeIndex([time, ])
 
-    try:
-        # pandas 0.19 and greater
-        unixtime = time.astype(np.int64).values/10**9
-    except AttributeError:
-        unixtime = time.astype(np.int64)/10**9
+    unixtime = np.array(time.astype(np.int64)/10**9)
 
     spa = _spa_python_import(how)
 

--- a/pvlib/test/test_spa.py
+++ b/pvlib/test/test_spa.py
@@ -29,11 +29,7 @@ except ImportError:
 
 times = (pd.date_range('2003-10-17 12:30:30', periods=1, freq='D')
            .tz_localize('MST'))
-try:
-    # pandas 0.19 and greater
-    unixtimes = times.tz_convert('UTC').astype(np.int64).values*1.0/10**9
-except AttributeError:
-    unixtimes = times.tz_convert('UTC').astype(np.int64)*1.0/10**9
+unixtimes = np.array(times.tz_convert('UTC').astype(np.int64)*1.0/10**9)
 
 lat = 39.742476
 lon = -105.1786

--- a/pvlib/test/test_spa.py
+++ b/pvlib/test/test_spa.py
@@ -29,7 +29,12 @@ except ImportError:
 
 times = (pd.date_range('2003-10-17 12:30:30', periods=1, freq='D')
            .tz_localize('MST'))
-unixtimes = times.tz_convert('UTC').astype(np.int64)*1.0/10**9
+try:
+    # pandas 0.19 and greater
+    unixtimes = times.tz_convert('UTC').astype(np.int64).values*1.0/10**9
+except AttributeError:
+    unixtimes = times.tz_convert('UTC').astype(np.int64)*1.0/10**9
+
 lat = 39.742476
 lon = -105.1786
 elev = 1830.14
@@ -251,6 +256,9 @@ class SpaBase(object):
         sunset = pd.DatetimeIndex([dt.datetime(1996, 7, 5, 17, 1, 4),
                                    dt.datetime(2004, 12, 4, 19, 2, 2)]
                                   ).tz_localize('UTC').astype(np.int64)*1.0/10**9
+        times = np.array(times)
+        sunrise = np.array(sunrise)
+        sunset = np.array(sunset)
         result = self.spa.transit_sunrise_sunset(times, -35.0, 0.0, 64.0, 1)
         assert_almost_equal(sunrise/1e3, result[1]/1e3, 3)
         assert_almost_equal(sunset/1e3, result[2]/1e3, 3)
@@ -262,6 +270,9 @@ class SpaBase(object):
                                   ).tz_localize('UTC').astype(np.int64)*1.0/10**9
         sunrise = pd.DatetimeIndex([dt.datetime(1994, 1, 2, 7, 8, 12),]
                                    ).tz_localize('UTC').astype(np.int64)*1.0/10**9
+        times = np.array(times)
+        sunrise = np.array(sunrise)
+        sunset = np.array(sunset)
         result = self.spa.transit_sunrise_sunset(times, 35.0, 0.0, 64.0, 1)
         assert_almost_equal(sunrise/1e3, result[1]/1e3, 3)
         assert_almost_equal(sunset/1e3, result[2]/1e3, 3)
@@ -283,6 +294,9 @@ class SpaBase(object):
                                    dt.datetime(2015, 8, 2, 19, 10),
                                    dt.datetime(2015, 12, 2, 16, 38),],
                                   ).tz_localize('MST').astype(np.int64)*1.0/10**9
+        times = np.array(times)
+        sunrise = np.array(sunrise)
+        sunset = np.array(sunset)
         result = self.spa.transit_sunrise_sunset(times, 39.0, -105.0, 64.0, 1)
         assert_almost_equal(sunrise/1e3, result[1]/1e3, 1)
         assert_almost_equal(sunset/1e3, result[2]/1e3, 1)
@@ -305,6 +319,9 @@ class SpaBase(object):
                                    dt.datetime(2015, 12, 2, 16, 50),],
                                   ).tz_localize('Asia/Shanghai'
                                   ).astype(np.int64)*1.0/10**9
+        times = np.array(times)
+        sunrise = np.array(sunrise)
+        sunset = np.array(sunset)
         result = self.spa.transit_sunrise_sunset(times, 39.917, 116.383, 64.0,1)
         assert_almost_equal(sunrise/1e3, result[1]/1e3, 1)
         assert_almost_equal(sunset/1e3, result[2]/1e3, 1)
@@ -313,6 +330,7 @@ class SpaBase(object):
         times = (pd.date_range('2003-10-17 12:30:30', periods=1, freq='D')
            .tz_localize('MST'))
         unixtimes = times.tz_convert('UTC').astype(np.int64)*1.0/10**9
+        unixtimes = np.array(unixtimes)
         result = self.spa.earthsun_distance(unixtimes, 64.0, 1)
         assert_almost_equal(R, result, 6)
 


### PR DESCRIPTION
pydata/pandas#13209 changed the behavior of DatetimeIndex.astype so that astype would yield an Index object instead of a numpy array. This caused problems in a handful of functions that need numpy arrays for calculations. 

I'll try to merge this later today. I'll try to release 0.4.1 tomorrow.

Closes #246.