### PR TITLE
ModelChain.prepare_inputs fails to pass solar_position and airmass to Location.get_clearsky

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -20,6 +20,8 @@ Bug fixes
 * Unset executable bits of irradiance.py and test_irradiance.py (:issue:`460`)
 * Fix failing tests due to column order on Python 3.6+ and Pandas 0.23+
   (:issue:`464`)
+* ModelChain.prepare_inputs failed to pass solar_position and airmass to
+  Location.get_clearsky. Fixed. (:issue:`481`)
 
 
 Documentation

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -273,7 +273,7 @@ class ModelChain(object):
     spectral_model: None, str, or function, default None
         If None, the model will be inferred from the contents of
         system.module_parameters. Valid strings are 'sapm',
-        'first_solar', 'no_loss'. The ModelChain instance will be passed 
+        'first_solar', 'no_loss'. The ModelChain instance will be passed
         as the first argument to a user-defined
         function.
 
@@ -772,8 +772,8 @@ class ModelChain(object):
         if not any([x in ['ghi', 'dni', 'dhi'] for x in self.weather.columns]):
             self.weather[['ghi', 'dni', 'dhi']] = self.location.get_clearsky(
                 self.solar_position.index, self.clearsky_model,
-                zenith_data=self.solar_position['apparent_zenith'],
-                airmass_data=self.airmass['airmass_absolute'])
+                solar_position=self.solar_position,
+                airmass_absolute=self.airmass['airmass_absolute'])
 
         if not {'ghi', 'dni', 'dhi'} <= set(self.weather.columns):
             raise ValueError(


### PR DESCRIPTION
 - [x] Closes #481
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

Not sure how to test this or if it's worth the time investment. I recommend double checking the code is right and merging.