### PR TITLE
add statement re ending python 2.7 support on June 1 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Installation
 pvlib-python releases may be installed using the ``pip`` and ``conda`` tools.
 Please see the [Installation page](http://pvlib-python.readthedocs.io/en/latest/installation.html) of the documentation for complete instructions.
 
-pvlib-python is compatible with Python versions 2.7 and 3.4-3.7
+pvlib-python is compatible with Python versions 2.7 and 3.4-3.7.
+
+**Python 2.7 support will end on June 1, 2019**. Releases made after this
+date will require Python 3.
 
 
 Contributing

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -3,6 +3,10 @@
 v0.6.0 (___, 2018)
 ---------------------
 
+**Python 2.7 support will end on June 1, 2019**. Releases made after this
+date will require Python 3. (:issue:`501`)
+
+
 API Changes
 ~~~~~~~~~~~
 * pvsystem.calcparams_desoto now requires arguments for each module model


### PR DESCRIPTION
 - [x] Closes #501
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
