### PR TITLE
fix errors when building docs with matplotlib 3.0

### DIFF
--- a/docs/sphinx/source/clearsky.rst
+++ b/docs/sphinx/source/clearsky.rst
@@ -289,10 +289,9 @@ A clear sky time series using only basic pvlib functions.
 
     In [1]: ax.set_title('Ineichen Clear Sky Model');
 
+    @savefig ineichen-vs-time-climo.png width=6in
     In [1]: ax.legend(loc=2);
 
-    @savefig ineichen-vs-time-climo.png width=6in
-    In [1]: plt.show();
 
 The input data types determine the returned output type. Array input
 results in an OrderedDict of array output, and Series input results in a
@@ -330,14 +329,11 @@ Grid with a clear sky irradiance for a few turbidity values.
        ...:     ineichen = clearsky.ineichen(apparent_zenith, airmass, linke_turbidity, altitude, dni_extra)
        ...:     ineichen.plot(ax=ax, title='Linke turbidity = {:0.1f}'.format(linke_turbidity));
 
-    In [1]: ax.legend(loc=1);
-
     @savefig ineichen-grid.png width=10in
-    In [1]: plt.show();
+    In [1]: ax.legend(loc=1);
 
     @suppress
     In [1]: plt.close();
-
 
 
 Validation
@@ -441,10 +437,8 @@ A clear sky time series using only basic pvlib functions.
 
     In [1]: ax.set_title('Simplified Solis Clear Sky Model');
 
-    In [1]: ax.legend(loc=2);
-
     @savefig solis-vs-time-0.1-1.png width=6in
-    In [1]: plt.show();
+    In [1]: ax.legend(loc=2);
 
     @suppress
     In [1]: plt.close();
@@ -485,7 +479,7 @@ Irradiance as a function of solar elevation.
     In [1]: plt.close();
 
 
-Grid with a clear sky irradiance for a few PW and AOD values.
+Grid with clear sky irradiance for a few PW and AOD values.
 
 .. ipython::
 
@@ -507,12 +501,10 @@ Grid with a clear sky irradiance for a few PW and AOD values.
 
     In [1]: axes = axes.flatten()
 
+    @savefig solis-grid.png width=10in
     In [1]: for (aod, pw), ax in zip(itertools.chain(itertools.product(aod700, precipitable_water)), axes):
        ...:     cs = clearsky.simplified_solis(apparent_elevation, aod, pw, pressure, dni_extra)
        ...:     cs.plot(ax=ax, title='aod700={}, pw={}'.format(aod, pw))
-
-    @savefig solis-grid.png width=10in
-    In [1]: plt.show();
 
     @suppress
     In [1]: plt.close();
@@ -557,26 +549,20 @@ Contour plots of irradiance as a function of both PW and AOD.
 
 .. ipython::
 
+    @savefig solis-ghi.png width=10in
     In [1]: plot_solis('ghi')
 
-    @savefig solis-ghi.png width=10in
-    In [1]: plt.show()
-
     @suppress
     In [1]: plt.close();
-
-    In [1]: plot_solis('dni')
 
     @savefig solis-dni.png width=10in
-    In [1]: plt.show()
+    In [1]: plot_solis('dni')
 
     @suppress
     In [1]: plt.close();
 
-    In [1]: plot_solis('dhi')
-
     @savefig solis-dhi.png width=10in
-    In [1]: plt.show()
+    In [1]: plot_solis('dhi')
 
     @suppress
     In [1]: plt.close();
@@ -641,9 +627,8 @@ GHI data. We first generate and plot the clear sky and measured data.
 
     ax.set_ylabel('Irradiance $W/m^2$');
 
-    plt.legend(loc=4);
     @savefig detect-clear-ghi.png width=10in
-    plt.show();
+    plt.legend(loc=4);
 
     @suppress
     plt.close();

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -20,6 +20,7 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Fix when building documentation using Matplotlib 3.0 or greater.
 
 
 Testing


### PR DESCRIPTION
 - [ ] Closes issue #xxxx
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

The doc build spits out a handful of new errors when using matplotlib 3.0. This PR fixes them. I confirmed that the changes are backwards compatible.

https://wholmgren-pvlib-python-new.readthedocs.io/en/csdocfix/clearsky.html