### PR TITLE
add more attributes to __repr__ methods

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.2.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.2.txt
@@ -36,6 +36,9 @@ Enhancements
 * Added calculate_deltat method to the spa module to calculate the
   time difference between terrestrial time and UT1. Specifying a scalar
   is sufficient for most calculations. (:issue:`165`)
+* Added more attributes to ModelChain, PVSystem, and Location printed
+  representations. (:issue:`254`)
+* Added name attribute to ModelChain and PVSystem. (:issue:`254`)
 
 Code Contributors
 ~~~~~~~~~~~~~~~~~

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -84,9 +84,9 @@ class Location(object):
         # super(Location, self).__init__(**kwargs)
 
     def __repr__(self):
-        return ('{}: latitude={}, longitude={}, tz={}, altitude={}'
-                .format(self.name, self.latitude, self.longitude,
-                        self.tz, self.altitude))
+        attrs = ['name', 'latitude', 'longitude', 'altitude', 'tz']
+        return ('Location: \n  ' + '\n  '.join(
+            (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
     @classmethod
     def from_tmy(cls, tmy_metadata, tmy_data=None, **kwargs):

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -322,12 +322,23 @@ class ModelChain(object):
         self.solar_position = None
 
     def __repr__(self):
-        return ('ModelChain for: ' + str(self.system) +
-                ' orientation_strategy: ' + str(self.orientation_strategy) +
-                ' clearsky_model: ' + str(self.clearsky_model) +
-                ' transposition_model: ' + str(self.transposition_model) +
-                ' solar_position_method: ' + str(self.solar_position_method) +
-                ' airmass_model: ' + str(self.airmass_model))
+        attrs = [
+            'orientation_strategy', 'clearsky_model', 'transposition_model',
+            'solar_position_method', 'airmass_model', 'dc_model', 'ac_model',
+            'aoi_model', 'spectral_model', 'temp_model', 'losses_model'
+            ]
+
+        def getmcattr(self, attr):
+            """needed to avoid recursion in property lookups"""
+            out = getattr(self, attr)
+            try:
+                out = out.__name__
+            except AttributeError:
+                pass
+            return out
+
+        return ('ModelChain: \n  ' + '\n  '.join(
+            (attr + ': ' + getmcattr(self, attr) for attr in attrs)))
 
     @property
     def orientation_strategy(self):

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -325,8 +325,7 @@ class ModelChain(object):
         attrs = [
             'orientation_strategy', 'clearsky_model', 'transposition_model',
             'solar_position_method', 'airmass_model', 'dc_model', 'ac_model',
-            'aoi_model', 'spectral_model', 'temp_model', 'losses_model'
-            ]
+            'aoi_model', 'spectral_model', 'temp_model', 'losses_model']
 
         def getmcattr(self, attr):
             """needed to avoid recursion in property lookups"""

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -299,8 +299,10 @@ class ModelChain(object):
                  dc_model=None, ac_model=None, aoi_model=None,
                  spectral_model=None, temp_model='sapm',
                  losses_model='no_loss',
+                 name=None,
                  **kwargs):
 
+        self.name = name
         self.system = system
         self.location = location
         self.clearsky_model = clearsky_model
@@ -323,9 +325,11 @@ class ModelChain(object):
 
     def __repr__(self):
         attrs = [
-            'orientation_strategy', 'clearsky_model', 'transposition_model',
-            'solar_position_method', 'airmass_model', 'dc_model', 'ac_model',
-            'aoi_model', 'spectral_model', 'temp_model', 'losses_model']
+            'name', 'orientation_strategy', 'clearsky_model',
+            'transposition_model', 'solar_position_method',
+            'airmass_model', 'dc_model', 'ac_model', 'aoi_model',
+            'spectral_model', 'temp_model', 'losses_model'
+            ]
 
         def getmcattr(self, attr):
             """needed to avoid recursion in property lookups"""

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -144,10 +144,10 @@ class PVSystem(object):
         super(PVSystem, self).__init__(**kwargs)
 
     def __repr__(self):
-        return ('PVSystem with tilt:' + str(self.surface_tilt) +
-                ' and azimuth: ' + str(self.surface_azimuth) +
-                ' with Module: ' + str(self.module) +
-                ' and Inverter: ' + str(self.inverter))
+        attrs = ['surface_tilt', 'surface_azimuth', 'module', 'inverter',
+                 'albedo', 'racking_model']
+        return ('PVSystem: \n  ' + '\n  '.join(
+            (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
     def get_aoi(self, solar_zenith, solar_azimuth):
         """Get the angle of incidence on the system.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -116,7 +116,10 @@ class PVSystem(object):
                  modules_per_string=1, strings_per_inverter=1,
                  inverter=None, inverter_parameters=None,
                  racking_model='open_rack_cell_glassback',
+                 name=None,
                  **kwargs):
+
+        self.name = name
 
         self.surface_tilt = surface_tilt
         self.surface_azimuth = surface_azimuth
@@ -144,8 +147,8 @@ class PVSystem(object):
         super(PVSystem, self).__init__(**kwargs)
 
     def __repr__(self):
-        attrs = ['surface_tilt', 'surface_azimuth', 'module', 'inverter',
-                 'albedo', 'racking_model']
+        attrs = ['name', 'surface_tilt', 'surface_azimuth', 'module',
+                 'inverter', 'albedo', 'racking_model']
         return ('PVSystem: \n  ' + '\n  '.join(
             (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
@@ -575,12 +578,12 @@ class LocalizedPVSystem(PVSystem, Location):
         super(LocalizedPVSystem, self).__init__(**new_kwargs)
 
     def __repr__(self):
-        return ('LocalizedPVSystem with tilt:' + str(self.surface_tilt) +
-                ' and azimuth: ' + str(self.surface_azimuth) +
-                ' with Module: ' + str(self.module) +
-                ' and Inverter: ' + str(self.inverter) +
-                ' at Latitude: ' + str(self.latitude) +
-                ' and Longitude: ' + str(self.longitude))
+        attrs = [
+            'name', 'latitude', 'longitude', 'altitude', 'tz', 'surface_tilt',
+            'surface_azimuth', 'module', 'inverter', 'albedo', 'racking_model'
+                 ]
+        return ('LocalizedPVSystem: \n  ' + '\n  '.join(
+            (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
 
 def systemdef(meta, surface_tilt, surface_azimuth, albedo, modules_per_string,

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -42,12 +42,12 @@ def test_location_invalid_tz_type():
 
 def test_location_print_all():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    expected_str = 'Tucson: latitude=32.2, longitude=-111, tz=US/Arizona, altitude=700'
+    expected_str = 'Location: \n  name: Tucson\n  latitude: 32.2\n  longitude: -111\n  altitude: 700\n  tz: US/Arizona'
     assert tus.__str__() == expected_str
 
 def test_location_print_pytz():
     tus = Location(32.2, -111, aztz, 700, 'Tucson')
-    expected_str = 'Tucson: latitude=32.2, longitude=-111, tz=US/Arizona, altitude=700'
+    expected_str = 'Location: \n  name: Tucson\n  latitude: 32.2\n  longitude: -111\n  altitude: 700\n  tz: US/Arizona'
     assert tus.__str__() == expected_str
 
 
@@ -283,5 +283,6 @@ def test_get_airmass_valueerror():
 
 def test_Location___repr__():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    assert tus.__repr__()==('Tucson: latitude=32.2, longitude=-111, '+
-    'tz=US/Arizona, altitude=700')
+
+    expected = 'Location: \n  name: Tucson\n  latitude: 32.2\n  longitude: -111\n  altitude: 700\n  tz: US/Arizona'
+    assert tus.__repr__() == expected

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -408,13 +408,12 @@ def test_ModelChain___repr__(system, location):
 
     strategy = 'south_at_latitude_tilt'
 
-    mc = ModelChain(system, location, orientation_strategy=strategy)
+    mc = ModelChain(system, location, orientation_strategy=strategy,
+                    name='my mc')
 
-    assert mc.__repr__() == ('ModelChain for: PVSystem with tilt:32.2 and '+
-    'azimuth: 180 with Module: None and Inverter: None '+
-    'orientation_strategy: south_at_latitude_tilt clearsky_model: '+
-    'ineichen transposition_model: haydavies solar_position_method: '+
-    'nrel_numpy airmass_model: kastenyoung1989')
+    expected = 'ModelChain: \n  name: my mc\n  orientation_strategy: south_at_latitude_tilt\n  clearsky_model: ineichen\n  transposition_model: haydavies\n  solar_position_method: nrel_numpy\n  airmass_model: kastenyoung1989\n  dc_model: sapm\n  ac_model: snlinverter\n  aoi_model: sapm_aoi_loss\n  spectral_model: sapm_spectral_loss\n  temp_model: sapm_temp\n  losses_model: no_extra_losses'
+
+    assert mc.__repr__() == expected
 
 
 @requires_scipy

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -672,19 +672,21 @@ def test_PVSystem_localize_with_latlon():
 
 
 def test_PVSystem___repr__():
-    system = pvsystem.PVSystem(module='blah', inverter='blarg')
+    system = pvsystem.PVSystem(module='blah', inverter='blarg', name='pv ftw')
 
-    assert system.__repr__()==('PVSystem with tilt:0 and azimuth:'+
-    ' 180 with Module: blah and Inverter: blarg')
+    expected = 'PVSystem: \n  name: pv ftw\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
+
+    assert system.__repr__() == expected
 
 
 def test_PVSystem_localize___repr__():
-    system = pvsystem.PVSystem(module='blah', inverter='blarg')
+    system = pvsystem.PVSystem(module='blah', inverter='blarg', name='pv ftw')
     localized_system = system.localize(latitude=32, longitude=-111)
 
-    assert localized_system.__repr__()==('LocalizedPVSystem with tilt:0 and'+
-    ' azimuth: 180 with Module: blah and Inverter: blarg at '+
-    'Latitude: 32 and Longitude: -111')
+    expected = 'LocalizedPVSystem: \n  name: None\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
+
+    assert localized_system.__repr__() == expected
+
 
 # we could retest each of the models tested above
 # when they are attached to LocalizedPVSystem, but
@@ -707,11 +709,12 @@ def test_LocalizedPVSystem___repr__():
     localized_system = pvsystem.LocalizedPVSystem(latitude=32,
                                                   longitude=-111,
                                                   module='blah',
-                                                  inverter='blarg')
+                                                  inverter='blarg',
+                                                  name='my name')
 
-    assert localized_system.__repr__()==('LocalizedPVSystem with tilt:0 and'+
-    ' azimuth: 180 with Module: blah and Inverter: blarg at Latitude: 32 ' +
-    'and Longitude: -111')
+    expected = 'LocalizedPVSystem: \n  name: None\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
+
+    assert localized_system.__repr__() == expected
 
 
 def test_pvwatts_dc_scalars():

--- a/pvlib/test/test_tracking.py
+++ b/pvlib/test/test_tracking.py
@@ -284,8 +284,8 @@ def test_get_irradiance():
 def test_SingleAxisTracker___repr__():
     system = tracking.SingleAxisTracker(max_angle=45, gcr=.25,
                                         module='blah', inverter='blarg')
-
-    assert system.__repr__() == 'SingleAxisTracker with max_angle: 45'
+    expected = 'SingleAxisTracker: \n  axis_tilt: 0\n  axis_azimuth: 0\n  max_angle: 45\n  backtrack: True\n  gcr: 0.25\n  name: None\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
+    assert system.__repr__() == expected
 
 
 def test_LocalizedSingleAxisTracker___repr__():
@@ -294,9 +294,7 @@ def test_LocalizedSingleAxisTracker___repr__():
                                                            module='blah',
                                                            inverter='blarg')
 
+    expected = 'LocalizedSingleAxisTracker: \n  axis_tilt: 0\n  axis_azimuth: 0\n  max_angle: 90\n  backtrack: True\n  gcr: 0.2857142857142857\n  name: None\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC'
 
-    assert localized_system.__repr__() == ('LocalizedSingleAxisTracker with '+
-                                          'max_angle: 90 at Location: None: '+
-                                          'latitude=32, longitude=-111, ' +
-                                          'tz=UTC, altitude=0')
+    assert localized_system.__repr__() == expected
 

--- a/pvlib/test/test_tracking.py
+++ b/pvlib/test/test_tracking.py
@@ -292,9 +292,10 @@ def test_LocalizedSingleAxisTracker___repr__():
     localized_system = tracking.LocalizedSingleAxisTracker(latitude=32,
                                                            longitude=-111,
                                                            module='blah',
-                                                           inverter='blarg')
+                                                           inverter='blarg',
+                                                           gcr=0.25)
 
-    expected = 'LocalizedSingleAxisTracker: \n  axis_tilt: 0\n  axis_azimuth: 0\n  max_angle: 90\n  backtrack: True\n  gcr: 0.2857142857142857\n  name: None\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC'
+    expected = 'LocalizedSingleAxisTracker: \n  axis_tilt: 0\n  axis_azimuth: 0\n  max_angle: 90\n  backtrack: True\n  gcr: 0.25\n  name: None\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC'
 
     assert localized_system.__repr__() == expected
 

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -165,12 +165,11 @@ class LocalizedSingleAxisTracker(SingleAxisTracker, Location):
         super(LocalizedSingleAxisTracker, self).__init__(**new_kwargs)
 
     def __repr__(self):
+        attrs = ['latitude', 'longitude', 'altitude', 'tz']
         return ('Localized' +
-                super(LocalizedSingleAxisTracker, self).__repr__() +
-                ' at Location: ' +
-                ('{}: latitude={}, longitude={}, tz={}, altitude={}'
-                    .format(self.name, self.latitude, self.longitude,
-                            self.tz, self.altitude)))
+            super(LocalizedSingleAxisTracker, self).__repr__() + '\n  ' +
+            '\n  '.join(
+                (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
 
 def singleaxis(apparent_zenith, apparent_azimuth,

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -29,8 +29,15 @@ class SingleAxisTracker(PVSystem):
         super(SingleAxisTracker, self).__init__(**kwargs)
 
     def __repr__(self):
-        return ('SingleAxisTracker with max_angle: ' +
-                str(self.max_angle))
+        attrs = ['axis_tilt', 'axis_azimuth', 'max_angle', 'backtrack', 'gcr']
+        sat_repr = ('SingleAxisTracker: \n  ' + '\n  '.join(
+            (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
+        # get the parent PVSystem info
+        pvsystem_repr = super(SingleAxisTracker, self).__repr__()
+        # remove the first line (contains 'PVSystem: \n')
+        pvsystem_repr = '\n'.join(pvsystem_repr.split('\n')[1:])
+        return sat_repr + '\n' + pvsystem_repr
+
 
     def singleaxis(self, apparent_zenith, apparent_azimuth):
         tracking_data = singleaxis(apparent_zenith, apparent_azimuth,


### PR DESCRIPTION
I've been wanting more attributes to be included in the string representations of objects. Here is a proposal, but I'm not sure if this is too verbose. This builds on #174.

``` python
In [1]: import pvlib

In [2]: location = pvlib.location.Location(32.2, -110.9, name='Tucson')

In [3]: location
Out[3]:
Location:
  name: Tucson
  latitude: 32.2
  longitude: -110.9
  altitude: 0
  tz: UTC

In [4]: system = pvlib.pvsystem.PVSystem()

In [5]: system
Out[5]:
PVSystem:
  surface_tilt: 0
  surface_azimuth: 180
  module: None
  inverter: None
  albedo: 0.25
  racking_model: open_rack_cell_glassback

In [6]: tracker = pvlib.tracking.SingleAxisTracker()

In [7]: tracker
Out[7]:
SingleAxisTracker:
  axis_tilt: 0
  axis_azimuth: 0
  max_angle: 90
  backtrack: True
  gcr: 0.2857142857142857
  surface_tilt: 0
  surface_azimuth: 180
  module: None
  inverter: None
  albedo: 0.25
  racking_model: open_rack_cell_glassback

In [8]: mc = pvlib.modelchain.ModelChain(
    system, location, dc_model='pvwatts', ac_model='pvwatts', spectral_model='no_loss', 
    losses_model='no_loss', aoi_model='physical')

In [9]: mc
Out[9]:
ModelChain:
  orientation_strategy: south_at_latitude_tilt
  clearsky_model: ineichen
  transposition_model: haydavies
  solar_position_method: nrel_numpy
  airmass_model: kastenyoung1989
  dc_model: pvwatts_dc
  ac_model: pvwatts_inverter
  aoi_model: physical_aoi_loss
  spectral_model: no_spectral_loss
  temp_model: sapm_temp
  losses_model: no_extra_losses
```

Thoughts? Too many attributes? newlines vs. commas?
