### PR TITLE
Improve lookup_linke_turbidity speed

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.5.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.1.rst
@@ -10,8 +10,8 @@ API Changes
 Bug fixes
 ~~~~~~~~~
 * Remove condition causing Overflow warning from clearsky.haurwitz
-* modelchain.basic_chain now correctly passes 'solar_position_method' arg to solarposition.get_solarposition 
-* Doc string of modelchain.basic_chain was updated to describe args more accurately 
+* modelchain.basic_chain now correctly passes 'solar_position_method'
+  arg to solarposition.get_solarposition
 
 Enhancements
 ~~~~~~~~~~~~
@@ -19,7 +19,8 @@ Enhancements
 
 Documentation
 ~~~~~~~~~~~~~
-*
+* Doc string of modelchain.basic_chain was updated to describe args
+  more accurately
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.5.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.1.rst
@@ -1,11 +1,11 @@
-.. _whatsnew_0500:
+.. _whatsnew_0510:
 
-v0.5.0 (August 11, 2017)
+v0.5.1 (?, 2017)
 ------------------------
 
 API Changes
 ~~~~~~~~~~~
-* 
+*
 
 Bug fixes
 ~~~~~~~~~
@@ -15,11 +15,11 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-* 
+* Improve clearsky.lookup_linke_turbidity speed. (:issue:`368`)
 
 Documentation
 ~~~~~~~~~~~~~
-* 
+*
 
 Testing
 ~~~~~~~
@@ -29,3 +29,4 @@ Contributors
 ~~~~~~~~~~~~
 * Cliff Hansen
 * KonstantinTr
+* Will Holmgren

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -264,22 +264,26 @@ def _interpolate_turbidity(lts, time):
     # next Jan to the array so that the interpolation will work for
     # Jan 1 - Jan 15 and Dec 16 - Dec 31.
     lts_concat = np.concatenate([[lts[-1]], lts, [lts[0]]])
-    # Then we map the month value to the day of year value.
 
-    # use this for the real code
+    # handle leap years
     try:
         isleap = time.is_leap_year
     except AttributeError:
         year = time.year
-        isleap = _is_leap_year(time.year)
+        isleap = _is_leap_year(year)
 
     dayofyear = time.dayofyear
     days_leap = _calendar_month_middles(2016)
     days_no_leap = _calendar_month_middles(2015)
+
+    # Then we map the month value to the day of year value.
+    # Do it for both leap and non-leap years.
     lt_leap = np.interp(dayofyear, days_leap, lts_concat)
     lt_no_leap = np.interp(dayofyear, days_no_leap, lts_concat)
     linke_turbidity = np.where(isleap, lt_leap, lt_no_leap)
+
     linke_turbidity = pd.Series(linke_turbidity, index=time)
+
     return linke_turbidity
 
 


### PR DESCRIPTION
 - [x] Closes issue #368 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes. (marked methods as private, so no action)
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

Improves the ``clearsky.lookup_linke_turbidity`` speed by 10-200x, depending on interpolation options and input data. See #368 for details.

@adriesse are you able to test this on your large dataset? 