### PR TITLE
improve forecast test reliability

### DIFF
--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -16,3 +16,4 @@ dependencies:
     - nose
     - pip:
         - coveralls
+        - pytest-timeout

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -1,7 +1,7 @@
 name: test_env
 channels:
+    - conda-forge
     - defaults
-    - http://conda.anaconda.org/conda-forge
 dependencies:
     - python=2.7
     - numpy

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -1,7 +1,7 @@
 name: test_env
 channels:
-    - defaults
     - conda-forge
+    - defaults
 dependencies:
     - python=3.4
     - numpy

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -16,3 +16,4 @@ dependencies:
     - nose
     - pip:
         - coveralls
+        - pytest-timeout

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -16,3 +16,4 @@ dependencies:
     - nose
     - pip:
         - coveralls
+        - pytest-timeout

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -1,7 +1,7 @@
 name: test_env
 channels:
-    - defaults
     - conda-forge
+    - defaults
 dependencies:
     - python=3.5
     - numpy

--- a/docs/sphinx/source/whatsnew/v0.4.4.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.4.txt
@@ -15,6 +15,15 @@ Documentation
 * Fixes broken Classes link in the v0.3.0 documentation.
 
 
+Bug fixes
+~~~~~~~~~
+
+* Resolved several issues with the forecast module tests. Library import
+  errors were resolved by prioritizing the conda-forge channel over the
+  default channel. Stalled ci runs were resolved by adding a timeout to
+  the HRRR_ESRL test. (:issue:`293`)
+
+
 Contributors
 ~~~~~~~~~~~~
 

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -7,6 +7,9 @@ import numpy as np
 import pytest
 
 
+skip_windows = pytest.mark.skipif('win' in sys.platform,
+                                  reason='does not run on windows')
+
 try:
     import scipy
     has_scipy = True

--- a/pvlib/test/test_forecast.py
+++ b/pvlib/test/test_forecast.py
@@ -30,7 +30,9 @@ if has_siphon:
     _end = _start + pd.Timedelta(days=1)
     _modelclasses = [
         GFS, NAM, HRRR, NDFD, RAP,
-        pytest.mark.xfail(HRRR_ESRL, reason="HRRR_ESRL is unreliable")]
+        pytest.mark.xfail(
+            pytest.mark.timeout(HRRR_ESRL, timeout=60),
+            reason="HRRR_ESRL is unreliable")]
     _working_models = []
     _variables = ['temp_air', 'wind_speed', 'total_clouds', 'low_clouds',
                   'mid_clouds', 'high_clouds', 'dni', 'dhi', 'ghi',]

--- a/pvlib/test/test_forecast.py
+++ b/pvlib/test/test_forecast.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
 
-from conftest import requires_siphon, has_siphon
+from conftest import requires_siphon, has_siphon, skip_windows
 
 pytestmark = pytest.mark.skipif(not has_siphon, reason='requires siphon')
 
@@ -30,9 +30,10 @@ if has_siphon:
     _end = _start + pd.Timedelta(days=1)
     _modelclasses = [
         GFS, NAM, HRRR, NDFD, RAP,
-        pytest.mark.xfail(
-            pytest.mark.timeout(HRRR_ESRL, timeout=60),
-            reason="HRRR_ESRL is unreliable")]
+        skip_windows(
+            pytest.mark.xfail(
+                pytest.mark.timeout(HRRR_ESRL, timeout=60),
+                reason="HRRR_ESRL is unreliable"))]
     _working_models = []
     _variables = ['temp_air', 'wind_speed', 'total_clouds', 'low_clouds',
                   'mid_clouds', 'high_clouds', 'dni', 'dhi', 'ghi',]


### PR DESCRIPTION
Resolved several issues with the forecast module tests. Library import errors were resolved by prioritizing the conda-forge channel over the default channel. Stalled ci runs were resolved by adding a timeout to the HRRR_ESRL test. Items 3 and 4 of issue #293.

It adds a test requirement, pytest-timeout, that is not particularly popular. The pytest-timeout plugin is part of the pytest-dev organization, though, so it shouldn't become abandonware. For now, I think this is preferable to writing our own timeout code.

Still more work to do to fully resolve #293, but this at least gets the builds working most of the time instead of none of the time. Assuming the Travis/Appveyor builds pass, I'll merge this Monday afternoon/evening unless there are objections.