### PR TITLE
fix fail_on_pvlib_version decorator does not run code when pass expected

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: '80'
+        target: 100%
         if_no_uploads: error
         if_not_found: success
         if_ci_failed: failure
@@ -19,10 +19,9 @@ coverage:
         if_ci_failed: failure
         paths:
           - "pvlib/(\w+/)?[^/]+\.py$"
-
       tests:
         target: 100%
         paths:
-          - "pvlib/tests/.*"
+          - "pvlib/test/.*"
 
 comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ coverage:
         paths:
           - "pvlib/(\w+/)?[^/]+\.py$"
       tests:
-        target: 100%
+        target: 96%
         paths:
           - "pvlib/test/.*"
 

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,6 +2,7 @@ linters:
     flake8:
         python: 3
         max-line-length: 79
+        ignore: E201,E241
 files:
     ignore:
         - 'pvlib/_version.py'

--- a/pvlib/test/conftest.py
+++ b/pvlib/test/conftest.py
@@ -14,6 +14,7 @@ pvlib_base_version = \
 # decorator takes one argument: the base version for which it should fail
 # for example @fail_on_pvlib_version('0.7') will cause a test to fail
 # on pvlib versions 0.7a, 0.7b, 0.7rc1, etc.
+# test function may not take args, kwargs, or fixtures.
 def fail_on_pvlib_version(version):
     # second level of decorator takes the function under consideration
     def wrapper(func):
@@ -27,7 +28,7 @@ def fail_on_pvlib_version(version):
                             'removed in %s' % version)
             # otherwise return the function to be executed
             else:
-                return func
+                return func()
         return inner
     return wrapper
 

--- a/pvlib/test/test_conftest.py
+++ b/pvlib/test/test_conftest.py
@@ -14,3 +14,10 @@ def test_fail_on_pvlib_version():
 @fail_on_pvlib_version('100000.0')
 def test_fail_on_pvlib_version_pass():
     pass
+
+
+@pytest.mark.xfail(strict=(not (platform_is_windows and has_python2)),
+                   reason='ensure that the test is called')
+@fail_on_pvlib_version('100000.0')
+def test_fail_on_pvlib_version_fail_in_test():
+    raise Exception

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -219,10 +219,10 @@ def poadc(mc):
 
 @pytest.mark.parametrize('dc_model', [
     'sapm',
-    pytest.param('cec', marks=requires_scipy), 
-    pytest.param('desoto', marks=requires_scipy), 
-    pytest.param('pvsyst', marks=requires_scipy), 
-    pytest.param('singlediode', marks=requires_scipy), 
+    pytest.param('cec', marks=requires_scipy),
+    pytest.param('desoto', marks=requires_scipy),
+    pytest.param('pvsyst', marks=requires_scipy),
+    pytest.param('singlediode', marks=requires_scipy),
     'pvwatts_dc'])
 def test_infer_dc_model(system, cec_dc_snl_ac_system, pvsyst_dc_snl_ac_system,
                         pvwatts_dc_pvwatts_ac_system, location, dc_model,
@@ -445,9 +445,12 @@ def test_bad_get_orientation():
 
 @fail_on_pvlib_version('0.7')
 def test_deprecated_07():
+    # explicit system creation call because fail_on_pvlib_version
+    # does not support decorators
+    system = cec_dc_snl_ac_system(sam_data())
     with pytest.warns(pvlibDeprecationWarning):
-        mc = ModelChain(cec_dc_snl_ac_system, location,
-                        dc_model='singlediode', # this should fail after 0.7
+        mc = ModelChain(system, location,
+                        dc_model='singlediode',  # this should fail after 0.7
                         aoi_model='no_loss', spectral_model='no_loss')
 
 


### PR DESCRIPTION
Analyzing the codecov results in #573 made me realize that the ``@fail_on_pvlib_version`` decorator was not actually running the function it decorated. Maybe someday I'll get non-trivial decorators right on the second or third try instead of the fourth or fifth. Also updates the modelchain test that no longer worked once I applied the fix to the decorator. Also pulls in the CI config changes in #573.