### PR TITLE
fix tests with python 3.6 and pandas 0.23

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -15,6 +15,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 * Unset executable bits of irradiance.py and test_irradiance.py (:issue:`460`)
+* Fix failing tests due to column order on Python 3.6+ and Pandas 0.23+
+  (:issue:`464`)
 
 
 Documentation

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -173,12 +173,13 @@ def test_run_model_tracker(system, location):
                          index=times)
     assert_series_equal(ac, expected, check_less_precise=2)
 
-    expected = pd.DataFrame(np.
+    expect = pd.DataFrame(np.
         array([[ 54.82513187,  90.        ,  11.0039221 ,  11.0039221 ],
                [         nan,   0.        ,   0.        ,          nan]]),
         columns=['aoi', 'surface_azimuth', 'surface_tilt', 'tracker_theta'],
         index=times)
-    assert_frame_equal(mc.tracking, expected, check_less_precise=2)
+    expect = expect[['tracker_theta', 'aoi', 'surface_azimuth', 'surface_tilt']]
+    assert_frame_equal(mc.tracking, expect, check_less_precise=2)
 
 
 def poadc(mc):

--- a/pvlib/test/test_tracking.py
+++ b/pvlib/test/test_tracking.py
@@ -25,6 +25,7 @@ def test_solar_noon():
     expect = pd.DataFrame({'tracker_theta': 0, 'aoi': 10,
                            'surface_azimuth': 90, 'surface_tilt': 0},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -41,6 +42,7 @@ def test_azimuth_north_south():
     expect = pd.DataFrame({'tracker_theta': -60, 'aoi': 0,
                            'surface_azimuth': 90, 'surface_tilt': 60},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 

--- a/pvlib/test/test_tracking.py
+++ b/pvlib/test/test_tracking.py
@@ -11,6 +11,8 @@ from numpy.testing import assert_allclose
 from pvlib.location import Location
 from pvlib import tracking
 
+SINGLEAXIS_COL_ORDER = ['tracker_theta', 'aoi',
+                        'surface_azimuth', 'surface_tilt']
 
 def test_solar_noon():
     apparent_zenith = pd.Series([10])
@@ -20,8 +22,8 @@ def test_solar_noon():
                                        max_angle=90, backtrack=True,
                                        gcr=2.0/7.0)
 
-    expect = pd.DataFrame({'aoi': 10, 'surface_azimuth': 90,
-                           'surface_tilt': 0, 'tracker_theta': 0},
+    expect = pd.DataFrame({'tracker_theta': 0, 'aoi': 10,
+                           'surface_azimuth': 90, 'surface_tilt': 0},
                            index=[0], dtype=np.float64)
 
     assert_frame_equal(expect, tracker_data)
@@ -36,8 +38,8 @@ def test_azimuth_north_south():
                                        max_angle=90, backtrack=True,
                                        gcr=2.0/7.0)
 
-    expect = pd.DataFrame({'aoi': 0, 'surface_azimuth': 90,
-                           'surface_tilt': 60, 'tracker_theta': -60},
+    expect = pd.DataFrame({'tracker_theta': -60, 'aoi': 0,
+                           'surface_azimuth': 90, 'surface_tilt': 60},
                            index=[0], dtype=np.float64)
 
     assert_frame_equal(expect, tracker_data)
@@ -63,6 +65,7 @@ def test_max_angle():
     expect = pd.DataFrame({'aoi': 15, 'surface_azimuth': 90,
                            'surface_tilt': 45, 'tracker_theta': 45},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -79,6 +82,7 @@ def test_backtrack():
     expect = pd.DataFrame({'aoi': 0, 'surface_azimuth': 90,
                            'surface_tilt': 80, 'tracker_theta': 80},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -90,6 +94,7 @@ def test_backtrack():
     expect = pd.DataFrame({'aoi': 52.5716, 'surface_azimuth': 90,
                            'surface_tilt': 27.42833, 'tracker_theta': 27.4283},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -104,8 +109,10 @@ def test_axis_tilt():
                                        gcr=2.0/7.0)
 
     expect = pd.DataFrame({'aoi': 7.286245, 'surface_azimuth': 142.65730,
-                           'surface_tilt': 35.98741, 'tracker_theta': -20.88121},
+                           'surface_tilt': 35.98741,
+                           'tracker_theta': -20.88121},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -117,6 +124,7 @@ def test_axis_tilt():
     expect = pd.DataFrame({'aoi': 47.6632, 'surface_azimuth': 50.96969,
                            'surface_tilt': 42.5152, 'tracker_theta': 31.6655},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -133,6 +141,7 @@ def test_axis_azimuth():
     expect = pd.DataFrame({'aoi': 30, 'surface_azimuth': 180,
                            'surface_tilt': 0, 'tracker_theta': 0},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -147,6 +156,7 @@ def test_axis_azimuth():
     expect = pd.DataFrame({'aoi': 0, 'surface_azimuth': 180,
                            'surface_tilt': 30, 'tracker_theta': 30},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -184,8 +194,10 @@ def test_SingleAxisTracker_tracking():
     tracker_data = system.singleaxis(apparent_zenith, apparent_azimuth)
 
     expect = pd.DataFrame({'aoi': 7.286245, 'surface_azimuth': 142.65730 ,
-                           'surface_tilt': 35.98741, 'tracker_theta': -20.88121},
+                           'surface_tilt': 35.98741,
+                           'tracker_theta': -20.88121},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 
@@ -202,9 +214,11 @@ def test_SingleAxisTracker_tracking():
     apparent_azimuth = pd.Series([180+pvsyst_solar_azimuth])
     apparent_zenith = pd.Series([90-pvsyst_solar_height])
     tracker_data = pvsyst_system.singleaxis(apparent_zenith, apparent_azimuth)
-    expect = pd.DataFrame({'aoi': 41.07852 , 'surface_azimuth': 180-18.432 ,
-                           'surface_tilt': 24.92122 , 'tracker_theta': -15.18391},
+    expect = pd.DataFrame({'aoi': 41.07852 , 'surface_azimuth': 180-18.432,
+                           'surface_tilt': 24.92122 ,
+                           'tracker_theta': -15.18391},
                            index=[0], dtype=np.float64)
+    expect = expect[SINGLEAXIS_COL_ORDER]
 
     assert_frame_equal(expect, tracker_data)
 

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -545,7 +545,8 @@ def singleaxis(apparent_zenith, apparent_azimuth,
                            'surface_azimuth': surface_azimuth,
                            'surface_tilt': surface_tilt},
                           index=times)
-
+    df_out = df_out[['tracker_theta', 'aoi',
+                     'surface_azimuth', 'surface_tilt']]
     df_out[apparent_zenith > 90] = np.nan
 
     return df_out


### PR DESCRIPTION

 - [x] Closes #464 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.