### PR TITLE
change appveyor testing from python 3.4 to python 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,8 @@ environment:
   matrix:
     - PYTHON_VERSION: "2.7"
     - PYTHON_VERSION: "3.4"
-    #- PYTHON_VERSION: "3.5"
+    - PYTHON_VERSION: "3.5"
+    - PYTHON_VERSION: "3.6"
 
 platform:
     - x86
@@ -18,6 +19,8 @@ install:
     # Use the pre-installed Miniconda for the desired arch
     - ps: if($env:PYTHON_VERSION -eq '3.5')
             { $env:CONDA_PATH="$($env:CONDA_PATH)35" }
+    - ps: if($env:PYTHON_VERSION -eq '3.6')
+            { $env:CONDA_PATH="$($env:CONDA_PATH)36" }
     - ps: if($env:TARGET_ARCH -eq 'x64')
             { $env:CONDA_PATH="$($env:CONDA_PATH)-x64" }
     - ps: $env:path="$($env:CONDA_PATH);$($env:CONDA_PATH)\Scripts;$($env:CONDA_PATH)\Library\bin;C:\cygwin\bin;$($env:PATH)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
 
   matrix:
     - PYTHON_VERSION: "2.7"
-    - PYTHON_VERSION: "3.4"
-    - PYTHON_VERSION: "3.5"
     - PYTHON_VERSION: "3.6"
 
 platform:

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -21,7 +21,7 @@ Documentation
 
 Testing
 ~~~~~~~
-*
+* Test Python 3.6 on Windows with Appveyor instead of 3.4. (:issue:`392`)
 
 Contributors
 ~~~~~~~~~~~~


### PR DESCRIPTION
 - [x] Closes issue #392 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

I'll merge in a day or two if there are no suggestions/objections.