### PR TITLE
codecov, deploy git tags to pypi with travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
+        target: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+        paths:
+          - "pvlib/(\w+/)?[^/]+\.py$"
+
+      tests:
+        target: 100%
+        paths:
+          - "pvlib/tests/.*"
+
+comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = pvlib/_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,6 @@ after_success:
     coveralls
 
 deploy:
-  matrix:
   - provider: pypi
     user: wholmgren
     password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       env:
         - CONDA_ENV=py36
         - TASK="coverage"
+        - DEPLOY_ENV="true"
     - python: 3.6
       env: CONDA_ENV=py37
 
@@ -97,5 +98,5 @@ deploy:
     on:
       repo: pvlib/pvlib-python
       python: 3.6
-      condition: $TASK != "docs"
+      condition: $DEPLOY_ENV == "true"
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ matrix:
     - python: 3.5
       env: CONDA_ENV=py35
     - python: 3.6
-      env: CONDA_ENV=py36
+      env:
+        - CONDA_ENV=py36
+        - TASK="coverage"
     - python: 3.6
       env: CONDA_ENV=py37
 
@@ -74,6 +76,12 @@ install:
 
 script:
     - pytest pvlib --cov=pvlib --cov-report term-missing
+
+after_script:
+  - if [[ $TASK == "coverage" ]]; then
+      pip install codecov;
+      codecov -e TRAVIS_PYTHON_VERSION;
+    fi
 
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # http://conda.pydata.org/docs/travis.html
 # https://github.com/xray/xray/blob/master/.travis.yml
 # https://github.com/scipy/scipy/blob/master/.travis.yml
+# https://github.com/Unidata/MetPy/blob/master/.travis.yml
 
 language: python
 sudo: false # if false, use TravisCI's container based build

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,3 +85,17 @@ after_script:
 
 after_success:
     coveralls
+
+deploy:
+  matrix:
+  - provider: pypi
+    user: wholmgren
+    password:
+      secure: cUaCm+/9BAZ7pn1e6+X1TBh4ysSW9dFnUHrYIcR8xefb/O5YVlzPZACt2pR0vYJuJ6vGWOK5VzigeKyh9dccIJUqntqsqNwQF3GkgcNNzIwDUKzsmbuKEgL1GCvJWaIvov0Sevfmg7eFpGbXdynw6IVFMBssz+eVCwEV5Ww8WbI=
+    distributions: sdist bdist_wheel
+    upload_docs: false
+    on:
+      repo: pvlib/pvlib-python
+      python: 3.6
+      condition: $TASK != "docs"
+      tags: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ pvlib-python
 [![TravisCI](https://travis-ci.org/pvlib/pvlib-python.svg?branch=master)](https://travis-ci.org/pvlib/pvlib-python)
 [![Build status](https://ci.appveyor.com/api/projects/status/gr2eyhc84tvtkopk?svg=true)](https://ci.appveyor.com/project/wholmgren/pvlib-python-fv2to)
 [![Coverage Status](https://img.shields.io/coveralls/pvlib/pvlib-python.svg)](https://coveralls.io/r/pvlib/pvlib-python)
+[![codecov](https://codecov.io/gh/pvlib/pvlib-python/branch/master/graph/badge.svg)](https://codecov.io/gh/pvlib/pvlib-python)
 [![Documentation Status](https://readthedocs.org/projects/pvlib-python/badge/?version=latest)](http://pvlib-python.readthedocs.org/en/latest/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1246152.svg)](https://doi.org/10.5281/zenodo.1246152)
 [![Code Health](https://landscape.io/github/pvlib/pvlib-python/master/landscape.svg?style=flat)](https://landscape.io/github/pvlib/pvlib-python/master)


### PR DESCRIPTION
Two changes here:

1. Adds support for the codecov tool. This seems to be the recommended test coverage tool these days. I'll keep coveralls for now.
2. Travis will deploy tagged versions to pypi. For example, the release process should be as simple as: ``git tag v0.6.0-rc1; git push --tags`` 