### PR TITLE
replace logging.warning with warnings.warn, remove logging.debug

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.5.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.5.2.rst
@@ -6,6 +6,9 @@ v0.5.2 (__, 2017)
 API Changes
 ~~~~~~~~~~~
 * removed unused 'pressure' arg from irradiance.liujordan function (:issue:`386`)
+* replaced logging.warning calls with warnings.warn calls, and removed
+  logging.debug calls. We encourage users to explore tools such as pdb and
+  trackback in place of the logging.debug calls. Fixes (:issue:`447`).
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pvlib/__init__.py
+++ b/pvlib/__init__.py
@@ -1,5 +1,3 @@
-import logging
-logging.basicConfig()
 from pvlib.version import __version__
 from pvlib import tools
 from pvlib import atmosphere

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -6,8 +6,6 @@ irradiance, and total irradiance under various conditions.
 
 from __future__ import division
 
-import logging
-
 import datetime
 from collections import OrderedDict
 from functools import partial
@@ -19,7 +17,6 @@ from pvlib import tools
 from pvlib import solarposition
 from pvlib import atmosphere
 
-pvl_logger = logging.getLogger('pvlib')
 
 SURFACE_ALBEDOS = {'urban': 0.18,
                    'grass': 0.20,
@@ -345,8 +342,6 @@ def total_irrad(surface_tilt, surface_azimuth,
         'poa_sky_diffuse', 'poa_ground_diffuse'``.
     """
 
-    pvl_logger.debug('planeofarray.total_irrad()')
-
     solar_zenith = apparent_zenith
     solar_azimuth = azimuth
 
@@ -498,12 +493,8 @@ def grounddiffuse(surface_tilt, ghi, albedo=.25, surface_type=None):
     http://en.wikipedia.org/wiki/Albedo
     '''
 
-    pvl_logger.debug('diffuse_ground.get_diffuse_ground()')
-
     if surface_type is not None:
         albedo = SURFACE_ALBEDOS[surface_type]
-        pvl_logger.info('surface_type=%s mapped to albedo=%s',
-                        surface_type, albedo)
 
     diffuse_irrad = ghi * albedo * (1 - np.cos(np.radians(surface_tilt))) * 0.5
 
@@ -554,8 +545,6 @@ def isotropic(surface_tilt, dhi):
     [2] Hottel, H.C., Woertz, B.B., 1942. Evaluation of flat-plate solar
     heat collector. Trans. ASME 64, 91.
     '''
-
-    pvl_logger.debug('diffuse_sky.isotropic()')
 
     sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
 
@@ -627,8 +616,6 @@ def klucher(surface_tilt, surface_azimuth, dhi, ghi, solar_zenith,
     [2] Klucher, T.M., 1979. Evaluation of models to predict insolation on
     tilted surfaces. Solar Energy 23 (2), 111-114.
     '''
-
-    pvl_logger.debug('diffuse_sky.klucher()')
 
     # zenith angle with respect to panel normal.
     cos_tt = aoi_projection(surface_tilt, surface_azimuth,
@@ -718,8 +705,6 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     (Eds.), Proc. of First Canadian Solar Radiation Data Workshop, 59.
     Ministry of Supply and Services, Canada.
     '''
-
-    pvl_logger.debug('diffuse_sky.haydavies()')
 
     # if necessary, calculate ratio of titled and horizontal beam irradiance
     if projection_ratio is None:
@@ -819,8 +804,6 @@ def reindl(surface_tilt, surface_azimuth, dhi, dni, ghi, dni_extra,
     hourly tilted surface radiation models. Solar Energy 45(1), 9-17.
     '''
 
-    pvl_logger.debug('diffuse_sky.reindl()')
-
     cos_tt = aoi_projection(surface_tilt, surface_azimuth,
                             solar_zenith, solar_azimuth)
 
@@ -880,8 +863,6 @@ def king(surface_tilt, dhi, ghi, solar_zenith):
     poa_sky_diffuse : numeric
         The diffuse component of the solar radiation.
     '''
-
-    pvl_logger.debug('diffuse_sky.king()')
 
     sky_diffuse = (dhi * ((1 + tools.cosd(surface_tilt))) / 2 + ghi *
                    ((0.012 * solar_zenith - 0.04)) *

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -7,7 +7,6 @@ the time to read the source code for the module.
 """
 
 from functools import partial
-import logging
 import warnings
 import pandas as pd
 
@@ -683,7 +682,6 @@ class ModelChain(object):
                    "https://github.com/pvlib/pvlib-python \n")
 
         if {'ghi', 'dhi'} <= icolumns and 'dni' not in icolumns:
-            logging.debug('Estimate dni from ghi and dhi')
             clearsky = self.location.get_clearsky(
                 times, solar_position=self.solar_position)
             self.weather.loc[:, 'dni'] = pvlib.irradiance.dni(
@@ -693,13 +691,11 @@ class ModelChain(object):
                 clearsky_tolerance=1.1)
         elif {'dni', 'dhi'} <= icolumns and 'ghi' not in icolumns:
             warnings.warn(wrn_txt, UserWarning)
-            logging.debug('Estimate ghi from dni and dhi')
             self.weather.loc[:, 'ghi'] = (
                 self.weather.dni * tools.cosd(self.solar_position.zenith) +
                 self.weather.dhi)
         elif {'dni', 'ghi'} <= icolumns and 'dhi' not in icolumns:
             warnings.warn(wrn_txt, UserWarning)
-            logging.debug('Estimate dhi from dni and ghi')
             self.weather.loc[:, 'dhi'] = (
                 self.weather.ghi - self.weather.dni *
                 tools.cosd(self.solar_position.zenith))

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -24,9 +24,6 @@ import pandas as pd
 from pvlib import atmosphere
 from pvlib.tools import datetime_to_djd, djd_to_datetime
 
-import logging
-pvl_logger = logging.getLogger('pvlib')
-
 
 def get_solarposition(time, latitude, longitude,
                       altitude=None, pressure=None,
@@ -182,8 +179,6 @@ def spa_c(time, latitude, longitude, pressure=101325, altitude=0,
         raise ImportError('Could not import built-in SPA calculator. ' +
                           'You may need to recompile the SPA code.')
 
-    pvl_logger.debug('using built-in spa code to calculate solar position')
-
     # if localized, convert to UTC. otherwise, assume UTC.
     try:
         time_utc = time.tz_convert('UTC')
@@ -236,14 +231,12 @@ def _spa_python_import(how):
         # the PVLIB_USE_NUMBA env variable is used to tell the module
         # to not compile with numba
         os.environ['PVLIB_USE_NUMBA'] = '0'
-        pvl_logger.debug('Reloading spa module without compiling')
         spa = reload(spa)
         del os.environ['PVLIB_USE_NUMBA']
     elif how == 'numba' and not using_numba:
         # The spa module was not compiled to numba code, so set
         # PVLIB_USE_NUMBA so it does compile to numba on reload.
         os.environ['PVLIB_USE_NUMBA'] = '1'
-        pvl_logger.debug('Reloading spa module, compiling with numba')
         spa = reload(spa)
         del os.environ['PVLIB_USE_NUMBA']
     elif how != 'numba' and how != 'numpy':
@@ -323,8 +316,6 @@ def spa_python(time, latitude, longitude,
 
     # Added by Tony Lorenzo (@alorenzo175), University of Arizona, 2015
 
-    pvl_logger.debug('Calculating solar position with spa_python code')
-
     lat = latitude
     lon = longitude
     elev = altitude
@@ -403,8 +394,6 @@ def get_sun_rise_set_transit(time, latitude, longitude, how='numpy',
     USA, http://www.nrel.gov.
     """
     # Added by Tony Lorenzo (@alorenzo175), University of Arizona, 2015
-
-    pvl_logger.debug('Calculating sunrise, set, transit with spa_python code')
 
     lat = latitude
     lon = longitude
@@ -492,8 +481,6 @@ def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
         import ephem
     except ImportError:
         raise ImportError('PyEphem must be installed')
-
-    pvl_logger.debug('using PyEphem to calculate solar position')
 
     # if localized, convert to UTC. otherwise, assume UTC.
     try:
@@ -790,7 +777,6 @@ def pyephem_earthsun_distance(time):
     -------
     pd.Series. Earth-sun distance in AU.
     """
-    pvl_logger.debug('solarposition.pyephem_earthsun_distance()')
 
     import ephem
 

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -10,9 +10,6 @@ from __future__ import division
 import os
 import threading
 import warnings
-import logging
-pvl_logger = logging.getLogger('pvlib')
-
 
 import numpy as np
 
@@ -995,13 +992,11 @@ def solar_position_numba(unixtime, lat, lon, elev, pressure, temp, delta_t,
         unixtime = unixtime.astype(np.float64)
 
     if ulength < numthreads:
-        pvl_logger.warning('The number of threads is more than the length of' +
-                           ' the time array. Only using %s threads.',
-                            ulength)
+        warnings.warn('The number of threads is more than the length of '
+                      'the time array. Only using %s threads.'.format(ulength))
         numthreads = ulength
 
     if numthreads <= 1:
-        pvl_logger.debug('Only using one thread for calculation')
         solar_position_loop(unixtime, loc_args, result)
         return result
 
@@ -1312,16 +1307,16 @@ def calculate_deltat(year, month):
     Equations taken from http://eclipse.gsfc.nasa.gov/SEcat5/deltatpoly.html
     """
 
-    plw = ' Deltat is unknown for years before -1999 and after 3000.'\
-          + ' Delta values will be calculated, but the calculations'\
-          + ' are not intended to be used for these years.'
+    plw = 'Deltat is unknown for years before -1999 and after 3000. ' \
+          'Delta values will be calculated, but the calculations ' \
+          'are not intended to be used for these years.'
 
     try:
         if np.any((year > 3000) | (year < -1999)):
-            pvl_logger.warning(plw)
+            warnings.warn(plw)
     except ValueError:
         if (year > 3000) | (year < -1999):
-            pvl_logger.warning(plw)
+            warnings.warn(plw)
     except TypeError:
         return 0
 

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -8,9 +8,6 @@ from pvlib.pvsystem import PVSystem
 from pvlib.location import Location
 from pvlib import irradiance, atmosphere
 
-import logging
-pvl_logger = logging.getLogger('pvlib')
-
 
 class SingleAxisTracker(PVSystem):
     """
@@ -307,15 +304,6 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     Photovoltaics: Research and Applications, v. 19, pp. 747-753.
     """
 
-    pvl_logger.debug('tracking.singleaxis')
-
-    pvl_logger.debug('axis_tilt=%s, axis_azimuth=%s, max_angle=%s, '
-                     'backtrack=%s, gcr=%.3f',
-                     axis_tilt, axis_azimuth, max_angle, backtrack, gcr)
-
-    pvl_logger.debug('\napparent_zenith=\n%s\napparent_azimuth=\n%s',
-                     apparent_zenith.head(), apparent_azimuth.head())
-
     # MATLAB to Python conversion by
     # Will Holmgren (@wholmgren), U. Arizona. March, 2015.
 
@@ -354,7 +342,6 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     # wholmgren: strange to see axis_azimuth calculated differently from az,
     # (not that it matters, or at least it shouldn't...).
     axis_azimuth_south = axis_azimuth - 180
-    pvl_logger.debug('axis_azimuth_south=%s', axis_azimuth_south)
 
     # translate input array tilt angle axis_tilt to [1] coordinate system.
 
@@ -418,7 +405,6 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     # Account for backtracking; modified from [1] to account for rotation
     # angle convention being used here.
     if backtrack:
-        pvl_logger.debug('applying backtracking')
         axes_distance = 1/gcr
         temp = np.minimum(axes_distance*cosd(wid), 1)
 
@@ -431,7 +417,6 @@ def singleaxis(apparent_zenith, apparent_azimuth,
         widc[~v] = wid[~v] - wc[~v]  # Eq 4 applied when wid in QI
         widc[v] = wid[v] + wc[v]     # Eq 4 applied when wid in QIV
     else:
-        pvl_logger.debug('no backtracking')
         widc = wid
 
     tracker_theta = widc.copy()
@@ -469,34 +454,27 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     rot_x = np.array([[1, 0, 0],
                       [0, cosd(-axis_tilt), -sind(-axis_tilt)],
                       [0, sind(-axis_tilt), cosd(-axis_tilt)]])
-    pvl_logger.debug('rot_x=\n%s', rot_x)
 
     # panel_norm_earth contains the normal vector
     # expressed in earth-surface coordinates
     # (z normal to surface, y aligned with tracker axis parallel to earth)
     panel_norm_earth = np.dot(rot_x, panel_norm).T
-    pvl_logger.debug('panel_norm_earth=%s', panel_norm_earth)
 
     # projection to plane tangent to earth surface,
     # in earth surface coordinates
     projected_normal = np.array([panel_norm_earth[:, 0],
                                  panel_norm_earth[:, 1],
                                  panel_norm_earth[:, 2]*0]).T
-    pvl_logger.debug('projected_normal=%s', projected_normal)
 
     # calculate vector magnitudes
     panel_norm_earth_mag = np.sqrt(np.nansum(panel_norm_earth**2, axis=1))
     projected_normal_mag = np.sqrt(np.nansum(projected_normal**2, axis=1))
-    pvl_logger.debug('panel_norm_earth_mag=%s, projected_normal_mag=%s',
-                     panel_norm_earth_mag, projected_normal_mag)
 
     # renormalize the projected vector
     # avoid creating nan values.
     non_zeros = projected_normal_mag != 0
     projected_normal[non_zeros] = (projected_normal[non_zeros].T /
                                    projected_normal_mag[non_zeros]).T
-    pvl_logger.debug('renormalized projected_normal=%s',
-                     projected_normal)
 
     # calculation of surface_azimuth
     # 1. Find the angle.


### PR DESCRIPTION
Will anyone miss these internal pvlib logging calls?

With these changes, ``grep logg pvlib/* -R`` returns nothing.

 - [x] Closes #447 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.