### PR TITLE
add ModelChain tutorial, nbsphinx extension

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -22,3 +22,4 @@ dependencies:
     - hdf4=4.2.12
     - sphinx_rtd_theme
     - docutils
+    - nbsphinx

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
+    'nbsphinx'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -100,7 +101,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['whatsnew/*']
+exclude_patterns = ['whatsnew/*', '**.ipynb_checkpoints']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -316,3 +317,4 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
 }
 
+nbsphinx_allow_errors = True

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -74,6 +74,7 @@ Contents
    whatsnew
    installation
    contributing
+   modelchain
    timetimezones
    clearsky
    forecasts

--- a/docs/sphinx/source/modelchain.ipynb
+++ b/docs/sphinx/source/modelchain.ipynb
@@ -385,7 +385,7 @@
     "\n",
     "Next, ModelChain.run_model calls the wrapper methods for AOI loss, spectral loss, effective irradiance, cell temperature, DC power, AC power, and other losses. These methods are assigned to standard names, as described in the next section.\n",
     "\n",
-    "The methods called by ModelChain.run_model store their results in a series of ModelChain attributes: ``times, solar_position, airmass, irradiance, total_irrad, effective_irradiance, weather, temps, aoi, aoi_modifier, spectral_modifier, dc, ac, losses``."
+    "The methods called by ModelChain.run_model store their results in a series of ModelChain attributes: ``times``, ``solar_position``, ``airmass``, ``irradiance``, ``total_irrad``, ``effective_irradiance``, ``weather``, ``temps``, ``aoi``, ``aoi_modifier``, ``spectral_modifier``, ``dc``, ``ac``, ``losses``."
    ]
   },
   {

--- a/docs/sphinx/source/modelchain.ipynb
+++ b/docs/sphinx/source/modelchain.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ModelChain"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "The :py:class:`~pvlib.modelchain.ModelChain` class provides a high-level interface for standardized PV modeling. The class aims to automate much of the modeling process while providing user-control and remaining extensible. This guide aims to build users' understanding of the ModelChain class. It assumes some familiarity with object-oriented code in Python, but most information should be understandable even without a solid understanding of classes.\n",
+    "\n",
+    "A :py:class:`~pvlib.modelchain.ModelChain` is composed of a :py:class:`~pvlib.pvsystem.PVSystem` object and a :py:class:`~pvlib.location.Location` object. A PVSystem object represents an assembled collection of modules, inverters, etc., a Location object represents a particular place on the planet, and a ModelChain object describes the modeling chain used to calculate a system's output at that location. The PVSystem and Location objects will be described in detail in another guide.\n",
+    "\n",
+    "Modeling with a ModelChain typically involves 3 steps:\n",
+    "\n",
+    "1. Creating the ModelChain.\n",
+    "2. Executing the ModelChain.run_model method with prepared weather data.\n",
+    "3. Examining the model results that run_model stored in attributes of the ModelChain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A simple ModelChain example\n",
+    "\n",
+    "Before delving into the intricacies of ModelChain, we provide a brief example of the modeling steps using ModelChain. First, we import pvlib's objects, module data, and inverter data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# pvlib imports\n",
+    "import pvlib\n",
+    "\n",
+    "from pvlib.pvsystem import PVSystem\n",
+    "from pvlib.location import Location\n",
+    "from pvlib.modelchain import ModelChain\n",
+    "\n",
+    "# load some module and inverter specifications\n",
+    "sandia_modules = pvlib.pvsystem.retrieve_sam('SandiaMod')\n",
+    "cec_inverters = pvlib.pvsystem.retrieve_sam('cecinverter')\n",
+    "\n",
+    "sandia_module = sandia_modules['Canadian_Solar_CS5P_220M___2009_']\n",
+    "cec_inverter = cec_inverters['ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we create a Location object, a PVSystem object, and a ModelChain object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "location = Location(latitude=32.2, longitude=-110.9)\n",
+    "system = PVSystem(surface_tilt=20, surface_azimuth=200, \n",
+    "                  module_parameters=sandia_module,\n",
+    "                  inverter_parameters=cec_inverter)\n",
+    "mc = ModelChain(system, location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we run a model with some simple weather data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "weather = pd.DataFrame([[1050, 1000, 100, 30, 5]], \n",
+    "                       columns=['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed'], \n",
+    "                       index=[pd.Timestamp('20170401 1200', tz='US/Arizona')])\n",
+    "\n",
+    "mc.run_model(times=weather.index, weather=weather);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ModelChain stores the modeling results on a series of attributes. A few examples are shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.aoi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.dc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The remainder of this guide examines the ModelChain functionality and explores common pitfalls."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining a ModelChain\n",
+    "\n",
+    "A ModelChain object is defined by:\n",
+    "\n",
+    "1. The properties of its Location and PVSystem objects\n",
+    "2. The keyword arguments passed to it at construction\n",
+    "\n",
+    "ModelChain uses the keyword arguments passed to it to determine the models for the simulation. The documentation describes the allowed values for each keyword argument. If a keyword argument is not supplied, ModelChain will attempt to infer the correct set of models by inspecting the Location and PVSystem attributes. \n",
+    "\n",
+    "Below, we show some examples of how to define a ModelChain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's make the most basic Location and PVSystem objects and build from there."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "location = Location(32.2, -110.9)\n",
+    "poorly_specified_system = PVSystem()\n",
+    "print(location)\n",
+    "print(poorly_specified_system)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These basic objects do not have enough information for ModelChain to be able to automatically determine its set of models, so the ModelChain will throw an error when we try to create it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ModelChain(poorly_specified_system, location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If our goal is simply to get the object constructed, we can specify the models that the ModelChain should use. We'll have to fill in missing data on the PVSystem object later, but maybe that's desirable in some workflows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc = ModelChain(poorly_specified_system, location, \n",
+    "                dc_model='singlediode', ac_model='snlinverter', \n",
+    "                aoi_model='physical', spectral_model='no_loss')\n",
+    "print(mc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, without additional information, the ModelChain fails at run time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.run_model(times=weather.index, weather=weather)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ModelChain attempted to execute the PVSystem object's ``singlediode`` method, and the method failed because the object's ``module_parameters`` did not include the data necessary to run the model. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define a PVSystem with a module from the SAPM database and an inverter from the CEC database. ModelChain will examine the PVSystem object's properties and determine that it should choose the SAPM DC model, AC model, AOI loss model, and spectral loss model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sapm_system = PVSystem(module_parameters=sandia_module, inverter_parameters=cec_inverter)\n",
+    "mc = ModelChain(system, location)\n",
+    "print(mc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.run_model(times=weather.index, weather=weather)\n",
+    "mc.ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we will specify PVWatts-relevant information in the PVSystem construction. ModelChain will automatically determine that it should choose PVWatts DC and AC models. ModelChain still needs us to specify ``aoi_model`` and ``spectral_model`` keyword arguments because the ``system.module_parameters`` dictionary does not contain enough information to determine which of those models to choose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pvwatts_system = PVSystem(module_parameters={'pdc0': 240, 'gamma_pdc': -0.004})\n",
+    "mc = ModelChain(pvwatts_system, location, \n",
+    "                aoi_model='physical', spectral_model='no_loss')\n",
+    "print(mc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.run_model(times=weather.index, weather=weather)\n",
+    "mc.ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "User-supplied keyword arguments override ModelChain's inspection methods. For example, we can tell ModelChain to use different loss functions for a PVSystem that contains SAPM-specific parameters. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sapm_system = PVSystem(module_parameters=sandia_module, inverter_parameters=cec_inverter)\n",
+    "mc = ModelChain(system, location, aoi_model='physical', spectral_model='no_loss')\n",
+    "print(mc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.run_model(times=weather.index, weather=weather)\n",
+    "mc.ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course, these choices can also lead to failure when executing ``run_model`` if your system objects do not contain the required parameters for running the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demystifying ModelChain internals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ModelChain class has a lot going in inside it in order to make users' code as simple as possible.\n",
+    "\n",
+    "The key parts of ModelChain are:\n",
+    "\n",
+    "1. The run_model method\n",
+    "1. A set of methods that wrap and call the PVSystem methods.\n",
+    "1. A set of methods that inspect user-supplied objects to determine the appropriate default models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### run_model\n",
+    "\n",
+    "Most users will only interact with the ModelChain.run_model method. The run_model method, shown below, calls a series of methods to complete the modeling steps. The first method, ModelChain.prepare_inputs, computes parameters such as solar position, airmass, angle of incidence, and plane of array irradiance. The prepare_inputs method also assigns default values for irradiance (clear sky), temperature (20 C), and wind speed (0 m/s) if these inputs are not provided.\n",
+    "\n",
+    "Next, ModelChain.run_model calls the wrapper methods for AOI loss, spectral loss, effective irradiance, cell temperature, DC power, AC power, and other losses. These methods are assigned to standard names, as described in the next section.\n",
+    "\n",
+    "The methods called by ModelChain.run_model store their results in a series of ModelChain attributes: ``times, solar_position, airmass, irradiance, total_irrad, effective_irradiance, weather, temps, aoi, aoi_modifier, spectral_modifier, dc, ac, losses``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.source(mc.run_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, the ModelChain.complete_irradiance method is available for calculating the full set of GHI, DNI, or DHI if only two of these three series are provided. The completed dataset can then be passed to ModelChain.run_model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wrapping methods into a unified API\n",
+    "\n",
+    "Readers may notice that the source code of the ModelChain.run_model method is model-agnostic. ModelChain.run_model calls generic methods such as ``self.dc_model`` rather than a specific model such as ``singlediode``. So how does the ModelChain.run_model know what models it's supposed to run? The answer comes in two parts, and allows us to explore more of the ModelChain API along the way.\n",
+    "\n",
+    "First, ModelChain has a set of methods that wrap the PVSystem methods that perform the calculations (or further wrap the pvsystem.py module's functions). Each of these methods takes the same arguments (``self``) and sets the same attributes, thus creating a uniform API. For example, the ModelChain.pvwatts_dc method is shown below. Its only argument is ``self``, and it sets the ``dc`` attribute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.source(mc.pvwatts_dc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ModelChain.pvwatts_dc method calls the pvwatts_dc method of the PVSystem object that we supplied using data that is stored in its own ``effective_irradiance`` and ``temps`` attributes. Then it assigns the result to the ``dc`` attribute of the ModelChain object. The code below shows a simple example of this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# make the objects\n",
+    "pvwatts_system = PVSystem(module_parameters={'pdc0': 240, 'gamma_pdc': -0.004})\n",
+    "mc = ModelChain(pvwatts_system, location, \n",
+    "                aoi_model='no_loss', spectral_model='no_loss')\n",
+    "\n",
+    "# manually assign data to the attributes that ModelChain.pvwatts_dc will need.\n",
+    "# for standard workflows, run_model would assign these attributes.\n",
+    "mc.effective_irradiance = pd.Series(1000, index=[pd.Timestamp('20170401 1200-0700')])\n",
+    "mc.temps = pd.DataFrame({'temp_cell': 50, 'temp_module': 50}, index=[pd.Timestamp('20170401 1200-0700')])\n",
+    "\n",
+    "# run ModelChain.pvwatts_dc and look at the result\n",
+    "mc.pvwatts_dc()\n",
+    "mc.dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ModelChain.sapm method works similarly to the ModelChain.pvwatts_dc method. It calls the PVSystem.sapm method using stored data, then assigns the result to the ``dc`` attribute. The ModelChain.sapm method differs from the ModelChain.pvwatts_dc method in three notable ways. First, the PVSystem.sapm method expects different units for effective irradiance, so ModelChain handles the conversion for us. Second, the PVSystem.sapm method (and the PVSystem.singlediode method) returns a DataFrame with current, voltage, and power parameters rather than a simple Series of power. Finally, this current and voltage information allows the SAPM and single diode model paths to support the concept of modules in series and parallel, which is handled by the PVSystem.scale_voltage_current_power method. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.source(mc.sapm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# make the objects\n",
+    "sapm_system = PVSystem(module_parameters=sandia_module, inverter_parameters=cec_inverter)\n",
+    "mc = ModelChain(sapm_system, location)\n",
+    "\n",
+    "# manually assign data to the attributes that ModelChain.sapm will need.\n",
+    "# for standard workflows, run_model would assign these attributes.\n",
+    "mc.effective_irradiance = pd.Series(1000, index=[pd.Timestamp('20170401 1200-0700')])\n",
+    "mc.temps = pd.DataFrame({'temp_cell': 50, 'temp_module': 50}, index=[pd.Timestamp('20170401 1200-0700')])\n",
+    "\n",
+    "# run ModelChain.sapm and look at the result\n",
+    "mc.sapm()\n",
+    "mc.dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We've established that the ``ModelChain.pvwatts_dc`` and ``ModelChain.sapm`` have the same API: they take the same arugments (``self``) and they both set the ``dc`` attribute.\\* Because the methods have the same API, we can call them in the same way. ModelChain includes a large number of methods that perform the same API-unification roles for each modeling step.\n",
+    "\n",
+    "Again, so how does the ModelChain.run_model know which models it's supposed to run?\n",
+    "\n",
+    "At object construction, ModelChain assigns the desired model's method (e.g. ``ModelChain.pvwatts_dc``) to the corresponding generic attribute (e.g. ``ModelChain.dc_model``) using a method described in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pvwatts_system = PVSystem(module_parameters={'pdc0': 240, 'gamma_pdc': -0.004})\n",
+    "mc = ModelChain(pvwatts_system, location, \n",
+    "                aoi_model='no_loss', spectral_model='no_loss')\n",
+    "mc.dc_model.__func__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ModelChain.run_model method can ignorantly call ``self.dc_module`` because the API is the same for all methods that may be assigned to this attribute."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\* some readers may object that the API is *not* actually the same because the type of the ``dc`` attribute is different (Series vs. DataFrame)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inferring models\n",
+    "\n",
+    "How does ModelChain infer the appropriate model types? ModelChain uses a series of methods (ModelChain.infer_dc_model, ModelChain.infer_ac_model, etc.) that examine the user-supplied PVSystem object. The inference methods use set logic to assign one of the model-specific methods, such as ModelChain.sapm or ModelChain.snlinverter, to the universal method names ModelChain.dc_model and ModelChain.ac_model. A few examples are shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.source(mc.infer_dc_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "np.source(mc.infer_ac_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User-defined models\n",
+    "\n",
+    "Users may also write their own functions and pass them as arguments to ModelChain. The first argument of the function must be a ModelChain instance. For example, the functions below implement the PVUSA model and a wrapper function appropriate for use with ModelChain. This follows the pattern of implementing the core models using the simplest possible functions, and then implementing wrappers to make them easier to use in specific applications. Of course, you could implement it in a single function if you wanted to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def pvusa(poa_global, wind_speed, temp_air, a, b, c, d):\n",
+    "    \"\"\"\n",
+    "    Calculates system power according to the PVUSA equation\n",
+    "    \n",
+    "    P = I * (a + b*I + c*W + d*T)\n",
+    "    \n",
+    "    where\n",
+    "    P is the output power,\n",
+    "    I is the plane of array irradiance,\n",
+    "    W is the wind speed, and\n",
+    "    T is the temperature\n",
+    "    a, b, c, d are empirically derived parameters.\n",
+    "    \"\"\"\n",
+    "    return poa_global * (a + b*poa_global + c*wind_speed + d*temp_air)\n",
+    "\n",
+    "\n",
+    "def pvusa_mc_wrapper(mc):\n",
+    "    # calculate the dc power and assign it to mc.dc\n",
+    "    mc.dc = pvusa(mc.total_irrad['poa_global'], mc.weather['wind_speed'], mc.weather['temp_air'],\n",
+    "                  mc.system.module_parameters['a'], mc.system.module_parameters['b'],\n",
+    "                  mc.system.module_parameters['c'], mc.system.module_parameters['d'])\n",
+    "    \n",
+    "    # returning mc is optional, but enables method chaining\n",
+    "    return mc\n",
+    "\n",
+    "\n",
+    "def pvusa_ac_mc_wrapper(mc):\n",
+    "    # keep it simple\n",
+    "    mc.ac = mc.dc\n",
+    "    return mc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "module_parameters = {'a': 0.2, 'b': 0.00001, 'c': 0.001, 'd': -0.00005}\n",
+    "pvusa_system = PVSystem(module_parameters=module_parameters)\n",
+    "\n",
+    "mc = ModelChain(pvusa_system, location, \n",
+    "                dc_model=pvusa_mc_wrapper, ac_model=pvusa_ac_mc_wrapper,\n",
+    "                aoi_model='no_loss', spectral_model='no_loss')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A ModelChain object uses Python's functools.partial function to assign itself as the argument to the user-supplied functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.dc_model.func"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The end result is that ModelChain.run_model works as expected!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mc.run_model(times=weather.index, weather=weather)\n",
+    "mc.dc"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/sphinx/source/modelchain.ipynb
+++ b/docs/sphinx/source/modelchain.ipynb
@@ -13,15 +13,15 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The :py:class:`~pvlib.modelchain.ModelChain` class provides a high-level interface for standardized PV modeling. The class aims to automate much of the modeling process while providing user-control and remaining extensible. This guide aims to build users' understanding of the ModelChain class. It assumes some familiarity with object-oriented code in Python, but most information should be understandable even without a solid understanding of classes.\n",
+    "The :py:class:`~.modelchain.ModelChain` class provides a high-level interface for standardized PV modeling. The class aims to automate much of the modeling process while providing user-control and remaining extensible. This guide aims to build users' understanding of the ModelChain class. It assumes some familiarity with object-oriented code in Python, but most information should be understandable even without a solid understanding of classes.\n",
     "\n",
-    "A :py:class:`~pvlib.modelchain.ModelChain` is composed of a :py:class:`~pvlib.pvsystem.PVSystem` object and a :py:class:`~pvlib.location.Location` object. A PVSystem object represents an assembled collection of modules, inverters, etc., a Location object represents a particular place on the planet, and a ModelChain object describes the modeling chain used to calculate a system's output at that location. The PVSystem and Location objects will be described in detail in another guide.\n",
+    "A :py:class:`~.modelchain.ModelChain` is composed of a :py:class:`~.pvsystem.PVSystem` object and a :py:class:`~.location.Location` object. A PVSystem object represents an assembled collection of modules, inverters, etc., a Location object represents a particular place on the planet, and a ModelChain object describes the modeling chain used to calculate a system's output at that location. The PVSystem and Location objects will be described in detail in another guide.\n",
     "\n",
-    "Modeling with a ModelChain typically involves 3 steps:\n",
+    "Modeling with a :py:class:`~.ModelChain` typically involves 3 steps:\n",
     "\n",
-    "1. Creating the ModelChain.\n",
-    "2. Executing the ModelChain.run_model method with prepared weather data.\n",
-    "3. Examining the model results that run_model stored in attributes of the ModelChain."
+    "1. Creating the :py:class:`~.ModelChain`.\n",
+    "2. Executing the :py:meth:`ModelChain.run_model() <.ModelChain.run_model>` method with prepared weather data.\n",
+    "3. Examining the model results that :py:meth:`~.ModelChain.run_model` stored in attributes of the :py:class:`~.ModelChain`."
    ]
   },
   {
@@ -79,6 +79,24 @@
     "                  module_parameters=sandia_module,\n",
     "                  inverter_parameters=cec_inverter)\n",
     "mc = ModelChain(system, location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printing a ModelChain object will display its models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(mc)"
    ]
   },
   {
@@ -154,11 +172,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defining a ModelChain\n",
+    "## Defining a ModelChain"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "A :py:class:`~pvlib.modelchain.ModelChain` object is defined by:\n",
     "\n",
-    "A ModelChain object is defined by:\n",
-    "\n",
-    "1. The properties of its Location and PVSystem objects\n",
+    "1. The properties of its :py:class:`~pvlib.pvsystem.PVSystem` and :py:class:`~pvlib.location.Location` objects\n",
     "2. The keyword arguments passed to it at construction\n",
     "\n",
     "ModelChain uses the keyword arguments passed to it to determine the models for the simulation. The documentation describes the allowed values for each keyword argument. If a keyword argument is not supplied, ModelChain will attempt to infer the correct set of models by inspecting the Location and PVSystem attributes. \n",
@@ -227,10 +252,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "As expected, without additional information, the ModelChain fails at run time."
+    "As expected, without additional information, the :py:meth:`~.ModelChain.run_model` method fails at run time."
    ]
   },
   {
@@ -245,10 +272,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "The ModelChain attempted to execute the PVSystem object's ``singlediode`` method, and the method failed because the object's ``module_parameters`` did not include the data necessary to run the model. "
+    "The ModelChain attempted to execute the PVSystem object's :py:meth:`~pvlib.pvsystem.PVSystem.singlediode` method, and the method failed because the object's ``module_parameters`` did not include the data necessary to run the model. "
    ]
   },
   {
@@ -287,7 +316,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we will specify PVWatts-relevant information in the PVSystem construction. ModelChain will automatically determine that it should choose PVWatts DC and AC models. ModelChain still needs us to specify ``aoi_model`` and ``spectral_model`` keyword arguments because the ``system.module_parameters`` dictionary does not contain enough information to determine which of those models to choose."
+    "Alternatively, we could have specified single diode or PVWatts related information in the PVSystem construction. Here we pass PVWatts data to the PVSystem. ModelChain will automatically determine that it should choose PVWatts DC and AC models. ModelChain still needs us to specify ``aoi_model`` and ``spectral_model`` keyword arguments because the ``system.module_parameters`` dictionary does not contain enough information to determine which of those models to choose."
    ]
   },
   {
@@ -349,10 +378,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "Of course, these choices can also lead to failure when executing ``run_model`` if your system objects do not contain the required parameters for running the model."
+    "Of course, these choices can also lead to failure when executing :py:meth:`~pvlib.modelchain.ModelChain.run_model` if your system objects do not contain the required parameters for running the model."
    ]
   },
   {
@@ -363,14 +394,16 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
     "The ModelChain class has a lot going in inside it in order to make users' code as simple as possible.\n",
     "\n",
     "The key parts of ModelChain are:\n",
     "\n",
-    "1. The run_model method\n",
+    "1. The :py:meth:`ModelChain.run_model() <.ModelChain.run_model>` method\n",
     "1. A set of methods that wrap and call the PVSystem methods.\n",
     "1. A set of methods that inspect user-supplied objects to determine the appropriate default models."
    ]
@@ -379,13 +412,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### run_model\n",
+    "### run_model"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Most users will only interact with the :py:meth:`~pvlib.modelchain.ModelChain.run_model` method. The :py:meth:`~pvlib.modelchain.ModelChain.run_model` method, shown below, calls a series of methods to complete the modeling steps. The first method, :py:meth:`~pvlib.modelchain.ModelChain.prepare_inputs`, computes parameters such as solar position, airmass, angle of incidence, and plane of array irradiance. The :py:meth:`~pvlib.modelchain.ModelChain.prepare_inputs` method also assigns default values for irradiance (clear sky), temperature (20 C), and wind speed (0 m/s) if these inputs are not provided.\n",
     "\n",
-    "Most users will only interact with the ModelChain.run_model method. The run_model method, shown below, calls a series of methods to complete the modeling steps. The first method, ModelChain.prepare_inputs, computes parameters such as solar position, airmass, angle of incidence, and plane of array irradiance. The prepare_inputs method also assigns default values for irradiance (clear sky), temperature (20 C), and wind speed (0 m/s) if these inputs are not provided.\n",
+    "Next, :py:meth:`~pvlib.modelchain.ModelChain.run_model` calls the wrapper methods for AOI loss, spectral loss, effective irradiance, cell temperature, DC power, AC power, and other losses. These methods are assigned to standard names, as described in the next section.\n",
     "\n",
-    "Next, ModelChain.run_model calls the wrapper methods for AOI loss, spectral loss, effective irradiance, cell temperature, DC power, AC power, and other losses. These methods are assigned to standard names, as described in the next section.\n",
-    "\n",
-    "The methods called by ModelChain.run_model store their results in a series of ModelChain attributes: ``times``, ``solar_position``, ``airmass``, ``irradiance``, ``total_irrad``, ``effective_irradiance``, ``weather``, ``temps``, ``aoi``, ``aoi_modifier``, ``spectral_modifier``, ``dc``, ``ac``, ``losses``."
+    "The methods called by :py:meth:`~pvlib.modelchain.ModelChain.run_model` store their results in a series of ModelChain attributes: ``times``, ``solar_position``, ``airmass``, ``irradiance``, ``total_irrad``, ``effective_irradiance``, ``weather``, ``temps``, ``aoi``, ``aoi_modifier``, ``spectral_modifier``, ``dc``, ``ac``, ``losses``."
    ]
   },
   {
@@ -400,10 +440,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "Finally, the ModelChain.complete_irradiance method is available for calculating the full set of GHI, DNI, or DHI if only two of these three series are provided. The completed dataset can then be passed to ModelChain.run_model."
+    "Finally, the :py:meth:`~pvlib.modelchain.ModelChain.complete_irradiance` method is available for calculating the full set of GHI, DNI, or DHI if only two of these three series are provided. The completed dataset can then be passed to :py:meth:`~pvlib.modelchain.ModelChain.run_model`."
    ]
   },
   {

--- a/docs/sphinx/source/package_overview.rst
+++ b/docs/sphinx/source/package_overview.rst
@@ -149,6 +149,8 @@ a full understanding of what it is doing internally!
     plt.ylabel('Yearly energy yield (W hr)')
 
 
+.. _object-oriented:
+
 Object oriented (Location, PVSystem, ModelChain)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -199,10 +201,6 @@ objects to accomplish our system modeling goal:
     energies.plot(kind='bar', rot=0)
     @savefig modelchain-energies.png width=6in
     plt.ylabel('Yearly energy yield (W hr)')
-
-See Will Holmgren's
-`ModelChain gist <https://gist.github.com/wholmgren/3fabacd3003c2a549b420b5e79f55e95>`_
-for more discussion about new features in ModelChain.
 
 
 Object oriented (LocalizedPVSystem)

--- a/docs/sphinx/source/whatsnew/v0.5.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.0.rst
@@ -29,7 +29,8 @@ Enhancements
 
 Documentation
 ~~~~~~~~~~~~~
-
+* Added ModelChain documentation page
+* Added nbsphinx to documentation build configuration.
 
 Testing
 ~~~~~~~


### PR DESCRIPTION
This PR adds a ModelChain tutorial to the documentation.

I'm trying a different documentation build technique than I've used in the past: write the tutorial in a Jupyter notebook, then use nbsphinx to embed it in the html documentation. After a few hiccups, I found that overall it's a lot easier than writing rst files with ipython directives. The downside is that the source ipynb file is harder to read with a simple text editor (or on github) than a simple rst file. The ipynb file doesn't have any output, though, so it's not as bad as it can be. 

You can few the documentation here:

http://wholmgren-pvlib-python-new.readthedocs.io/en/mcdocs2/modelchain.html

I'll leave this open for a day for edits/suggestions. We can always improve it later, too.