### PR TITLE
add tests and compatibility statement for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: CONDA_ENV=py34
     - python: 3.5
       env: CONDA_ENV=py35
+    - python: 3.6
+      env: CONDA_ENV=py36
 
 addons:
     apt:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 pvlib-python releases may be installed using the ``pip`` and ``conda`` tools.
 Please see the [Installation page](http://pvlib-python.readthedocs.io/en/latest/installation.html) of the documentation for complete instructions.
 
-pvlib-python is compatible with Python versions 2.7, 3.4, 3.5
+pvlib-python is compatible with Python versions 2.7, 3.4, 3.5, 3.6
 
 
 Contributing

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -1,0 +1,18 @@
+name: test_env
+channels:
+    - defaults
+    - conda-forge
+dependencies:
+    - python=3.6
+    - numpy
+    - scipy
+    - pandas
+    - pytz
+    - ephem
+    - numba
+    - siphon
+    - pytest
+    - pytest-cov
+    - nose
+    - pip:
+        - coveralls

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -8,9 +8,9 @@ dependencies:
     - scipy
     - pandas
     - pytz
-    - ephem
-    - numba
-    - siphon
+    #- ephem
+    #- numba
+    #- siphon
     - pytest
     - pytest-cov
     - nose

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -1,6 +1,7 @@
 import sys
 import platform
 
+from pkg_resources import parse_version
 import pandas as pd
 import numpy as np
 import pytest
@@ -25,22 +26,14 @@ requires_ephem = pytest.mark.skipif(not has_ephem, reason='requires ephem')
 
 
 def pandas_0_17():
-    version = tuple(map(int, pd.__version__.split('.')))
-    if version[0] <= 0 and version[1] < 17:
-        return False
-    else:
-        return True
+    return parse_version(pd.__version__) >= parse_version('0.17.0')
 
 needs_pandas_0_17 = pytest.mark.skipif(
     not pandas_0_17(), reason='requires pandas 0.17 or greater')
 
 
 def numpy_1_10():
-    version = tuple(map(int, np.__version__.split('.')))
-    if version[0] <= 1 and version[1] < 10:
-        return False
-    else:
-        return True
+    return parse_version(np.__version__) >= parse_version('1.10.0')
 
 needs_numpy_1_10 = pytest.mark.skipif(
     not numpy_1_10(), reason='requires numpy 1.10 or greater')

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Scientific/Engineering',
 ]
 


### PR DESCRIPTION
All of the pvlib python tests pass on python 3.6 provided that you also install pandas 0.19.2. Not all of the packages are available on conda/conda-forge, so the new TravisCI build in this PR is not working yet. I'll wait to merge until then. 