### PR TITLE
Improve precision of v_from_i for large arguments

### DIFF
--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1843,7 +1843,7 @@ def v_from_i(resistance_shunt, resistance_series, nNsVth, current,
     # evaluation (above) results in NaN from overflow, 3 iterations
     # of Newton's method gives approximately 8 digits of precision.
     w = logargW
-    order = np.log10(w)
+    order = np.ceil(np.log10(w)).astype(int)
     for i in range(0, 3*order):
         w = w * (1 - np.log(w) + logargW) / (1 + w)
     lambertwterm_log = w

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1843,7 +1843,8 @@ def v_from_i(resistance_shunt, resistance_series, nNsVth, current,
     # evaluation (above) results in NaN from overflow, 3 iterations
     # of Newton's method gives approximately 8 digits of precision.
     w = logargW
-    for i in range(0, 3):
+    order = np.log10(w)
+    for i in range(0, 3*order):
         w = w * (1 - np.log(w) + logargW) / (1 + w)
     lambertwterm_log = w
 


### PR DESCRIPTION
Number of iterations of Newton method should increase with the order of
the argument, to maintain precision.  Not expected to have a significant
effect on most calculated IV curves.