### PR TITLE
set default module and inverter_parameters to empty dict

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.4.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.4.txt
@@ -10,6 +10,14 @@ Enhancements
   improvements by Ineichen and Perez to extend range of air mass (:issue:`278`)
 
 
+API Changes
+~~~~~~~~~~~
+
+* Change PVSystem default module_parameters and inverter_parameters to
+  empty dict. Code that relied on these attributes being None or raising
+  a TypeError will need to be updated. (issue:`294`)
+
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -133,13 +133,19 @@ class PVSystem(object):
 
         # could tie these together with @property
         self.module = module
-        self.module_parameters = module_parameters
+        if module_parameters is None:
+            self.module_parameters = {}
+        else:
+            self.module_parameters = module_parameters
 
         self.modules_per_string = modules_per_string
         self.strings_per_inverter = strings_per_inverter
 
         self.inverter = inverter
-        self.inverter_parameters = inverter_parameters
+        if inverter_parameters is None:
+            self.inverter_parameters = {}
+        else:
+            self.inverter_parameters = inverter_parameters
 
         self.racking_model = racking_model
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -615,6 +615,9 @@ def test_snlinverter_Pnt_micro(sam_data):
 
 def test_PVSystem_creation():
     pv_system = pvsystem.PVSystem(module='blah', inverter='blarg')
+    # ensure that parameter attributes are dict-like. GH 294
+    pv_system.module_parameters['pdc0'] = 1
+    pv_system.inverter_parameters['Paco'] = 1
 
 
 def test_PVSystem_get_aoi():


### PR DESCRIPTION
closes #294. This is a very minor API change, but let me know if you think it should be delayed until 0.5.