### PR TITLE
avoid runtime warnings from nan comparisons and divide by zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
     - if [[ "$CONDA_ENV" == "py27-min" ]]; then
         pip uninstall numpy --yes;
         pip uninstall pandas --yes;
-        pip install --no-cache-dir numpy==1.9.0;
+        pip install --no-cache-dir numpy==1.10.1;
         pip install --no-cache-dir pandas==0.14.0;
       fi
     - conda list

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -19,8 +19,8 @@ Bug fixes
 * corrected docstring for irradiance.total_irrad (:issue: '423')
 * removed RuntimeWarnings due to divide by 0 or nans in input data within
   irradiance.perez, clearsky.simplified_solis, pvsystem.adrinverter,
-  pvsystem.ashraeiam, pvsystem.physicaliam, pvsystem.sapm_aoi_loss.
-  (:issue:`428`)
+  pvsystem.ashraeiam, pvsystem.physicaliam, pvsystem.sapm_aoi_loss,
+  pvsystem.v_from_i. (:issue:`428`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -19,7 +19,7 @@ Bug fixes
 * corrected docstring for irradiance.total_irrad (:issue: '423')
 * removed RuntimeWarnings due to divide by 0 or nans in input data within
   irradiance.perez, clearsky.simplified_solis, pvsystem.adrinverter,
-  pvsystem.ashraeiam, pvsystem.physicaliam.
+  pvsystem.ashraeiam, pvsystem.physicaliam, pvsystem.sapm_aoi_loss.
   (:issue:`428`)
 
 Documentation

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -17,6 +17,7 @@ Bug fixes
 * physicaliam now returns a Series if called with a Series as an
   argument. (:issue:`397`)
 * corrected docstring for irradiance.total_irrad (:issue: '423')
+* removed RuntimeWarnings caused by nans in the perez transposition function
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -17,7 +17,10 @@ Bug fixes
 * physicaliam now returns a Series if called with a Series as an
   argument. (:issue:`397`)
 * corrected docstring for irradiance.total_irrad (:issue: '423')
-* removed RuntimeWarnings caused by nans in the perez transposition function
+* removed RuntimeWarnings due to divide by 0 or nans in input data within
+  irradiance.perez, clearsky.simplified_solis, pvsystem.adrinverter,
+  pvsystem.ashraeiam, pvsystem.physicaliam.
+  (:issue:`428`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -433,11 +433,7 @@ def simplified_solis(apparent_elevation, aod700=0.1, precipitable_water=1.,
     w = precipitable_water
 
     # algorithm fails for pw < 0.2
-    if np.isscalar(w):
-        w = 0.2 if w < 0.2 else w
-    else:
-        w = w.copy()
-        w[w < 0.2] = 0.2
+    w = np.maximum(w, 0.2)
 
     # this algorithm is reasonably fast already, but it could be made
     # faster by precalculating the powers of aod700, the log(p/p0), and
@@ -542,7 +538,9 @@ def _calc_taud(w, aod700, p):
     elif np.isscalar(aod700):
         aod700 = np.full_like(w, aod700)
 
-    aod700_mask = aod700 < 0.05
+    aod700_mask = np.full_like(aod700, False, dtype='bool')
+    # avoid nan warnings by using less with where and out
+    np.less(aod700, 0.05, where=~np.isnan(aod700), out=aod700_mask)
     aod700_mask = np.array([aod700_mask, ~aod700_mask], dtype=np.int)
 
     # create tuples of coefficients for

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -538,10 +538,10 @@ def _calc_taud(w, aod700, p):
     elif np.isscalar(aod700):
         aod700 = np.full_like(w, aod700)
 
-    aod700_mask = np.full_like(aod700, False, dtype='bool')
-    # avoid nan warnings by using less with where and out
-    np.less(aod700, 0.05, where=~np.isnan(aod700), out=aod700_mask)
-    aod700_mask = np.array([aod700_mask, ~aod700_mask], dtype=np.int)
+    # set up nan-tolerant masks
+    aod700_lt_0p05 = np.full_like(aod700, False, dtype='bool')
+    np.less(aod700, 0.05, where=~np.isnan(aod700), out=aod700_lt_0p05)
+    aod700_mask = np.array([aod700_lt_0p05, ~aod700_lt_0p05], dtype=np.int)
 
     # create tuples of coefficients for
     # aod700 < 0.05, aod700 >= 0.05

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1005,15 +1005,8 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     # rules. 1 = overcast ... 8 = clear (these names really only make
     # sense for small zenith angles, but...) these values will
     # eventually be used as indicies for coeffecient look ups
-    ebin = np.zeros_like(eps, dtype=np.int8)
-    ebin[eps < 1.065] = 1
-    ebin[(eps >= 1.065) & (eps < 1.23)] = 2
-    ebin[(eps >= 1.23) & (eps < 1.5)] = 3
-    ebin[(eps >= 1.5) & (eps < 1.95)] = 4
-    ebin[(eps >= 1.95) & (eps < 2.8)] = 5
-    ebin[(eps >= 2.8) & (eps < 4.5)] = 6
-    ebin[(eps >= 4.5) & (eps < 6.2)] = 7
-    ebin[eps >= 6.2] = 8
+    ebin = np.digitize(eps, (0., 1.065, 1.23, 1.5, 1.95, 2.8, 4.5, 6.2))
+    ebin[np.isnan(eps)] = 0
 
     # correct for 0 indexing in coeffecient lookup
     # later, ebin = -1 will yield nan coefficients
@@ -1333,7 +1326,7 @@ def dirindex(ghi, ghi_clearsky, dni_clearsky, zenith, times, pressure=101325.,
     Determine DNI from GHI using the DIRINDEX model, which is a modification of
     the DIRINT model with information from a clear sky model.
 
-    DIRINDEX [1] improves upon the DIRINT model by taking into account 
+    DIRINDEX [1] improves upon the DIRINT model by taking into account
     turbidity when used with the Ineichen clear sky model results.
 
     Parameters
@@ -1396,7 +1389,7 @@ def dirindex(ghi, ghi_clearsky, dni_clearsky, zenith, times, pressure=101325.,
                         use_delta_kt_prime=use_delta_kt_prime,
                         temp_dew=temp_dew)
 
-    dni_dirint_clearsky = dirint(ghi_clearsky, zenith, times, 
+    dni_dirint_clearsky = dirint(ghi_clearsky, zenith, times,
                                  pressure=pressure,
                                  use_delta_kt_prime=use_delta_kt_prime,
                                  temp_dew=temp_dew)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -995,7 +995,8 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     delta = dhi * airmass / dni_extra
 
     # epsilon is the sky's "clearness"
-    eps = ((dhi + dni) / dhi + kappa * (z ** 3)) / (1 + kappa * (z ** 3))
+    with np.errstate(invalid='ignore'):
+        eps = ((dhi + dni) / dhi + kappa * (z ** 3)) / (1 + kappa * (z ** 3))
 
     # numpy indexing below will not work with a Series
     if isinstance(eps, pd.Series):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2318,10 +2318,17 @@ def adrinverter(v_dc, p_dc, inverter, vtol=0.10):
     ac_power = p_nom * (pdc-p_loss)
     p_nt = -1 * np.absolute(p_nt)
 
-    ac_power = np.where((v_lim_upper < v_dc) | (v_dc < v_lim_lower),
-                        np.nan, ac_power)
+    # set output to nan where input is outside of limits
+    # errstate silences case where input is nan
+    with np.errstate(invalid='ignore'):
+        invalid = (v_lim_upper < v_dc) | (v_dc < v_lim_lower)
+    ac_power = np.where(invalid, np.nan, ac_power)
+
+    # set night values
     ac_power = np.where(vdc == 0, p_nt, ac_power)
     ac_power = np.maximum(ac_power, p_nt)
+
+    # set max ac output
     ac_power = np.minimum(ac_power, pac_max)
 
     if isinstance(p_dc, pd.Series):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -733,9 +733,9 @@ def ashraeiam(aoi, b=0.05):
     '''
 
     iam = 1 - b * ((1 / np.cos(np.radians(aoi)) - 1))
-    mask = np.full_like(aoi, False, dtype='bool')
-    np.greater_equal(np.abs(aoi), 90, where=~np.isnan(aoi), out=mask)
-    iam = np.where(mask, 0, iam)
+    aoi_gte_90 = np.full_like(aoi, False, dtype='bool')
+    np.greater_equal(np.abs(aoi), 90, where=~np.isnan(aoi), out=aoi_gte_90)
+    iam = np.where(aoi_gte_90, 0, iam)
     iam = np.maximum(0, iam)
 
     if isinstance(iam, pd.Series):
@@ -837,14 +837,14 @@ def physicaliam(aoi, n=1.526, K=4., L=0.002):
     # after deducting the reflected portion of each
     iam = ((1 - (rho_para + rho_perp) / 2) / (1 - rho_zero) * tau / tau_zero)
 
-    # set up arrays for nan-tolerant masking operations
-    mask = np.full_like(aoi, False, dtype='bool')
+    # set up array for nan-tolerant masking operations
     notnan = ~np.isnan(aoi)
 
     # angles near zero produce nan, but iam is defined as one
     small_angle = 1e-06
-    np.less(np.abs(aoi), small_angle, where=notnan, out=mask)
-    iam = np.where(mask, 1.0, iam)
+    aoi_lt_small_angle = np.full_like(aoi, False, dtype='bool')
+    np.less(np.abs(aoi), small_angle, where=notnan, out=aoi_lt_small_angle)
+    iam = np.where(aoi_lt_small_angle, 1.0, iam)
 
     # angles at 90 degrees can produce tiny negative values,
     # which should be zero. this is a result of calculation precision
@@ -852,9 +852,9 @@ def physicaliam(aoi, n=1.526, K=4., L=0.002):
     iam = np.maximum(0, iam)
 
     # for light coming from behind the plane, none can enter the module
-    mask = np.full_like(aoi, False, dtype='bool')
-    np.greater(aoi, 90, where=notnan, out=mask)
-    iam = np.where(mask, 0, iam)
+    aoi_gt_90 = np.full_like(aoi, False, dtype='bool')
+    np.greater(aoi, 90, where=notnan, out=aoi_gt_90)
+    iam = np.where(aoi_gt_90, 0, iam)
 
     if isinstance(aoi_input, pd.Series):
         iam = pd.Series(iam, index=aoi_input.index)
@@ -1309,11 +1309,11 @@ def sapm(effective_irradiance, temp_cell, module):
     Ee = np.array(effective_irradiance, dtype='float64')
 
     # set up masking for 0, positive, and nan inputs
-    mask_pos = np.full_like(Ee, False, dtype='bool')
-    mask_zero = np.full_like(Ee, False, dtype='bool')
+    Ee_gt_0 = np.full_like(Ee, False, dtype='bool')
+    Ee_eq_0 = np.full_like(Ee, False, dtype='bool')
     notnan = ~np.isnan(Ee)
-    positive = np.greater(Ee, 0, where=notnan, out=mask_pos)
-    zeros = np.equal(Ee, 0, where=notnan, out=mask_zero)
+    np.greater(Ee, 0, where=notnan, out=Ee_gt_0)
+    np.equal(Ee, 0, where=notnan, out=Ee_eq_0)
 
     Bvmpo = module['Bvmpo'] + module['Mbvmp']*(1 - Ee)
     Bvoco = module['Bvoco'] + module['Mbvoc']*(1 - Ee)
@@ -1321,8 +1321,8 @@ def sapm(effective_irradiance, temp_cell, module):
 
     # avoid repeated computation
     logEe = np.full_like(Ee, np.nan)
-    np.log(Ee, where=positive, out=logEe)
-    logEe = np.where(zeros, -np.inf, logEe)
+    np.log(Ee, where=Ee_gt_0, out=logEe)
+    logEe = np.where(Ee_eq_0, -np.inf, logEe)
     # avoid repeated __getitem__
     cells_in_series = module['Cells_in_Series']
 
@@ -1542,9 +1542,10 @@ def sapm_aoi_loss(aoi, module, upper=None):
 
     aoi_loss = np.polyval(aoi_coeff, aoi)
     aoi_loss = np.clip(aoi_loss, 0, upper)
-    mask = np.full_like(aoi, False, dtype='bool')
-    np.less(aoi, 0, where=~np.isnan(aoi), out=mask)
-    aoi_loss = np.where(mask, 0, aoi_loss)
+    # nan tolerant masking
+    aoi_lt_0 = np.full_like(aoi, False, dtype='bool')
+    np.less(aoi, 0, where=~np.isnan(aoi), out=aoi_lt_0)
+    aoi_loss = np.where(aoi_lt_0, 0, aoi_loss)
 
     if isinstance(aoi, pd.Series):
         aoi_loss = pd.Series(aoi_loss, aoi.index)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1542,7 +1542,9 @@ def sapm_aoi_loss(aoi, module, upper=None):
 
     aoi_loss = np.polyval(aoi_coeff, aoi)
     aoi_loss = np.clip(aoi_loss, 0, upper)
-    aoi_loss = np.where(aoi < 0, 0, aoi_loss)
+    mask = np.full_like(aoi, False, dtype='bool')
+    np.less(aoi, 0, where=~np.isnan(aoi), out=mask)
+    aoi_loss = np.where(mask, 0, aoi_loss)
 
     if isinstance(aoi, pd.Series):
         aoi_loss = pd.Series(aoi_loss, aoi.index)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2312,18 +2312,11 @@ def adrinverter(v_dc, p_dc, inverter, vtol=0.10):
     ac_power = p_nom * (pdc-p_loss)
     p_nt = -1 * np.absolute(p_nt)
 
-    # set ac_power to nan where results are non-physical
     ac_power = np.where((v_lim_upper < v_dc) | (v_dc < v_lim_lower),
                         np.nan, ac_power)
-    # machinery to set limits
-    # more verbose than simple bitwise comparisons, but more robust to nans
-    notnan = ~np.isnan(ac_power)
-    mask = np.full_like(ac_power, False, dtype='bool')
-    np.less(ac_power, p_nt, where=notnan, out=mask)
-    np.equal(vdc, 0, where=notnan, out=mask)
-    # p_nt where mask is True, ac_power where mask is False
-    ac_power = np.where(mask, p_nt, ac_power)
-    ac_power = np.minimum(pac_max, ac_power)
+    ac_power = np.where(vdc == 0, p_nt, ac_power)
+    ac_power = np.maximum(ac_power, p_nt)
+    ac_power = np.minimum(ac_power, pac_max)
 
     if isinstance(p_dc, pd.Series):
         ac_power = pd.Series(ac_power, index=pdc.index)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2305,9 +2305,16 @@ def adrinverter(v_dc, p_dc, inverter, vtol=0.10):
 
     pdc = p_dc / p_nom
     vdc = v_dc / v_nom
-    poly = np.array([pdc**0, pdc, pdc**2, vdc - 1, pdc * (vdc - 1),
-                     pdc**2 * (vdc - 1), 1 / vdc - 1, pdc * (1. / vdc - 1),
-                     pdc**2 * (1. / vdc - 1)])
+    with np.errstate(invalid='ignore', divide='ignore'):
+        poly = np.array([pdc**0,  # replace with np.ones_like?
+                         pdc,
+                         pdc**2,
+                         vdc - 1,
+                         pdc * (vdc - 1),
+                         pdc**2 * (vdc - 1),
+                         1. / vdc - 1,  # divide by 0
+                         pdc * (1. / vdc - 1),  # invalid 0./0. --> nan
+                         pdc**2 * (1. / vdc - 1)])  # divide by 0
     p_loss = np.dot(np.array(ce_list), poly)
     ac_power = p_nom * (pdc-p_loss)
     p_nt = -1 * np.absolute(p_nt)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1938,9 +1938,11 @@ def v_from_i(resistance_shunt, resistance_series, nNsVth, current,
     # Only compute using LambertW if there are cases with Gsh>0
     if np.any(idx_p):
         # LambertW argument, cannot be float128, may overflow to np.inf
-        argW = I0[idx_p] / (Gsh[idx_p]*a[idx_p]) * \
-            np.exp((-I[idx_p] + IL[idx_p] + I0[idx_p]) /
-                   (Gsh[idx_p]*a[idx_p]))
+        # overflow is explicitly handled below, so ignore warnings here
+        with np.errstate(over='ignore'):
+            argW = (I0[idx_p] / (Gsh[idx_p]*a[idx_p]) *
+                    np.exp((-I[idx_p] + IL[idx_p] + I0[idx_p]) /
+                           (Gsh[idx_p]*a[idx_p])))
 
         # lambertw typically returns complex value with zero imaginary part
         # may overflow to np.inf

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -839,6 +839,16 @@ def test_adrinverter_float(sam_data):
     assert_allclose(pacs, 1161.5745)
 
 
+def test_adrinverter_invalid_and_night(sam_data):
+    inverters = sam_data['adrinverter']
+    testinv = 'Zigor__Sunzet_3_TL_US_240V__CEC_2011_'
+    vdcs = np.array([39.873036, 0.])
+    pdcs = np.array([188.09182, 0.])
+
+    pacs = pvsystem.adrinverter(vdcs, pdcs, inverters[testinv])
+    assert_allclose(pacs, np.array([np.nan, -0.25]))
+
+
 def test_snlinverter(sam_data):
     inverters = sam_data['cecinverter']
     testinv = 'ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_'

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -102,6 +102,18 @@ def test_ashraeiam():
 
 
 @needs_numpy_1_10
+def test_ashraeiam_scalar():
+    thetas = -45.
+    iam = pvsystem.ashraeiam(thetas, .05)
+    expected = 0.97928932
+    assert_allclose(iam, expected, equal_nan=True)
+    thetas = np.nan
+    iam = pvsystem.ashraeiam(thetas, .05)
+    expected = np.nan
+    assert_allclose(iam, expected, equal_nan=True)
+
+
+@needs_numpy_1_10
 def test_PVSystem_ashraeiam():
     module_parameters = pd.Series({'b': 0.05})
     system = pvsystem.PVSystem(module_parameters=module_parameters)
@@ -125,6 +137,18 @@ def test_physicaliam():
     iam = pvsystem.physicaliam(aoi, 1.526, 0.002, 4)
     expected = pd.Series(expected)
     assert_series_equal(iam, expected)
+
+
+@needs_numpy_1_10
+def test_physicaliam_scalar():
+    aoi = -45.
+    iam = pvsystem.physicaliam(aoi, 1.526, 0.002, 4)
+    expected = 0.98797788
+    assert_allclose(iam, expected, equal_nan=True)
+    aoi = np.nan
+    iam = pvsystem.physicaliam(aoi, 1.526, 0.002, 4)
+    expected = np.nan
+    assert_allclose(iam, expected, equal_nan=True)
 
 
 @needs_numpy_1_10

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -842,11 +842,11 @@ def test_adrinverter_float(sam_data):
 def test_adrinverter_invalid_and_night(sam_data):
     inverters = sam_data['adrinverter']
     testinv = 'Zigor__Sunzet_3_TL_US_240V__CEC_2011_'
-    vdcs = np.array([39.873036, 0.])
-    pdcs = np.array([188.09182, 0.])
+    vdcs = np.array([39.873036, 0., np.nan, 420])
+    pdcs = np.array([188.09182, 0., 420, np.nan])
 
     pacs = pvsystem.adrinverter(vdcs, pdcs, inverters[testinv])
-    assert_allclose(pacs, np.array([np.nan, -0.25]))
+    assert_allclose(pacs, np.array([np.nan, -0.25, np.nan, np.nan]))
 
 
 def test_snlinverter(sam_data):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ AUTHOR = 'PVLIB Python Developers'
 MAINTAINER_EMAIL = 'holmgren@email.arizona.edu'
 URL = 'https://github.com/pvlib/pvlib-python'
 
-INSTALL_REQUIRES = ['numpy >= 1.9.0',
+INSTALL_REQUIRES = ['numpy >= 1.10.1',
                     'pandas >= 0.14.0',
                     'pytz',
                     'six',


### PR DESCRIPTION
 - [x] Closes #428 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] ~Updates entries to `docs/sphinx/source/api.rst` for API changes.~
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

I'll look into adding a few more of the items in #428.