### PR TITLE
Change method of multi-inheritance to allow kwargs in parent class of LocalizedPVSystem and LocalizedSingleAxisTracker

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -100,7 +100,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['whatsnew/*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.4.6.rst
 .. include:: whatsnew/v0.4.5.txt
 .. include:: whatsnew/v0.4.4.txt
 .. include:: whatsnew/v0.4.3.txt

--- a/docs/sphinx/source/whatsnew/v0.4.6.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.6.rst
@@ -8,7 +8,8 @@ Bug fixes
 ~~~~~~~~~
 
 * Method of multi-inheritance has changed to make it possible to use kwargs in
-  the parent class (:issue:`330`)
+  the parent classes of LocalizedPVSystem and LocalizedSingleAxisTracker
+  (:issue:`330`)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.4.6.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.6.rst
@@ -7,6 +7,9 @@ v0.4.6 ()
 Bug fixes
 ~~~~~~~~~
 
+* Method of multi-inheritance has changed to make it possible to use kwargs in
+  the parent class (:issue:`330`)
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -24,3 +27,4 @@ Contributors
 ~~~~~~~~~~~~
 
 * Will Holmgren
+* Uwe Krien

--- a/docs/sphinx/source/whatsnew/v0.4.6.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.6.rst
@@ -1,0 +1,26 @@
+.. _whatsnew_0460:
+
+v0.4.6 ()
+---------
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+API Changes
+~~~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+
+* Will Holmgren

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -79,10 +79,6 @@ class Location(object):
 
         self.name = name
 
-        # needed for tying together Location and PVSystem in LocalizedPVSystem
-        # if LocalizedPVSystem signature is reversed
-        # super(Location, self).__init__(**kwargs)
-
     def __repr__(self):
         attrs = ['name', 'latitude', 'longitude', 'altitude', 'tz']
         return ('Location: \n  ' + '\n  '.join(

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -149,9 +149,6 @@ class PVSystem(object):
 
         self.racking_model = racking_model
 
-        # needed for tying together Location and PVSystem in LocalizedPVSystem
-        super(PVSystem, self).__init__(**kwargs)
-
     def __repr__(self):
         attrs = ['name', 'surface_tilt', 'surface_azimuth', 'module',
                  'inverter', 'albedo', 'racking_model']
@@ -584,7 +581,8 @@ class LocalizedPVSystem(PVSystem, Location):
                           list(loc_dict.items()) +
                           list(kwargs.items()))
 
-        super(LocalizedPVSystem, self).__init__(**new_kwargs)
+        PVSystem.__init__(self, **new_kwargs)
+        Location.__init__(self, **new_kwargs)
 
     def __repr__(self):
         attrs = [

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -150,7 +150,7 @@ class PVSystem(object):
         self.racking_model = racking_model
 
         # needed for tying together Location and PVSystem in LocalizedPVSystem
-        super(PVSystem, self).__init__()
+        super(PVSystem, self).__init__(**kwargs)
 
     def __repr__(self):
         attrs = ['name', 'surface_tilt', 'surface_azimuth', 'module',

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -150,7 +150,7 @@ class PVSystem(object):
         self.racking_model = racking_model
 
         # needed for tying together Location and PVSystem in LocalizedPVSystem
-        super(PVSystem, self).__init__(**kwargs)
+        super(PVSystem, self).__init__()
 
     def __repr__(self):
         attrs = ['name', 'surface_tilt', 'surface_azimuth', 'module',

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -751,7 +751,7 @@ def test_LocalizedPVSystem___repr__():
                                                   inverter='blarg',
                                                   name='my name')
 
-    expected = 'LocalizedPVSystem: \n  name: None\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
+    expected = 'LocalizedPVSystem: \n  name: my name\n  latitude: 32\n  longitude: -111\n  altitude: 0\n  tz: UTC\n  surface_tilt: 0\n  surface_azimuth: 180\n  module: blah\n  inverter: blarg\n  albedo: 0.25\n  racking_model: open_rack_cell_glassback'
 
     assert localized_system.__repr__() == expected
 

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -162,7 +162,8 @@ class LocalizedSingleAxisTracker(SingleAxisTracker, Location):
                           list(loc_dict.items()) +
                           list(kwargs.items()))
 
-        super(LocalizedSingleAxisTracker, self).__init__(**new_kwargs)
+        SingleAxisTracker.__init__(self, **new_kwargs)
+        Location.__init__(self, **new_kwargs)
 
     def __repr__(self):
         attrs = ['latitude', 'longitude', 'altitude', 'tz']

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -38,7 +38,6 @@ class SingleAxisTracker(PVSystem):
         pvsystem_repr = '\n'.join(pvsystem_repr.split('\n')[1:])
         return sat_repr + '\n' + pvsystem_repr
 
-
     def singleaxis(self, apparent_zenith, apparent_azimuth):
         tracking_data = singleaxis(apparent_zenith, apparent_azimuth,
                                    self.axis_tilt, self.axis_azimuth,
@@ -168,9 +167,9 @@ class LocalizedSingleAxisTracker(SingleAxisTracker, Location):
     def __repr__(self):
         attrs = ['latitude', 'longitude', 'altitude', 'tz']
         return ('Localized' +
-            super(LocalizedSingleAxisTracker, self).__repr__() + '\n  ' +
-            '\n  '.join(
-                (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
+                super(LocalizedSingleAxisTracker, self).__repr__() + '\n  ' +
+                '\n  '.join(
+                    (attr + ': ' + str(getattr(self, attr)) for attr in attrs)))
 
 
 def singleaxis(apparent_zenith, apparent_azimuth,


### PR DESCRIPTION
If keyword arguments are present a `TypeError` will be raised, so it is better to remove it from the `super` call.

As I normally initialise classes using a parameter dictionary, so it often happens that I will have additional keys. Therefore it is convenient if the PVSystem class takes `**kwargs` but they should not be passed on.