### PR TITLE
specify user-agent in tmy3 remote request

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -22,6 +22,8 @@ Bug fixes
   (:issue:`464`)
 * ModelChain.prepare_inputs failed to pass solar_position and airmass to
   Location.get_clearsky. Fixed. (:issue:`481`)
+* Add User-Agent specification to TMY3 remote requests to avoid rejection.
+  (:issue:`493`)
 
 
 Documentation


### PR DESCRIPTION
 - [x] Closes #493 
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff`` and/or landscape.io linting service.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.