### PR TITLE
add v0.6.1 whatsnew and update zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ pvlib-python
 [![Coverage Status](https://img.shields.io/coveralls/pvlib/pvlib-python.svg)](https://coveralls.io/r/pvlib/pvlib-python)
 [![codecov](https://codecov.io/gh/pvlib/pvlib-python/branch/master/graph/badge.svg)](https://codecov.io/gh/pvlib/pvlib-python)
 [![Documentation Status](https://readthedocs.org/projects/pvlib-python/badge/?version=latest)](http://pvlib-python.readthedocs.org/en/latest/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1246152.svg)](https://doi.org/10.5281/zenodo.1246152)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1420548.svg)](https://doi.org/10.5281/zenodo.1420548)
 [![Code Health](https://landscape.io/github/pvlib/pvlib-python/master/landscape.svg?style=flat)](https://landscape.io/github/pvlib/pvlib-python/master)
 [![status](http://joss.theoj.org/papers/41187535cad22dd4b076c89b72f874b1/status.svg)](http://joss.theoj.org/papers/41187535cad22dd4b076c89b72f874b1)
 [![Code Quality: Python](https://img.shields.io/lgtm/grade/python/g/pvlib/pvlib-python.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pvlib/pvlib-python/context:python)

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.6.1.rst
 .. include:: whatsnew/v0.6.0.rst
 .. include:: whatsnew/v0.5.2.rst
 .. include:: whatsnew/v0.5.1.rst

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -1,0 +1,31 @@
+.. _whatsnew_0601:
+
+v0.6.1 (EST October, 2018)
+--------------------------
+
+This is a minor release. We recommend all users of 0.6.0 upgrade to this
+release.
+
+**Python 2.7 support will end on June 1, 2019**. Releases made after this
+date will require Python 3. (:issue:`501`)
+
+
+API Changes
+~~~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+* Will Holmgren (:ghuser:`wholmgren`)


### PR DESCRIPTION
Adds a new whatsnew file for v0.6.1 and updates the zenodo badge to point to 0.6.0

 - [x] Pull request is nearly complete and ready for detailed review.

Builds ok locally so will go ahead and merge.