### PR TITLE
decrease merge conflicts in whatsnew

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 pvlib/version.py export-subst
+
+# reduce the number of merge conflicts
+docs/sphinx/source/whatsnew/v*.txt merge=union


### PR DESCRIPTION
We occasionally run into a silly situation in which we need to resolve merge conflicts in a whatsnew file because multiple users have added new features. 

This PR should reduce the number of merge conflicts in the whatsnew files by telling git to take the union of the changes to the whatsnew files. I saw this trick on an xarray PR, which got it from numpy/numpy#8612

The downside is that I (or whoever releases pvlib in the future) will probably need to remove some erroneous blank lines from the whatsnew file when preparing a release.

I tested this locally and it worked.