### PR TITLE
Detect clearsky modifications

### DIFF
--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -688,9 +688,6 @@ def detect_clearsky(measured, clearsky, times, window_length,
                                   'times. consider resampling your data.')
 
     samples_per_window = int(window_length / sample_interval) + 1
-    # print(window_length)
-    # print(sample_interval)
-    # print(samples_per_window)
 
     # generate matrix of integers for creating windows with indexing
     from scipy.linalg import hankel
@@ -730,8 +727,7 @@ def detect_clearsky(measured, clearsky, times, window_length,
         c2 = np.abs(meas_max - alpha*clear_max) < max_diff
         c3 = (line_diff > lower_line_length) & (line_diff < upper_line_length)
         c4 = meas_slope_nstd < var_diff
-        #  c5 = (meas_slope_max - alpha*clear_slope_max) < slope_dev
-        c5 = np.max(meas_slope - alpha*clear_slope, axis=0) < slope_dev
+        c5 = np.max(np.abs(meas_slope - alpha*clear_slope), axis=0) < slope_dev
         c6 = (clear_mean != 0) & ~np.isnan(clear_mean)
         clear_windows = c1 & c2 & c3 & c4 & c5 & c6
 


### PR DESCRIPTION
Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

The fifth condition (`c5`) of the `clearsky.detect_clearsky` function wasn't calculated as defined in the original reference (equations 12 - 14).  This pull request also addresses part of #507 where there was an implicit assumption of minutely data.  All derivatives are now calculated by explicitly dividing by the `sample_interval`.  This does not address non-uniform time intervals.

 - [ ] Closes issue #506 (addresses part of #507)
 - [ ] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.


