### PR TITLE
BUG: fix klucher nan output for numpy

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -59,7 +59,8 @@ Bug fixes
   Location.get_clearsky. Fixed. (:issue:`481`)
 * Add User-Agent specification to TMY3 remote requests to avoid rejection.
   (:issue:`493`)
-
+* Fix ``pvlib.irradiance.klucher`` output is different for Pandas Series vs.
+  floats and NumPy arrays. (:issue:`508`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -629,7 +629,7 @@ def klucher(surface_tilt, surface_azimuth, dhi, ghi, solar_zenith,
         # fails with single point input
         F.fillna(0, inplace=True)
     except AttributeError:
-        F = 0
+        F = np.where(np.isnan(F), 0, F)
 
     term1 = 0.5 * (1 + tools.cosd(surface_tilt))
     term2 = 1 + F * (tools.sind(0.5 * surface_tilt) ** 3)

--- a/pvlib/test/test_irradiance.py
+++ b/pvlib/test/test_irradiance.py
@@ -114,8 +114,20 @@ def test_isotropic_series():
 
 
 def test_klucher_series_float():
-    result = irradiance.klucher(40, 180, 100, 900, 20, 180)
-    assert_allclose(result, 88.3022221559)
+    # klucher inputs
+    surface_tilt, surface_azimuth = 40.0, 180.0
+    dhi, ghi = 100.0, 900.0
+    solar_zenith, solar_azimuth = 20.0, 180.0
+    # expect same result for floats and pd.Series
+    expected = irradiance.klucher(
+        surface_tilt, surface_azimuth,
+        pd.Series(dhi), pd.Series(ghi),
+        pd.Series(solar_zenith), pd.Series(solar_azimuth)
+    )  # 94.99429931664851
+    result = irradiance.klucher(
+        surface_tilt, surface_azimuth, dhi, ghi, solar_zenith, solar_azimuth
+    )
+    assert_allclose(result, expected[0])
 
 
 def test_klucher_series():
@@ -123,6 +135,12 @@ def test_klucher_series():
                        ephem_data['apparent_zenith'],
                        ephem_data['azimuth'])
     assert_allclose(result, [0, 37.446276, 109.209347, 56.965916], atol=1e-4)
+    # expect same result for np.array and pd.Series
+    expected = irradiance.klucher(
+        40, 180, irrad_data['dhi'].values, irrad_data['ghi'].values,
+        ephem_data['apparent_zenith'].values, ephem_data['azimuth'].values
+    )
+    assert_allclose(result, expected, atol=1e-4)
 
 
 def test_haydavies():


### PR DESCRIPTION
* fixes #508
* use `F = np.where(np.isnan(F), 0, F)` to only replace `nan` with zero
* previously if numpy array with nan, then entire array was zeroed so output differed from pandas series input

pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes issue #xxxx
 - [ ] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
