### PR TITLE
use pytest-mock to simplify and improve tests, improve test docs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - cmd: conda info -a
 
     # install depenencies
-    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy pytables pandas nose pytest pytz ephem numba siphon -c conda-forge
+    - cmd: conda create -n test_env --yes --quiet python=%PYTHON_VERSION% pip numpy scipy pytables pandas nose pytest pytz ephem numba siphon pytest-mock -c conda-forge
     - cmd: activate test_env
     - cmd: python --version
     - cmd: conda list

--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -4,6 +4,7 @@ dependencies:
     - pytz
     - pytest
     - pytest-cov
+    - pytest-mock
     - nose
     - pip:
         - coveralls

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -14,6 +14,7 @@ dependencies:
     - siphon
     - pytest
     - pytest-cov
+    - pytest-mock
     - nose
     - pip:
         - coveralls

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -14,6 +14,7 @@ dependencies:
     - siphon
     - pytest
     - pytest-cov
+    - pytest-mock
     - nose
     - pip:
         - coveralls

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -14,6 +14,7 @@ dependencies:
     - siphon
     - pytest
     - pytest-cov
+    - pytest-mock
     - nose
     - pip:
         - coveralls

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -14,6 +14,7 @@ dependencies:
     #- siphon
     - pytest
     - pytest-cov
+    - pytest-mock
     - nose
     - pip:
         - coveralls

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -143,8 +143,8 @@ it was called. Then a ``PVSystem`` object is created and the
 ``PVSystem.ashraeiam`` method is supposed to call the
 ``pvsystem.ashraeiam`` function with the angles supplied to the method
 call and the value of ``b`` that we defined in ``module_parameters``.
-The ``pvsystem.ashraeiam.assert_called_once_with`` call will test this
-for us! Finally, we check that the output of the method call is
+The ``pvsystem.ashraeiam.assert_called_once_with`` tests that this does,
+in fact, happen. Finally, we check that the output of the method call is
 reasonable.
 
 .. code-block:: python

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -9,7 +9,7 @@ contribute.
 
 
 Easy ways to contribute
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Here are a few ideas for you can contribute, even if you are new to
 pvlib-python, git, or Python:
@@ -33,7 +33,7 @@ pvlib-python, git, or Python:
 
 
 How to contribute new code
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Contributors to pvlib-python use GitHub's pull requests to add/modify
 its source code. The GitHub pull request process can be intimidating for
@@ -81,29 +81,113 @@ changes, such as fixing documentation typos.
 
 
 Testing
--------
+~~~~~~~
 
 pvlib's unit tests can easily be run by executing ``py.test`` on the
 pvlib directory:
 
-``py.test pvlib``
+``pytest pvlib``
 
 or, for a single module:
 
-``py.test pvlib/test/test_clearsky.py``
+``pytest pvlib/test/test_clearsky.py``
 
-While copy/paste coding should generally be avoided, it's a great way
-to learn how to write unit tests!
+or, for a single test:
 
-Unit test code should be placed in the corresponding test module in the
-pvlib/test directory.
+``pytest pvlib/test/test_clearsky.py::test_ineichen_nans``
+
+Use the ``--pdb`` flag to debug failures and avoid using ``print``.
+
+New unit test code should be placed in the corresponding test module in
+the pvlib/test directory.
 
 Developers **must** include comprehensive tests for any additions or
 modifications to pvlib.
 
+pvlib-python contains 3 "layers" of code: functions, PVSystem/Location,
+and ModelChain. Contributors will need to add tests that correspond to
+the layer that they modify.
+
+Functions
+---------
+Tests of core pvlib functions should ensure that the function returns
+the desired output for a variety of function inputs. The tests should be
+independent of other pvlib functions (see :issue:`394`). The tests
+should ensure that all reasonable combinations of input types (floats,
+nans, arrays, series, scalars, etc) work as expected. Remember that your
+use case is likely not the only way that this function will be used, and
+your input data may not be generic enough to fully test the function.
+Write tests that cover the full range of validity of the algorithm.
+It is also important to write tests that assert the return value of the
+function or that the function throws an exception when input data is
+beyond the range of algorithm validity.
+
+PVSystem/Location
+-----------------
+The PVSystem and Location classes provide convenience wrappers around
+the core pvlib functions. The tests in test_pvsystem.py and
+test_location.py should ensure that the method calls correctly wrap the
+function calls. Many PVSystem/Location methods pass one or more of their
+object's attributes (e.g. PVSystem.module_parameters, Location.latitude)
+to a function. Tests should ensure that attributes are passed correctly.
+These tests should also ensure that the method returns some reasonable
+data, though the precise values of the data should be covered by
+function-specific tests discussed above.
+
+We prefer to use the ``pytest-mock`` framework to write these tests. The
+test below shows an example of testing the ``PVSystem.ashraeiam``
+method. ``mocker`` is a ``pytest-mock`` object. ``mocker.spy`` adds
+features to the ``pvsystem.ashraeiam`` *function* that keep track of how
+it was called. Then a ``PVSystem`` object is created and the
+``PVSystem.ashraeiam`` *method* is called in the usual way. The
+``PVSystem.ashraeiam`` method is supposed to call the
+``pvsystem.ashraeiam`` function with the angles supplied to the method
+call and the value of ``b`` that we defined in ``module_parameters``.
+The ``pvsystem.ashraeiam.assert_called_once_with`` call will test this
+for us! Finally, we check that the output of the method call is
+reasonable.
+
+.. code-block:: python
+    def test_PVSystem_ashraeiam(mocker):
+        # mocker is a pytest-mock object.
+        # mocker.spy adds code to a function to keep track of how its called
+        mocker.spy(pvsystem, 'ashraeiam')
+
+        # set up inputs
+        module_parameters = pd.Series({'b': 0.05})
+        system = pvsystem.PVSystem(module_parameters=module_parameters)
+        thetas = 1
+
+        # call the method
+        iam = system.ashraeiam(thetas)
+
+        # did the method call the function as we expected?
+        # mocker.spy added assert_called_once_with to the function
+        pvsystem.ashraeiam.assert_called_once_with(thetas, b=0.05)
+
+        # check that the output is reasonable, but no need to duplicate
+        # the rigorous tests of the function
+        assert iam < 1.
+
+Avoid writing PVSystem/Location tests that depend sensitively on the
+return value of a statement as a substitute for using mock. These tests
+are sensitive to changes in the functions, which is *not* what we want
+to test here, and are difficult to maintain.
+
+ModelChain
+----------
+The tests in test_modelchain.py should ensure that
+``ModelChain.__init__`` correctly configures the ModelChain object to
+eventually run the selected models. A test should ensure that the
+appropriate method is actually called in the course of
+``Model_chain.run_model``. A test should ensure that the model selection
+does have a reasonable effect on the subsequent calculations, though the
+precise values of the data should be covered by the function tests
+discussed above. ``pytest-mock`` can also be used for testing ``ModelChain``.
+
 
 This documentation
-------------------
+~~~~~~~~~~~~~~~~~~
 
 If this documentation is unclear, help us improve it! Consider looking
 at the `pandas

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -21,10 +21,16 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
+* Expand testing section with guidelines for functions, PVSystem/Location
+  objects, and ModelChain.
 
 
 Testing
 ~~~~~~~
+* Add pytest-mock dependency
+* Use pytest-mock to ensure that PVSystem methods call corresponding functions
+  correctly. Removes implicit dependence on precise return values of functions
+* Use pytest-mock to ensure that ModelChain DC model is set up correctly.
 
 
 Contributors

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -211,6 +211,22 @@ def test_dc_models(system, cec_dc_snl_ac_system, pvwatts_dc_pvwatts_ac_system,
     assert_series_equal(ac, expected, check_less_precise=2)
 
 
+@pytest.mark.parametrize('dc_model', ['sapm', 'singlediode', 'pvwatts_dc'])
+def test_infer_dc_model(system, cec_dc_snl_ac_system,
+                        pvwatts_dc_pvwatts_ac_system, location, dc_model,
+                        mocker):
+    dc_systems = {'sapm': system, 'singlediode': cec_dc_snl_ac_system,
+                  'pvwatts_dc': pvwatts_dc_pvwatts_ac_system}
+    system = dc_systems[dc_model]
+    m = mocker.spy(system, dc_model)
+    mc = ModelChain(system, location,
+                    aoi_model='no_loss', spectral_model='no_loss')
+    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
+    mc.run_model(times)
+    m.assert_called_once()
+    assert isinstance(mc.dc, (pd.Series, pd.DataFrame))
+
+
 def acdc(mc):
     mc.ac = mc.dc
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -116,7 +116,7 @@ def test_ashraeiam_scalar():
 def test_PVSystem_ashraeiam(mocker):
     module_parameters = pd.Series({'b': 0.05})
     system = pvsystem.PVSystem(module_parameters=module_parameters)
-    m = mocker.patch('pvlib.pvsystem.ashraeiam')
+    m = mocker.patch('pvlib.pvsystem.ashraeiam', autospec=True)
     thetas = None
     iam = system.ashraeiam(thetas)
     m.assert_called_once_with(thetas, **module_parameters)
@@ -152,7 +152,7 @@ def test_physicaliam_scalar():
 def test_PVSystem_physicaliam_mocked(mocker):
     module_parameters = pd.Series({'K': 4, 'L': 0.002, 'n': 1.526})
     system = pvsystem.PVSystem(module_parameters=module_parameters)
-    m = mocker.patch('pvlib.pvsystem.physicaliam')
+    m = mocker.patch('pvlib.pvsystem.physicaliam', autospec=True)
     thetas = None
     iam = system.physicaliam(thetas)
     m.assert_called_once_with(thetas, **module_parameters)

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1092,36 +1092,57 @@ def make_pvwatts_system_kwargs():
     return system
 
 
-def test_PVSystem_pvwatts_dc():
+def test_PVSystem_pvwatts_dc(mocker):
+    mocker.spy(pvsystem, 'pvwatts_dc')
     system = make_pvwatts_system_defaults()
-    irrad_trans = pd.Series([np.nan, 900, 900])
-    temp_cell = pd.Series([30, np.nan, 30])
-    expected = pd.Series(np.array([   nan,    nan,  88.65]))
-    out = system.pvwatts_dc(irrad_trans, temp_cell)
-    assert_series_equal(expected, out)
+    irrad = 900
+    temp_cell = 30
+    expected = 90
+    out = system.pvwatts_dc(irrad, temp_cell)
+    pvsystem.pvwatts_dc.assert_called_once_with(irrad, temp_cell,
+                                                **system.module_parameters)
+    assert_allclose(expected, out, atol=10)
 
+
+def test_PVSystem_pvwatts_dc_kwargs(mocker):
+    mocker.spy(pvsystem, 'pvwatts_dc')
     system = make_pvwatts_system_kwargs()
-    expected = pd.Series(np.array([   nan,    nan,  87.3]))
-    out = system.pvwatts_dc(irrad_trans, temp_cell)
-    assert_series_equal(expected, out)
+    irrad = 900
+    temp_cell = 30
+    expected = 90
+    out = system.pvwatts_dc(irrad, temp_cell)
+    pvsystem.pvwatts_dc.assert_called_once_with(irrad, temp_cell,
+                                                **system.module_parameters)
+    assert_allclose(expected, out, atol=10)
 
 
-def test_PVSystem_pvwatts_losses():
+def test_PVSystem_pvwatts_losses(mocker):
+    mocker.spy(pvsystem, 'pvwatts_losses')
     system = make_pvwatts_system_defaults()
-    expected = pd.Series([nan, 14.934904])
-    age = pd.Series([nan, 1])
+    expected = 15
+    age = 1
     out = system.pvwatts_losses(age=age)
-    assert_series_equal(expected, out)
+    pvsystem.pvwatts_losses.assert_called_once_with(age=age)
+    assert out < 100
 
 
-def test_PVSystem_pvwatts_ac():
+def test_PVSystem_pvwatts_ac(mocker):
+    mocker.spy(pvsystem, 'pvwatts_ac')
     system = make_pvwatts_system_defaults()
-    pdc = pd.Series([np.nan, 50, 100])
-    expected = pd.Series(np.array([       nan,  48.1095776694, 96.0]))
+    pdc = 50
+    pdc0 = system.module_parameters['pdc0']
     out = system.pvwatts_ac(pdc)
-    assert_series_equal(expected, out)
+    pvsystem.pvwatts_ac.assert_called_once_with(pdc, pdc0,
+                                                **system.inverter_parameters)
+    assert out < pdc
 
+
+def test_PVSystem_pvwatts_ac_kwargs(mocker):
+    mocker.spy(pvsystem, 'pvwatts_ac')
     system = make_pvwatts_system_kwargs()
-    expected = pd.Series(np.array([       nan,  45.88025, 91.5515]))
+    pdc = 50
+    pdc0 = system.module_parameters['pdc0']
     out = system.pvwatts_ac(pdc)
-    assert_series_equal(expected, out)
+    pvsystem.pvwatts_ac.assert_called_once_with(pdc, pdc0,
+                                                **system.inverter_parameters)
+    assert out < pdc

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -113,15 +113,13 @@ def test_ashraeiam_scalar():
     assert_allclose(iam, expected, equal_nan=True)
 
 
-@needs_numpy_1_10
-def test_PVSystem_ashraeiam():
+def test_PVSystem_ashraeiam(mocker):
     module_parameters = pd.Series({'b': 0.05})
     system = pvsystem.PVSystem(module_parameters=module_parameters)
-    thetas = np.array([-90. , -67.5, -45. , -22.5,   0. ,  22.5,  45. ,  67.5,  89., 90. , np.nan])
+    m = mocker.patch('pvlib.pvsystem.ashraeiam')
+    thetas = None
     iam = system.ashraeiam(thetas)
-    expected = np.array([        0,  0.9193437 ,  0.97928932,  0.99588039,  1.        ,
-        0.99588039,  0.97928932,  0.9193437 ,         0, 0,  np.nan])
-    assert_allclose(iam, expected, equal_nan=True)
+    m.assert_called_once_with(thetas, **module_parameters)
 
 
 @needs_numpy_1_10
@@ -151,15 +149,13 @@ def test_physicaliam_scalar():
     assert_allclose(iam, expected, equal_nan=True)
 
 
-@needs_numpy_1_10
-def test_PVSystem_physicaliam():
+def test_PVSystem_physicaliam_mocked(mocker):
     module_parameters = pd.Series({'K': 4, 'L': 0.002, 'n': 1.526})
     system = pvsystem.PVSystem(module_parameters=module_parameters)
-    thetas = np.array([-90. , -67.5, -45. , -22.5,   0. ,  22.5,  45. ,  67.5,  90. , np.nan])
+    m = mocker.patch('pvlib.pvsystem.physicaliam')
+    thetas = None
     iam = system.physicaliam(thetas)
-    expected = np.array([        0,  0.8893998 ,  0.98797788,  0.99926198,         1,
-        0.99926198,  0.98797788,  0.8893998 ,         0, np.nan])
-    assert_allclose(iam, expected, equal_nan=True)
+    m.assert_called_once_with(thetas, **module_parameters)
 
 
 # if this completes successfully we'll be able to do more tests below.

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -230,14 +230,15 @@ def test_sapm(sapm_module_params):
                   sapm_module_params.to_dict())
 
 
-def test_PVSystem_sapm(sapm_module_params):
+def test_PVSystem_sapm(sapm_module_params, mocker):
+    mocker.spy(pvsystem, 'sapm')
     system = pvsystem.PVSystem(module_parameters=sapm_module_params)
-
-    times = pd.DatetimeIndex(start='2015-01-01', periods=5, freq='12H')
-    effective_irradiance = pd.Series([-1, 0.5, 1.1, np.nan, 1], index=times)
-    temp_cell = pd.Series([10, 25, 50, 25, np.nan], index=times)
-
+    effective_irradiance = 0.5
+    temp_cell = 25
     out = system.sapm(effective_irradiance, temp_cell)
+    pvsystem.sapm.assert_called_once_with(effective_irradiance, temp_cell,
+                                          sapm_module_params)
+    assert_allclose(out['p_mp'], 100, atol=100)
 
 
 @pytest.mark.parametrize('airmass,expected', [

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -21,38 +21,11 @@ from pvlib.location import Location
 
 from conftest import needs_numpy_1_10, requires_scipy
 
-latitude = 32.2
-longitude = -111
-tus = Location(latitude, longitude, 'US/Arizona', 700, 'Tucson')
-times = pd.date_range(start=datetime.datetime(2014,1,1),
-                      end=datetime.datetime(2014,1,2), freq='1Min')
-ephem_data = solarposition.get_solarposition(times,
-                                             latitude=latitude,
-                                             longitude=longitude,
-                                             method='nrel_numpy')
-am = atmosphere.relativeairmass(ephem_data.apparent_zenith)
-irrad_data = clearsky.ineichen(ephem_data['apparent_zenith'], am,
-                               linke_turbidity=3)
-aoi = irradiance.aoi(0, 0, ephem_data['apparent_zenith'],
-                     ephem_data['azimuth'])
-
-
-meta = {'latitude': 37.8,
-        'longitude': -122.3,
-        'altitude': 10,
-        'Name': 'Oakland',
-        'State': 'CA',
-        'TZ': -8}
-
-pvlib_abspath = os.path.dirname(os.path.abspath(inspect.getfile(tmy)))
-
-tmy3_testfile = os.path.join(pvlib_abspath, 'data', '703165TY.csv')
-tmy2_testfile = os.path.join(pvlib_abspath, 'data', '12839.tm2')
-
-tmy3_data, tmy3_metadata = tmy.readtmy3(tmy3_testfile)
-tmy2_data, tmy2_metadata = tmy.readtmy2(tmy2_testfile)
 
 def test_systemdef_tmy3():
+    pvlib_abspath = os.path.dirname(os.path.abspath(inspect.getfile(tmy)))
+    tmy3_testfile = os.path.join(pvlib_abspath, 'data', '703165TY.csv')
+    tmy3_data, tmy3_metadata = tmy.readtmy3(tmy3_testfile)
     expected = {'tz': -9.0,
                 'albedo': 0.1,
                 'altitude': 7.0,
@@ -65,7 +38,12 @@ def test_systemdef_tmy3():
                 'surface_tilt': 0}
     assert expected == pvsystem.systemdef(tmy3_metadata, 0, 0, .1, 5, 5)
 
+
 def test_systemdef_tmy2():
+    pvlib_abspath = os.path.dirname(os.path.abspath(inspect.getfile(tmy)))
+    tmy2_testfile = os.path.join(pvlib_abspath, 'data', '12839.tm2')
+    tmy2_data, tmy2_metadata = tmy.readtmy2(tmy2_testfile)
+
     expected = {'tz': -5,
                 'albedo': 0.1,
                 'altitude': 2.0,
@@ -78,7 +56,15 @@ def test_systemdef_tmy2():
                 'surface_tilt': 0}
     assert expected == pvsystem.systemdef(tmy2_metadata, 0, 0, .1, 5, 5)
 
+
 def test_systemdef_dict():
+    meta = {'latitude': 37.8,
+            'longitude': -122.3,
+            'altitude': 10,
+            'Name': 'Oakland',
+            'State': 'CA',
+            'TZ': -8}
+
     expected = {'tz': -8, ## Note that TZ is float, but Location sets tz as string
                 'albedo': 0.1,
                 'altitude': 10,


### PR DESCRIPTION
Rewrites PVSystem tests using ``pytest-mock`` and adds a new ModelChain test. Please see the whatsnew diff and the new documentation for more details on how and why. 

The changes to ``test_pvsystem.py`` are complete (I think). I don't currently have time to go through the entire ``test_modelchain.py`` module and improve the tests to use the new methods. I suggest calling it good enough for this pull request. It at least provides an example for people working with the modelchain code in the future.

See discussion in #466 in [this comment](https://github.com/pvlib/pvlib-python/pull/466#issuecomment-392558404) and below for more context.

 - [ ] Closes issue #xxxx
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [ ] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
