### PR TITLE
DOC: fix superscript in forecast.rst

### DIFF
--- a/docs/sphinx/source/forecasts.rst
+++ b/docs/sphinx/source/forecasts.rst
@@ -457,8 +457,8 @@ Here's the forecast plane of array irradiance...
 
     mc.total_irrad.plot();
     @savefig poa_irrad.png width=6in
-    plt.legend(loc='best')
     plt.ylabel('Plane of array irradiance ($W/m^2$)');
+    plt.legend(loc='best');
 
 ...the cell and module temperature...
 

--- a/docs/sphinx/source/forecasts.rst
+++ b/docs/sphinx/source/forecasts.rst
@@ -457,7 +457,8 @@ Here's the forecast plane of array irradiance...
 
     mc.total_irrad.plot();
     @savefig poa_irrad.png width=6in
-    plt.ylabel('Plane of array irradiance ($W/m**2$)');
+    plt.legend(loc='best')
+    plt.ylabel('Plane of array irradiance ($W/m^2$)');
 
 ...the cell and module temperature...
 


### PR DESCRIPTION
* change `$W/m**2$` to `$W/m^2$` so 2 is superscripted
* also change legend location to `"best"`
* _n.b._: this image doesn't appear to be using seaborn, and it also appears to be different than the previous build, not sure why?
![poa_irrad](https://user-images.githubusercontent.com/1385621/37732323-f2e24dc4-2d01-11e8-9611-3bc6f4dbbbeb.png)
