### PR TITLE
add PVSystem.losses_parameters, add support for custom pvwatts losses parameters in ModelChain

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -5,10 +5,11 @@ v0.6.0 (___, 2018)
 
 API Changes
 ~~~~~~~~~~~
-* pvsystem.calcparams_desoto now requires arguments for each module model parameter.
+* pvsystem.calcparams_desoto now requires arguments for each module model
+  parameter. (:issue:`462`)
 * Add losses_parameters attribute to PVSystem objects and remove the **kwargs
   support from PVSystem.pvwatts_losses. Enables custom losses specification
-  in ModelChain calculations. (:issue:``)
+  in ModelChain calculations. (:issue:`484`)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -6,6 +6,9 @@ v0.6.0 (___, 2018)
 API Changes
 ~~~~~~~~~~~
 * pvsystem.calcparams_desoto now requires arguments for each module model parameter.
+* Add losses_parameters attribute to PVSystem objects and remove the **kwargs
+  support from PVSystem.pvwatts_losses. Enables custom losses specification
+  in ModelChain calculations. (:issue:``)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -10,7 +10,6 @@ API Changes
 * Add losses_parameters attribute to PVSystem objects and remove the kwargs
   support from PVSystem.pvwatts_losses. Enables custom losses specification
   in ModelChain calculations. (:issue:`484`)
-* pvsystem.calcparams_desoto now requires arguments for each module model parameter.
 * removed irradiance parameter from ModelChain.run_model and ModelChain.prepare_inputs
 
 

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -7,7 +7,7 @@ API Changes
 ~~~~~~~~~~~
 * pvsystem.calcparams_desoto now requires arguments for each module model
   parameter. (:issue:`462`)
-* Add losses_parameters attribute to PVSystem objects and remove the **kwargs
+* Add losses_parameters attribute to PVSystem objects and remove the kwargs
   support from PVSystem.pvwatts_losses. Enables custom losses specification
   in ModelChain calculations. (:issue:`484`)
 * pvsystem.calcparams_desoto now requires arguments for each module model parameter.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -611,7 +611,7 @@ class PVSystem(object):
         kwargs = _build_kwargs(['soiling', 'shading', 'snow', 'mismatch',
                                 'wiring', 'connections', 'lid',
                                 'nameplate_rating', 'age', 'availability'],
-                                self.losses_parameters)
+                               self.losses_parameters)
         return pvwatts_losses(**kwargs)
 
     def pvwatts_ac(self, pdc):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -99,6 +99,9 @@ class PVSystem(object):
     racking_model : None or string, default 'open_rack_cell_glassback'
         Used for cell and module temperature calculations.
 
+    losses_parameters : None, dict or Series, default None
+        Losses parameters as defined by PVWatts or other.
+
     name : None or string, default None
 
     **kwargs

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 from numpy import nan
@@ -78,9 +80,17 @@ def pvwatts_dc_pvwatts_ac_system(sam_data):
     return system
 
 
-@pytest.fixture()
+@pytest.fixture
 def location():
     return Location(32.2, -111, altitude=700)
+
+
+@pytest.fixture
+def weather():
+    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
+    weather = pd.DataFrame({'ghi': [500, 0], 'dni': [800, 0], 'dhi': [100, 0]},
+                           index=times)
+    return weather
 
 
 def test_ModelChain_creation(system, location):
@@ -302,64 +312,43 @@ def constant_losses(mc):
     mc.ac *= mc.losses
 
 
-@requires_scipy
-@pytest.mark.parametrize('losses_model, expected', [
-    ('pvwatts', [163.280464174, 0]),
-    ('no_loss', [190.028186986, 0]),
-    (constant_losses, [171.025368287, 0])
-])
-def test_losses_models(pvwatts_dc_pvwatts_ac_system, location, losses_model,
-                       expected):
-    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
-                    aoi_model='no_loss', spectral_model='no_loss',
-                    losses_model=losses_model)
-    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
-    ac = mc.run_model(times).ac
-
-    expected = pd.Series(np.array(expected), index=times)
-    assert_series_equal(ac, expected, check_less_precise=2)
-
-
-@requires_scipy
-def test_losses_models_pvwatts(pvwatts_dc_pvwatts_ac_system, location, mocker):
+def test_losses_models_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather,
+                               mocker):
     age = 1
     pvwatts_dc_pvwatts_ac_system.losses_parameters = dict(age=age)
     m = mocker.spy(pvsystem, 'pvwatts_losses')
     mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
                     aoi_model='no_loss', spectral_model='no_loss',
                     losses_model='pvwatts')
-    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
-    mc.run_model(times)
-
+    mc.run_model(weather.index, weather=weather)
     assert m.call_count == 1
-    assert pvsystem.pvwatts_losses.assert_called_with(age=age)
+    m.assert_called_with(age=age)
     assert isinstance(mc.ac, (pd.Series, pd.DataFrame))
     assert not mc.ac.empty
 
 
-@requires_scipy
-def test_losses_models_ext_def(pvwatts_dc_pvwatts_ac_system, location, mocker):
-    m = mocker.spy(__name__, 'constant_losses')
+def test_losses_models_ext_def(pvwatts_dc_pvwatts_ac_system, location, weather,
+                               mocker):
+    m = mocker.spy(sys.modules[__name__], 'constant_losses')
     mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
                     aoi_model='no_loss', spectral_model='no_loss',
                     losses_model=constant_losses)
-    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
-    mc.run_model(times)
-
+    mc.run_model(weather.index, weather=weather)
     assert m.call_count == 1
     assert isinstance(mc.ac, (pd.Series, pd.DataFrame))
+    assert mc.losses == 0.9
     assert not mc.ac.empty
 
 
-@requires_scipy
-def test_losses_models_no_loss(pvwatts_dc_pvwatts_ac_system, location):
+def test_losses_models_no_loss(pvwatts_dc_pvwatts_ac_system, location, weather,
+                               mocker):
+    m = mocker.spy(pvsystem, 'pvwatts_losses')
     mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
                     aoi_model='no_loss', spectral_model='no_loss',
                     losses_model='no_loss')
-    times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
-
     assert mc.losses_model == mc.no_extra_losses
-    mc.run_model(times)
+    mc.run_model(weather.index, weather=weather)
+    assert m.call_count == 0
     assert mc.losses == 1
 
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1156,9 +1156,10 @@ def test_PVSystem_pvwatts_dc_kwargs(mocker):
 def test_PVSystem_pvwatts_losses(mocker):
     mocker.spy(pvsystem, 'pvwatts_losses')
     system = make_pvwatts_system_defaults()
-    expected = 15
     age = 1
-    out = system.pvwatts_losses(age=age)
+    system.losses_parameters = dict(age=age)
+    expected = 15
+    out = system.pvwatts_losses()
     pvsystem.pvwatts_losses.assert_called_once_with(age=age)
     assert out < expected
 


### PR DESCRIPTION
 - [x] Closes #484
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.

Added tests to ensure that custom losses are now supported in ModelChain.