### PR TITLE
Removes var w from _calc_d (Issue #344)

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.4.6.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.6.rst
@@ -18,7 +18,7 @@ Enhancements
 
 API Changes
 ~~~~~~~~~~~
-
+* Removed parameter w from _calc_d (:issue:`344`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -29,3 +29,4 @@ Contributors
 
 * Will Holmgren
 * Uwe Krien
+* Alaina Kafkes

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -525,7 +525,7 @@ def _calc_taud(w, aod700, p):
     return taud
 
 
-def _calc_d(w, aod700, p):
+def _calc_d(aod700, p):
     """Calculate the d coefficient."""
 
     p0 = 101325.

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -411,7 +411,7 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
     g = _calc_g(w, aod700)
 
     taud = _calc_taud(w, aod700, p)
-    d = _calc_d(w, aod700, p)
+    d = _calc_d(aod700, p)
 
     # this prevents the creation of nans at night instead of 0s
     # it's also friendly to scalar and series inputs


### PR DESCRIPTION
First commit removes var w from declaration of _calc_d, second commit removes var w from invocation of _calc_d.