### PR TITLE
add Stickler CI config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ The following items must be addressed before the code can be merged. Please don'
  - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
  - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
  - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
- - [ ] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
+ - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
  - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
  - [ ] Pull request is nearly complete and ready for detailed review.
 

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,7 @@
+linters:
+    flake8:
+        python: 3
+        max-line-length: 79
+files:
+    ignore:
+        - 'pvlib/_version.py'

--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -167,6 +167,7 @@ Testing
 * Make test_forecast.py more robust. (:issue:`293`)
 * Improve test_atmosphere.py. (:issue:`158`)
 * Add LGTM.com integration. (:issue:`554`)
+* Add SticklerCI integration.
 
 
 Contributors


### PR DESCRIPTION
I'd like to try using Stickler CI service with pvlib. https://stickler-ci.com

Stickler CI will automatically review pull requests and comment on style issues. I configured it on my fork and made this example pull request: https://github.com/wholmgren/pvlib-python/pull/5

Pros:
- Maintainers don't have to spend as much time on style issues
- It won't accidentally overlook issues
- People can get frustrated at a bot that nags them instead of at me

Cons:
- It's an extra notification clogging your inbox
- Maybe it makes pull requests a little harder to read