### PR TITLE
do not check brentq is NotImplemented

### DIFF
--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -209,8 +209,6 @@ def bishop88_i_from_v(voltage, photocurrent, saturation_current,
         return bishop88(x, *a)[1] - v
 
     if method.lower() == 'brentq':
-        if brentq is NotImplemented:
-            raise ImportError('This function requires scipy')
         # first bound the search using voc
         voc_est = estimate_voc(photocurrent, saturation_current, nNsVth)
 
@@ -275,9 +273,6 @@ def bishop88_v_from_i(current, photocurrent, saturation_current,
         return bishop88(x, *a)[0] - i
 
     if method.lower() == 'brentq':
-        if brentq is NotImplemented:
-            raise ImportError('This function requires scipy')
-
         # brentq only works with scalar inputs, so we need a set up function
         # and np.vectorize to repeatedly call the optimizer with the right
         # arguments for possible array input
@@ -336,8 +331,6 @@ def bishop88_mpp(photocurrent, saturation_current, resistance_series,
         return bishop88(x, *a, gradients=True)[6]
 
     if method.lower() == 'brentq':
-        if brentq is NotImplemented:
-            raise ImportError('This function requires scipy')
         # break out arguments for numpy.vectorize to handle broadcasting
         vec_fun = np.vectorize(
             lambda voc, iph, isat, rs, rsh, gamma:


### PR DESCRIPTION
* related to #556 
* if brentq can't be imported it will raise a `NotImplementedError` already
* lgtm says it's better for a callable to have a consistent API
* that's why we changed the not-imported `brentq` from `NotImplemented` to a callable, b/c `brentq` is usually callable
* but we forgot the original code has a check if `brentq` is `NotImplemented`, so we can remove that now

pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [ ] Closes issue #xxxx
 - [ ] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
