### PR TITLE
defer ForecastModel network operations until necessary

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.5.txt
+++ b/docs/sphinx/source/whatsnew/v0.4.5.txt
@@ -25,6 +25,9 @@ Enhancements
 
 * Added irradiance.dni method that determines DNI from GHI and DHI and corrects
   unreasonable DNI values during sunrise/sunset transitions
+* ForecastModel will now only connect to the Unidata server when necessary,
+  rather than when the object is created. This supports offline work
+  and speeds up analysis of previously downloaded data.
 
 
 Contributors

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -118,12 +118,16 @@ class ForecastModel(object):
         self.model_type = model_type
         self.model_name = model_name
         self.set_type = set_type
+        self.connected = False
+
+    def connect_to_catalog(self):
         self.catalog = TDSCatalog(self.catalog_url)
-        self.fm_models = TDSCatalog(self.catalog.catalog_refs[model_type].href)
+        self.fm_models = TDSCatalog(
+            self.catalog.catalog_refs[self.model_type].href)
         self.fm_models_list = sorted(list(self.fm_models.catalog_refs.keys()))
 
         try:
-            model_url = self.fm_models.catalog_refs[model_name].href
+            model_url = self.fm_models.catalog_refs[self.model_name].href
         except ParseError:
             raise ParseError(self.model_name + ' model may be unavailable.')
 
@@ -137,6 +141,7 @@ class ForecastModel(object):
 
         self.datasets_list = list(self.model.datasets.keys())
         self.set_dataset()
+        self.connected = True
 
     def __repr__(self):
         return '{}, {}'.format(self.model_name, self.set_type)
@@ -224,6 +229,10 @@ class ForecastModel(object):
         forecast_data : DataFrame
             column names are the weather model's variable names.
         """
+
+        if not self.connected:
+            self.connect_to_catalog()
+
         if vert_level is not None:
             self.vert_level = vert_level
 


### PR DESCRIPTION
ForecastModel will now only connect to the Unidata server when necessary, rather than when the object is created. This supports offline work and speeds up analysis of previously downloaded data.