### PR TITLE
improve performance of solarposition.ephemeris dataframe assembly

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -60,6 +60,7 @@ Enhancements
   :func:`~pvlib.singlediode.bishop88_mpp`.
 * Add PVSyst thin-film recombination losses for CdTe and a:Si (:issue:`163`)
 * Python 3.7 officially supported. (:issue:`496`)
+* Improve performance of solarposition.ephemeris. (:issue:`512`)
 
 
 Bug fixes

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -690,13 +690,14 @@ def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
     ApparentSunEl = SunEl + Refract
 
     # make output DataFrame
-    DFOut = pd.DataFrame(index=time)
+    DFOut = pd.DataFrame(index=time_utc)
     DFOut['apparent_elevation'] = ApparentSunEl
     DFOut['elevation'] = SunEl
     DFOut['azimuth'] = SunAz
     DFOut['apparent_zenith'] = 90 - ApparentSunEl
     DFOut['zenith'] = 90 - SunEl
     DFOut['solar_time'] = SolarTime
+    DFOut.index = time
 
     return DFOut
 

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -260,6 +260,19 @@ def test_ephemeris_physical_dst(expected_solpos):
     assert_frame_equal(expected_solpos, ephem_data[expected_solpos.columns])
 
 
+def test_ephemeris_physical_no_tz(expected_solpos):
+    times = pd.date_range(datetime.datetime(2003,10,17,19,30,30),
+                          periods=1, freq='D')
+    ephem_data = solarposition.ephemeris(times, golden_mst.latitude,
+                                         golden_mst.longitude,
+                                         pressure=82000,
+                                         temperature=11)
+    expected_solpos.index = times
+    expected_solpos = np.round(expected_solpos, 2)
+    ephem_data = np.round(ephem_data, 2)
+    assert_frame_equal(expected_solpos, ephem_data[expected_solpos.columns])
+
+
 def test_get_solarposition_error():
     times = pd.date_range(datetime.datetime(2003,10,17,13,30,30),
                           periods=1, freq='D', tz=golden.tz)


### PR DESCRIPTION
 - [x] Closes #512
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.