### PR TITLE
update test for pandas 0.22

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -24,6 +24,7 @@ Documentation
 Testing
 ~~~~~~~
 * Test Python 3.6 on Windows with Appveyor instead of 3.4. (:issue:`392`)
+* Fix failing test on pandas 0.22 (:issue:`406`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -42,6 +42,10 @@ needs_numpy_1_10 = pytest.mark.skipif(
     not numpy_1_10(), reason='requires numpy 1.10 or greater')
 
 
+def pandas_0_22():
+    return parse_version(pd.__version__) >= parse_version('0.22.0')
+
+
 def has_spa_c():
     try:
         from pvlib.spa_c_files.spa_py import spa_calc

--- a/pvlib/test/test_irradiance.py
+++ b/pvlib/test/test_irradiance.py
@@ -15,7 +15,8 @@ from pvlib import solarposition
 from pvlib import irradiance
 from pvlib import atmosphere
 
-from conftest import requires_ephem, requires_numba, needs_numpy_1_10
+from conftest import (requires_ephem, requires_numba, needs_numpy_1_10,
+                      pandas_0_22)
 
 # setup times and location to be tested.
 tus = Location(32.2, -111, 'US/Arizona', 700)
@@ -176,11 +177,16 @@ def test_perez_components():
         columns=['isotropic', 'circumsolar', 'horizon'],
         index=times
     )
+    if pandas_0_22:
+        expected_for_sum = expected.copy()
+        expected_for_sum.iloc[2] = 0
+    else:
+        expected_for_sum = expected
     sum_components = df_components.sum(axis=1)
 
     assert_series_equal(out, expected, check_less_precise=2)
     assert_frame_equal(df_components, expected_components)
-    assert_series_equal(sum_components, expected, check_less_precise=2)
+    assert_series_equal(sum_components, expected_for_sum, check_less_precise=2)
 
 @needs_numpy_1_10
 def test_perez_arrays():

--- a/pvlib/test/test_irradiance.py
+++ b/pvlib/test/test_irradiance.py
@@ -177,7 +177,7 @@ def test_perez_components():
         columns=['isotropic', 'circumsolar', 'horizon'],
         index=times
     )
-    if pandas_0_22:
+    if pandas_0_22():
         expected_for_sum = expected.copy()
         expected_for_sum.iloc[2] = 0
     else:


### PR DESCRIPTION
 - [x] Closes #406 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.