### PR TITLE
lookup_linke_turbidity speed improvement, mat to h5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - cmd: conda info -a
 
     # install depenencies
-    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy tables pandas nose pytest pytz ephem numba siphon -c conda-forge
+    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy pytables pandas nose pytest pytz ephem numba siphon -c conda-forge
     - cmd: activate test_env
     - cmd: python --version
     - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - cmd: conda info -a
 
     # install depenencies
-    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy pandas nose pytest pytz ephem numba siphon -c conda-forge
+    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy tables pandas nose pytest pytz ephem numba siphon -c conda-forge
     - cmd: activate test_env
     - cmd: python --version
     - cmd: conda list

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=2.7
     - numpy
     - scipy
-    - tables
+    - pytables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -6,6 +6,7 @@ dependencies:
     - python=2.7
     - numpy
     - scipy
+    - tables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -6,6 +6,7 @@ dependencies:
     - python=3.4
     - numpy
     - scipy
+    - tables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.4
     - numpy
     - scipy
-    - tables
+    - pytables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.5
     - numpy
     - scipy
-    - tables
+    - pytables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -6,6 +6,7 @@ dependencies:
     - python=3.5
     - numpy
     - scipy
+    - tables
     - pandas
     - pytz
     - ephem

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -6,6 +6,7 @@ dependencies:
     - python=3.6
     - numpy
     - scipy
+    - tables
     - pandas
     - pytz
     #- ephem

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.6
     - numpy
     - scipy
-    - tables
+    - pytables
     - pandas
     - pytz
     #- ephem

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,6 +7,7 @@ dependencies:
     - mock  # needed for local python 2.7 builds
     - numpy=1.11.2
     - scipy
+    - tables
     - pandas=0.19.1
     - pytz
     - ephem

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -140,7 +140,7 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: pvlib_path = os.path.dirname(os.path.abspath(pvlib.clearsky.__file__))
 
-    In [1]: filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
+    In [1]: filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.h5')
 
     # data is in units of 20 x turbidity
     In [1]: lt_h5_file = tables.open_file(filepath)

--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -136,23 +136,23 @@ the year. You could run it in a loop to create plots for all months.
 
     In [1]: import os
 
-    In [1]: import scipy.io
+    In [1]: import tables
 
     In [1]: pvlib_path = os.path.dirname(os.path.abspath(pvlib.clearsky.__file__))
 
     In [1]: filepath = os.path.join(pvlib_path, 'data', 'LinkeTurbidities.mat')
 
-    In [1]: mat = scipy.io.loadmat(filepath)
-
     # data is in units of 20 x turbidity
-    In [1]: linke_turbidity_table = mat['LinkeTurbidity']  # / 20.   # crashes on rtd
+    In [1]: lt_h5_file = tables.open_file(filepath)
 
     In [1]: def plot_turbidity_map(month, vmin=1, vmax=100):
        ...:     plt.figure();
-       ...:     plt.imshow(linke_turbidity_table[:, :, month-1], vmin=vmin, vmax=vmax);
+       ...:     plt.imshow(lt_h5_file.root.LinkeTurbidity[:, :, month-1], vmin=vmin, vmax=vmax);
        ...:     plt.title('Linke turbidity x 20, ' + calendar.month_name[month]);
        ...:     plt.colorbar(shrink=0.5);
        ...:     plt.tight_layout();
+
+    In [1]: lt_h5_file.close()
 
     @savefig turbidity-1.png width=10in
     In [1]: plot_turbidity_map(1)

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -9,7 +9,8 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-* Improve clearsky.lookup_linke_turbidity speed (IO) (:issue:`437`)
+* Improve clearsky.lookup_linke_turbidity speed, changing .mat source
+  file to .h5 (:issue:`437`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -9,7 +9,7 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-*
+* Improve clearsky.lookup_linke_turbidity speed (IO) (:issue:`437`)
 
 Bug fixes
 ~~~~~~~~~
@@ -42,5 +42,4 @@ Contributors
 * Will Holmgren
 * KonstantinTr
 * Anton Driesse
-
-
+* Cedric Leroy

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -153,7 +153,7 @@ def ineichen(apparent_zenith, airmass_absolute, linke_turbidity,
 def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
                            interp_turbidity=True):
     """
-    Look up the Linke Turibidity from the ``LinkeTurbidities.mat``
+    Look up the Linke Turibidity from the ``LinkeTurbidities.h5``
     data file supplied with pvlib.
 
     Parameters
@@ -165,18 +165,18 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
     longitude : float
 
     filepath : None or string, default None
-        The path to the ``.mat`` file.
+        The path to the ``.h5`` file.
 
     interp_turbidity : bool, default True
         If ``True``, interpolates the monthly Linke turbidity values
-        found in ``LinkeTurbidities.mat`` to daily values.
+        found in ``LinkeTurbidities.h5`` to daily values.
 
     Returns
     -------
     turbidity : Series
     """
 
-    # The .mat file 'LinkeTurbidities.mat' contains a single 2160 x 4320 x 12
+    # The .h5 file 'LinkeTurbidities.h5' contains a single 2160 x 4320 x 12
     # matrix of type uint8 called 'LinkeTurbidity'. The rows represent global
     # latitudes from 90 to -90 degrees; the columns represent global longitudes
     # from -180 to 180; and the depth (third dimension) represents months of

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -20,6 +20,15 @@ requires_scipy = pytest.mark.skipif(not has_scipy, reason='requires scipy')
 
 
 try:
+    import tables
+    has_tables = True
+except ImportError:
+    has_tables = False
+
+requires_tables = pytest.mark.skipif(not has_tables, reason='requires tables')
+
+
+try:
     import ephem
     has_ephem = True
 except ImportError:

--- a/pvlib/test/test_clearsky.py
+++ b/pvlib/test/test_clearsky.py
@@ -16,7 +16,7 @@ from pvlib import solarposition
 from pvlib import atmosphere
 from pvlib import irradiance
 
-from conftest import requires_scipy
+from conftest import requires_scipy, requires_tables
 
 
 def test_ineichen_series():
@@ -158,7 +158,7 @@ def test_ineichen_altitude():
     assert_frame_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity():
     times = pd.date_range(start='2014-06-24', end='2014-06-25',
                           freq='12h', tz='America/Phoenix')
@@ -171,7 +171,7 @@ def test_lookup_linke_turbidity():
     assert_series_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity_leapyear():
     times = pd.date_range(start='2016-06-24', end='2016-06-25',
                           freq='12h', tz='America/Phoenix')
@@ -184,7 +184,7 @@ def test_lookup_linke_turbidity_leapyear():
     assert_series_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity_nointerp():
     times = pd.date_range(start='2014-06-24', end='2014-06-25',
                           freq='12h', tz='America/Phoenix')
@@ -195,7 +195,7 @@ def test_lookup_linke_turbidity_nointerp():
     assert_series_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity_months():
     times = pd.date_range(start='2014-04-01', end='2014-07-01',
                           freq='1M', tz='America/Phoenix')
@@ -206,7 +206,7 @@ def test_lookup_linke_turbidity_months():
     assert_series_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity_months_leapyear():
     times = pd.date_range(start='2016-04-01', end='2016-07-01',
                           freq='1M', tz='America/Phoenix')
@@ -217,7 +217,7 @@ def test_lookup_linke_turbidity_months_leapyear():
     assert_series_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_lookup_linke_turbidity_nointerp_months():
     times = pd.date_range(start='2014-04-10', end='2014-07-10',
                           freq='1M', tz='America/Phoenix')
@@ -448,7 +448,7 @@ def test_simplified_solis_nans_series():
     assert_frame_equal(expected, out)
 
 
-@requires_scipy
+@requires_tables
 def test_linke_turbidity_corners():
     """Test Linke turbidity corners out of bounds."""
     months = pd.DatetimeIndex('%d/1/2016' % (m + 1) for m in range(12))


### PR DESCRIPTION
 - [x] Closes issue #437
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

**Note:**  `git diff upstream/master -u -- "*.py" | flake8 --diff` is giving me `fatal: bad revision 'upstream/master'`. I use `pylint` though and it didn't complain on additions.
