### PR TITLE
make test_forecast.py more robust, warn problems instead of fail

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -95,6 +95,7 @@ Testing
   function per test. (:issue:`394`)
 * Use pytest-mock to ensure that ModelChain DC model is set up correctly.
 * Add Python 3.7 to build matrix
+* Make test_forecast.py more robust. (:issue:`293`)
 
 
 Contributors

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -1,4 +1,3 @@
-import sys
 import platform
 
 from pkg_resources import parse_version
@@ -7,7 +6,7 @@ import numpy as np
 import pytest
 
 
-skip_windows = pytest.mark.skipif('win' in sys.platform,
+skip_windows = pytest.mark.skipif(platform.system() == 'Windows',
                                   reason='does not run on windows')
 
 try:

--- a/pvlib/test/test_forecast.py
+++ b/pvlib/test/test_forecast.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import inspect
 from math import isnan
 from pytz import timezone
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -53,11 +54,10 @@ def model(request):
     try:
         raw_data = amodel.get_data(_latitude, _longitude, _start, _end)
     except Exception as e:
-        print('Exception getting data for ', amodel)
-        print('latitude, longitude, start, end = ',
-              _latitude, _longitude, _start, _end)
-        print(e)
-        raw_data = pd.DataFrame(tz=_start.tzinfo)
+        warnings.warn('Exception getting data for {}.\n'
+                      'latitude, longitude, start, end = {} {} {} {}\n{}'
+                      .format(amodel, _latitude, _longitude, _start, _end, e))
+        raw_data = pd.DataFrame()  # raw_data.empty will be used later
     amodel.raw_data = raw_data
     return amodel
 
@@ -66,15 +66,16 @@ def model(request):
 def test_process_data(model):
     for how in ['liujordan', 'clearsky_scaling']:
         if model.raw_data.empty:
-            print('Could not process {} data with how={} '
-                  'because raw_data was empty'.format(model, how))
+            warnings.warn('Could not test {} process_data with how={} '
+                          'because raw_data was empty'.format(model, how))
             continue
         data = model.process_data(model.raw_data, how=how)
         for variable in _nonnan_variables:
             try:
                 assert not data[variable].isnull().values.any()
             except AssertionError:
-                print(model, variable, 'data contained null values')
+                warnings.warn('{}, {}, data contained null values'
+                              .format(model, variable))
 
 
 @requires_siphon


### PR DESCRIPTION
 - [x] Closes #293
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

This PR should resolve the majority of the intermittent test failures due to ``test_forecast.py``. The errors will now be recorded as warnings. This is not ideal but I think it's acceptable. 

I tested that all of the warnings are printed when I force exceptions in the try blocks.