### PR TITLE
limit pvwatts_ac results to greater than equal to 0

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -118,6 +118,7 @@ Bug fixes
   Hay-Davies diffuse sky algorithms. (:issue:`432`)
 * Fix argument order of longitude and latitude when querying weather forecasts
   by lonlat bounding box (:issue:`521`)
+* Limit pvwatts_ac results to be greater than or equal to 0. (:issue:`541`)
 
 
 Documentation

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2693,9 +2693,11 @@ def pvwatts_ac(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     pac0 = eta_inv_nom * pdc0
     zeta = pdc / pdc0
 
+    # eta < 0 if zeta < 0.006. pac is forced to be >= 0 below. GH 541
     eta = eta_inv_nom / eta_inv_ref * (-0.0162*zeta - 0.0059/zeta + 0.9858)
 
     pac = eta * pdc
     pac = np.minimum(pac0, pac)
+    pac = np.maximum(0, pac)     # GH 541
 
     return pac

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1275,6 +1275,14 @@ def test_pvwatts_ac_scalars():
     assert_allclose(out, expected)
 
 
+def test_pvwatts_ac_possible_negative():
+    # pvwatts_ac could return a negative value for (pdc / pdc0) < 0.006
+    # unless it is clipped. see GH 541 for more
+    expected = 0
+    out = pvsystem.pvwatts_ac(0.001, 1)
+    assert_allclose(out, expected)
+
+
 @needs_numpy_1_10
 def test_pvwatts_ac_arrays():
     pdc = np.array([[np.nan], [50], [100]])


### PR DESCRIPTION
 - [x] Closes #541 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

I confirmed that the new test fails without the fix.
