### PR TITLE
fix variable/column name bug in HRRR_ESRL.output_variables

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -129,6 +129,8 @@ Bug fixes
 * Fix issue with unbounded clearness index calculation in disc. (:issue:`540`)
 * Limit pvwatts_ac results to be greater than or equal to 0. (:issue:`541`)
 * Fix bug in get_relative_airmass(model='youngirvine1967'). (:issue:`545`)
+* Fix bug in variable names returned by forecast.py's HRRR_ESRL model.
+  (:issue:`557`)
 
 
 Documentation

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -747,8 +747,8 @@ class HRRR_ESRL(ForecastModel):
     """
 
     def __init__(self, set_type='best'):
-        import warnings
-        warnings.warn('HRRR_ESRL is an experimental model and is not always available.')
+        warnings.warn('HRRR_ESRL is an experimental model and is not '
+                      'always available.')
 
         model_type = 'Forecast Model Data'
         model = 'GSD HRRR CONUS 3km surface'
@@ -764,7 +764,7 @@ class HRRR_ESRL(ForecastModel):
 
         self.output_variables = [
             'temp_air',
-            'wind_speed'
+            'wind_speed',
             'ghi_raw',
             'ghi',
             'dni',


### PR DESCRIPTION
 - [x] Closes #557 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
