### PR TITLE
Change name to solarposition.sun_rise_set_transit_spa

### DIFF
--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -56,6 +56,7 @@ Additional functions for quantities closely related to solar position.
    solarposition.pyephem_earthsun_distance
    solarposition.nrel_earthsun_distance
    solarposition.rise_set_transit_ephem
+   solarposition.rise_set_transit_spa
    spa.calculate_deltat
 
 The spa module contains the implementation of the built-in NREL SPA

--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -55,8 +55,6 @@ Additional functions for quantities closely related to solar position.
    solarposition.calc_time
    solarposition.pyephem_earthsun_distance
    solarposition.nrel_earthsun_distance
-   solarposition.rise_set_transit_ephem
-   solarposition.rise_set_transit_spa
    spa.calculate_deltat
 
 

--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -59,6 +59,17 @@ Additional functions for quantities closely related to solar position.
    solarposition.rise_set_transit_spa
    spa.calculate_deltat
 
+
+Functions for calculating sunrise, sunset and transit times.
+
+.. autosummary::
+   :toctree: generated/
+
+   solarposition.sun_rise_set_transit_ephem
+   solarposition.sun_rise_set_transit_spa
+   solarposition.sun_rise_set_transit_geometric
+
+
 The spa module contains the implementation of the built-in NREL SPA
 algorithm.
 

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -21,6 +21,7 @@ API Changes
 * Added keyword argument ``horizon`` to :func:`~pvlib.solarposition.pyephem`
   and :func:`~pvlib.solarposition.calc_time` with default value ``'+0:00'``
 * Changed key names for `components` returned from :py:func:`pvlib.clearsky.detect_clearsky`
+* Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated) to :py:func:`pvlib.solarposition.rise_set_transit_spa. `rise_set_transit_spa` requires time input to be localized to the specified latitude/longitude. (:issue:`316')
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -21,7 +21,9 @@ API Changes
 * Added keyword argument ``horizon`` to :func:`~pvlib.solarposition.pyephem`
   and :func:`~pvlib.solarposition.calc_time` with default value ``'+0:00'``
 * Changed key names for `components` returned from :py:func:`pvlib.clearsky.detect_clearsky`
-* Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated) to :py:func:`pvlib.solarposition.rise_set_transit_spa. `rise_set_transit_spa` requires time input to be localized to the specified latitude/longitude. (:issue:`316')
+* Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated)
+  to :py:func:`pvlib.solarposition.rise_set_transit_spa. `rise_set_transit_spa` requires time
+  input to be localized to the specified latitude/longitude. (:issue:`316')
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -22,16 +22,16 @@ API Changes
   and :func:`~pvlib.solarposition.calc_time` with default value ``'+0:00'``
 * Changed key names for `components` returned from :py:func:`pvlib.clearsky.detect_clearsky`
 * Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated)
-  to :py:func:`pvlib.solarposition.rise_set_transit_spa. `rise_set_transit_spa` requires time
-  input to be localized to the specified latitude/longitude. (:issue:`316')
+  to :py:func:`pvlib.solarposition.sun_rise_set_transit_spa. `sun_rise_set_transit_spa`
+  requires time input to be localized to the specified latitude/longitude. (:issue:`316')
 
 
 Enhancements
 ~~~~~~~~~~~~
-* :func:`~pvlib.solarposition.rise_set_transit_ephem` returns sunrise, sunset
+* :func:`~pvlib.solarposition.sun_rise_set_transit_ephem` returns sunrise, sunset
   and transit times using pyephem (:issue:`114`)
 * Add geometric functions for sunrise, sunset, and sun transit times,
-  :func:`~pvlib.solarposition.sunrise_sunset_transit_geometric` (:issue:`114`)
+  :func:`~pvlib.solarposition.sun_rise_set_transit_geometric` (:issue:`114`)
 * Created :py:func:`pvlib.iotools.read_srml` and
   :py:func:`pvlib.iotools.read_srml_month_from_solardat` to read University of
   Oregon Solar Radiation Monitoring Laboratory data. (:issue:`589`)

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -360,7 +360,7 @@ def spa_python(time, latitude, longitude,
     return result
 
 
-get_sun_rise_set_transit = deprecated('0.6',
+get_sun_rise_set_transit = deprecated('0.6.1',
                                       alternative='sun_rise_set_transit_spa',
                                       removal='0.7')
 

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -360,11 +360,6 @@ def spa_python(time, latitude, longitude,
     return result
 
 
-get_sun_rise_set_transit = deprecated('0.6.1',
-                                      alternative='sun_rise_set_transit_spa',
-                                      removal='0.7')
-
-
 def sun_rise_set_transit_spa(times, latitude, longitude, how='numpy',
                              delta_t=67.0, numthreads=4):
     """
@@ -444,6 +439,12 @@ def sun_rise_set_transit_spa(times, latitude, longitude, how='numpy',
     return pd.DataFrame(index=times, data={'sunrise': sunrise,
                                            'sunset': sunset,
                                            'transit': transit})
+
+
+get_sun_rise_set_transit = deprecated('0.6.1',
+                                      alternative='sun_rise_set_transit_spa',
+                                      name='get_sun_rise_set_transit',
+                                      removal='0.7')(sun_rise_set_transit_spa)
 
 
 def _ephem_convert_to_seconds_and_microseconds(date):

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -420,7 +420,7 @@ def sun_rise_set_transit_spa(times, latitude, longitude, how='numpy',
     if times.tz:
         tzinfo = times.tz
     else:
-        raise ValueError('sun_rise_set_transit_spa: times must be localized')
+        raise ValueError('times must be localized')
 
     # must convert to midnight UTC on day of interest
     utcday = pd.DatetimeIndex(times.date).tz_localize('UTC')
@@ -532,7 +532,7 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
     if times.tz:
         tzinfo = times.tz
     else:
-        raise ValueError('sun_rise_set_transit_ephem: times must be localized')
+        raise ValueError('times must be localized')
 
     obs, sun = _ephem_setup(latitude, longitude, altitude,
                             pressure, temperature, horizon)

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -437,8 +437,8 @@ def rise_set_transit_spa(times, latitude, longitude, how='numpy',
         times.tz).tolist()
 
     return pd.DataFrame(index=times, data={'sunrise': sunrise,
-                                          'sunset': sunset,
-                                          'transit': transit})
+                                           'sunset': sunset,
+                                           'transit': transit})
 
 
 def _ephem_convert_to_seconds_and_microseconds(date):

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -417,9 +417,9 @@ def sun_rise_set_transit_spa(times, latitude, longitude, how='numpy',
     lon = longitude
 
     # times must be localized
-    try:
+    if times.tz:
         tzinfo = times.tz
-    except AttributeError:
+    else:
         raise ValueError('sun_rise_set_transit_spa: times must be localized')
 
     # must convert to midnight UTC on day of interest
@@ -529,9 +529,9 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
         raise ImportError('PyEphem must be installed')
 
     # times must be localized
-    try:
+    if times.tz:
         tzinfo = times.tz
-    except AttributeError:
+    else:
         raise ValueError('sun_rise_set_transit_ephem: times must be localized')
 
     obs, sun = _ephem_setup(latitude, longitude, altitude,

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -107,8 +107,9 @@ def expected_rise_set_ephem():
 
 @fail_on_pvlib_version('0.7')
 def test_deprecated_07():
+    tt = pd.DatetimeIndex(2015, 1, 1, 0, 0, 0).tz_localize('MST')
     with pytest.warns(pvlibDeprecationWarning):
-        solarposition.get_sun_rise_set_transit(datetime.datetime(2015, 1, 1),
+        solarposition.get_sun_rise_set_transit(tt,
                                                39.7,
                                                -105.2)
 

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -184,7 +184,8 @@ def test_spa_python_numba_physical_dst(expected_solpos, golden):
 
 
 @needs_pandas_0_17
-def test_get_sun_rise_set_transit(expected_rise_set_spa, golden):
+def test_rise_set_transit_spa(expected_rise_set_spa, golden):
+    # solution from NREL SAP web calculator
     south = Location(-35.0, 0.0, tz='UTC')
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),
                               datetime.datetime(2004, 12, 4, 0)]
@@ -195,22 +196,26 @@ def test_get_sun_rise_set_transit(expected_rise_set_spa, golden):
     sunset = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 17, 1, 4),
                                datetime.datetime(2004, 12, 4, 19, 2, 3)]
                               ).tz_localize('UTC').tolist()
-    frame = pd.DataFrame({'sunrise': sunrise, 'sunset': sunset}, index=times)
+    transit = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 12, 4, 36),
+                               datetime.datetime(2004, 12, 4, 11, 50, 22)]
+                              ).tz_localize('UTC').tolist()
+    frame = pd.DataFrame({'sunrise': sunrise,
+                          'sunset': sunset,
+                          'transit': transit}, index=times)
 
-    result = solarposition.get_sun_rise_set_transit(times, south.latitude,
-                                                    south.longitude,
-                                                    delta_t=65.0)
+    result = solarposition.rise_set_transit_spa(times, south.latitude,
+                                                south.longitude,
+                                                delta_t=65.0)
     result_rounded = pd.DataFrame(index=result.index)
     # need to iterate because to_datetime does not accept 2D data
     # the rounding fails on pandas < 0.17
     for col, data in result.iteritems():
         result_rounded[col] = data.dt.round('1s')
 
-    del result_rounded['transit']
     assert_frame_equal(frame, result_rounded)
 
     # test for Golden, CO compare to NREL SPA
-    result = solarposition.get_sun_rise_set_transit(
+    result = solarposition.rise_set_transit_spa(
         expected_rise_set_spa.index, golden.latitude, golden.longitude,
         delta_t=65.0)
 

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -107,7 +107,7 @@ def expected_rise_set_ephem():
 
 @fail_on_pvlib_version('0.7')
 def test_deprecated_07():
-    tt = pd.DatetimeIndex(2015, 1, 1, 0, 0, 0).tz_localize('MST')
+    tt = pd.DatetimeIndex([datetime.datetime(2015, 1, 1)]).tz_localize('MST')
     with pytest.warns(pvlibDeprecationWarning):
         solarposition.get_sun_rise_set_transit(tt,
                                                39.7,

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -197,8 +197,8 @@ def test_rise_set_transit_spa(expected_rise_set_spa, golden):
                                datetime.datetime(2004, 12, 4, 19, 2, 3)]
                               ).tz_localize('UTC').tolist()
     transit = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 12, 4, 36),
-                               datetime.datetime(2004, 12, 4, 11, 50, 22)]
-                              ).tz_localize('UTC').tolist()
+                                datetime.datetime(2004, 12, 4, 11, 50, 22)]
+                               ).tz_localize('UTC').tolist()
     frame = pd.DataFrame({'sunrise': sunrise,
                           'sunset': sunset,
                           'transit': transit}, index=times)

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -184,7 +184,7 @@ def test_spa_python_numba_physical_dst(expected_solpos, golden):
 
 
 @needs_pandas_0_17
-def test_rise_set_transit_spa(expected_rise_set_spa, golden):
+def test_sun_rise_set_transit_spa(expected_rise_set_spa, golden):
     # solution from NREL SAP web calculator
     south = Location(-35.0, 0.0, tz='UTC')
     times = pd.DatetimeIndex([datetime.datetime(1996, 7, 5, 0),
@@ -203,9 +203,9 @@ def test_rise_set_transit_spa(expected_rise_set_spa, golden):
                           'sunset': sunset,
                           'transit': transit}, index=times)
 
-    result = solarposition.rise_set_transit_spa(times, south.latitude,
-                                                south.longitude,
-                                                delta_t=65.0)
+    result = solarposition.sun_rise_set_transit_spa(times, south.latitude,
+                                                    south.longitude,
+                                                    delta_t=65.0)
     result_rounded = pd.DataFrame(index=result.index)
     # need to iterate because to_datetime does not accept 2D data
     # the rounding fails on pandas < 0.17
@@ -215,7 +215,7 @@ def test_rise_set_transit_spa(expected_rise_set_spa, golden):
     assert_frame_equal(frame, result_rounded)
 
     # test for Golden, CO compare to NREL SPA
-    result = solarposition.rise_set_transit_spa(
+    result = solarposition.sun_rise_set_transit_spa(
         expected_rise_set_spa.index, golden.latitude, golden.longitude,
         delta_t=65.0)
 
@@ -229,9 +229,9 @@ def test_rise_set_transit_spa(expected_rise_set_spa, golden):
 
 
 @requires_ephem
-def test_rise_set_transit_ephem(expected_rise_set_ephem, golden):
+def test_sun_rise_set_transit_ephem(expected_rise_set_ephem, golden):
     # test for Golden, CO compare to USNO, using local midnight
-    result = solarposition.rise_set_transit_ephem(
+    result = solarposition.sun_rise_set_transit_ephem(
         expected_rise_set_ephem.index, golden.latitude, golden.longitude,
         next_or_previous='next', altitude=golden.altitude, pressure=0,
         temperature=11, horizon='-0:34')
@@ -266,14 +266,14 @@ def test_rise_set_transit_ephem(expected_rise_set_ephem, golden):
         expected_rise_set_ephem.loc[datetime.datetime(2015, 1, 3), 'transit'],
         expected_rise_set_ephem.loc[datetime.datetime(2015, 1, 3), 'transit']])
 
-    result = solarposition.rise_set_transit_ephem(times,
-                                                  golden.latitude,
-                                                  golden.longitude,
-                                                  next_or_previous='next',
-                                                  altitude=golden.altitude,
-                                                  pressure=0,
-                                                  temperature=11,
-                                                  horizon='-0:34')
+    result = solarposition.sun_rise_set_transit_ephem(times,
+                                                      golden.latitude,
+                                                      golden.longitude,
+                                                      next_or_previous='next',
+                                                      altitude=golden.altitude,
+                                                      pressure=0,
+                                                      temperature=11,
+                                                      horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
     for col, data in result.iteritems():
@@ -305,14 +305,9 @@ def test_rise_set_transit_ephem(expected_rise_set_ephem, golden):
         expected_rise_set_ephem.loc[datetime.datetime(2015, 1, 2), 'transit'],
         expected_rise_set_ephem.loc[datetime.datetime(2015, 1, 3), 'transit']])
 
-    result = solarposition.rise_set_transit_ephem(times,
-                                                  golden.latitude,
-                                                  golden.longitude,
-                                                  next_or_previous='previous',
-                                                  altitude=golden.altitude,
-                                                  pressure=0,
-                                                  temperature=11,
-                                                  horizon='-0:34')
+    result = solarposition.sun_rise_set_transit_ephem(times,
+        golden.latitude, golden.longitude, next_or_previous='previous',
+        altitude=golden.altitude, pressure=0, temperature=11, horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
     for col, data in result.iteritems():
@@ -324,14 +319,9 @@ def test_rise_set_transit_ephem(expected_rise_set_ephem, golden):
     expected = expected.tz_convert('UTC')  # resuse result from previous
     for col, data in expected.iteritems():
         expected[col] = data.dt.tz_convert('UTC')
-    result = solarposition.rise_set_transit_ephem(times,
-                                                  golden.latitude,
-                                                  golden.longitude,
-                                                  next_or_previous='previous',
-                                                  altitude=golden.altitude,
-                                                  pressure=0,
-                                                  temperature=11,
-                                                  horizon='-0:34')
+    result = solarposition.sun_rise_set_transit_ephem(times,
+        golden.latitude, golden.longitude, next_or_previous='previous',
+        altitude=golden.altitude, pressure=0, temperature=11, horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
     for col, data in result.iteritems():
@@ -340,32 +330,29 @@ def test_rise_set_transit_ephem(expected_rise_set_ephem, golden):
 
 
 @requires_ephem
-def test_rise_set_transit_ephem_error(expected_rise_set_ephem, golden):
+def test_sun_rise_set_transit_ephem_error(expected_rise_set_ephem, golden):
     with pytest.raises(ValueError):
-        solarposition.rise_set_transit_ephem(expected_rise_set_ephem.index,
-                                             golden.latitude,
-                                             golden.longitude,
-                                             next_or_previous='other')
+        solarposition.sun_rise_set_transit_ephem(expected_rise_set_ephem.index,
+                                                 golden.latitude,
+                                                 golden.longitude,
+                                                 next_or_previous='other')
     tz_naive = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 3, 0, 0)])
     with pytest.raises(ValueError):
-        solarposition.rise_set_transit_ephem(tz_naive,
-                                             golden.latitude,
-                                             golden.longitude,
-                                             next_or_previous='next')
+        solarposition.sun_rise_set_transit_ephem(tz_naive,
+                                                 golden.latitude,
+                                                 golden.longitude,
+                                                 next_or_previous='next')
 
 
 @requires_ephem
-def test_rise_set_transit_ephem_horizon(golden):
+def test_sun_rise_set_transit_ephem_horizon(golden):
     times = pd.DatetimeIndex([datetime.datetime(2016, 1, 3, 0, 0, 0)
                               ]).tz_localize('MST')
     # center of sun disk
-    center = solarposition.rise_set_transit_ephem(times,
-                                                  latitude=golden.latitude,
-                                                  longitude=golden.longitude)
-    edge = solarposition.rise_set_transit_ephem(times,
-                                                latitude=golden.latitude,
-                                                longitude=golden.longitude,
-                                                horizon='-0:34')
+    center = solarposition.sun_rise_set_transit_ephem(times,
+        latitude=golden.latitude, longitude=golden.longitude)
+    edge = solarposition.sun_rise_set_transit_ephem(times,
+        latitude=golden.latitude, longitude=golden.longitude, horizon='-0:34')
     result_rounded = (edge['sunrise'] - center['sunrise']).dt.round('min')
 
     sunrise_delta = datetime.datetime(2016, 1, 3, 7, 17, 11) - \
@@ -728,14 +715,14 @@ def test_hour_angle():
     assert np.allclose(hours, expected)
 
 
-def test_sunrise_sunset_transit_geometric(expected_rise_set_spa, golden_mst):
+def test_sun_rise_set_transit_geometric(expected_rise_set_spa, golden_mst):
     """Test geometric calculations for sunrise, sunset, and transit times"""
     times = expected_rise_set_spa.index
     latitude = golden_mst.latitude
     longitude = golden_mst.longitude
     eot = solarposition.equation_of_time_spencer71(times.dayofyear)  # minutes
     decl = solarposition.declination_spencer71(times.dayofyear)  # radians
-    sr, ss, st = solarposition.sunrise_sunset_transit_geometric(
+    sr, ss, st = solarposition.sun_rise_set_transit_geometric(
         times, latitude=latitude, longitude=longitude, declination=decl,
         equation_of_time=eot)
     # sunrise: 2015-01-02 07:26:39.763224487, 2015-08-02 05:04:35.688533801

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -107,7 +107,7 @@ def expected_rise_set_ephem():
 
 @fail_on_pvlib_version('0.7')
 def test_deprecated_07():
-    tt = pd.DatetimeIndex([datetime.datetime(2015, 1, 1)]).tz_localize('MST')
+    tt = pd.DatetimeIndex(['2015-01-01 00:00:00']).tz_localize('MST')
     with pytest.warns(pvlibDeprecationWarning):
         solarposition.get_sun_rise_set_transit(tt,
                                                39.7,

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -9,10 +9,11 @@ from pandas.util.testing import (assert_frame_equal, assert_series_equal,
 from numpy.testing import assert_allclose
 import pytest
 
+from pvlib._deprecation import pvlibDeprecationWarning
 from pvlib.location import Location
 from pvlib import solarposition, spa
 
-from conftest import (requires_ephem, needs_pandas_0_17,
+from conftest import (fail_on_pvlib_version, requires_ephem, needs_pandas_0_17,
                       requires_spa_c, requires_numba)
 
 
@@ -102,6 +103,16 @@ def expected_rise_set_ephem():
                          'sunset': sunset,
                          'transit': transit},
                         index=times)
+
+
+@fail_on_pvlib_version('0.7')
+def test_deprecated_07():
+    with pytest.warns(pvlibDeprecationWarning):
+        solarposition.get_sun_rise_set_transit(datetime.datetime(2015, 1, 1),
+                                               golden.latitude,
+                                               golden.longitude)
+
+
 # the physical tests are run at the same time as the NREL SPA test.
 # pyephem reproduces the NREL result to 2 decimal places.
 # this doesn't mean that one code is better than the other.

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -109,8 +109,8 @@ def expected_rise_set_ephem():
 def test_deprecated_07():
     with pytest.warns(pvlibDeprecationWarning):
         solarposition.get_sun_rise_set_transit(datetime.datetime(2015, 1, 1),
-                                               golden.latitude,
-                                               golden.longitude)
+                                               39.7,
+                                               -105.2)
 
 
 # the physical tests are run at the same time as the NREL SPA test.

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -69,9 +69,9 @@ def expected_rise_set_spa():
     transit = pd.DatetimeIndex([datetime.datetime(2015, 1, 2, 12, 4, 45),
                                 datetime.datetime(2015, 8, 2, 12, 6, 58)
                                 ]).tz_localize('MST').tolist()
-    return pd.DataFrame({'transit': transit,
-                         'sunrise': sunrise,
-                         'sunset': sunset},
+    return pd.DataFrame({'sunrise': sunrise,
+                         'sunset': sunset,
+                         'transit': transit},
                         index=times)
 
 


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes issue #316 
- [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

Change to function name to conform with sun_rise_set_transit_ephem and sun_rise_set_transit_geometric. Edits to docstrings to clarify expected timezone and location.  Changed local variable `time` to `times` to avoid possible conflict with `time` module.