### PR TITLE
Change sapm to expect effective_irradiance in W/m2

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -24,9 +24,6 @@ API Changes
 * Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated)
   to :py:func:`pvlib.solarposition.sun_rise_set_transit_spa. `sun_rise_set_transit_spa`
   requires time input to be localized to the specified latitude/longitude. (:issue:`316')
-* Changed function :py:func:`pvlib.pvsystem.sapm` to expect input `effective_irradiance`
-  in units of W/m2 rather than suns. Changed output of function 
-  :py:func:`sapm_effective_irradiance` to units of W/m2 rather than suns.
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -24,6 +24,9 @@ API Changes
 * Changed function name from :py:func:`pvlib.solarposition.get_rise_set_transit` (deprecated)
   to :py:func:`pvlib.solarposition.sun_rise_set_transit_spa. `sun_rise_set_transit_spa`
   requires time input to be localized to the specified latitude/longitude. (:issue:`316')
+* Changed function :py:func:`pvlib.pvsystem.sapm` to expect input `effective_irradiance`
+  in units of W/m2 rather than suns. Changed output of function 
+  :py:func:`sapm_effective_irradiance` to units of W/m2 rather than suns.
 
 
 Enhancements

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -414,7 +414,7 @@ class ModelChain(object):
                              'system.module_parameters')
 
     def sapm(self):
-        self.dc = self.system.sapm(self.effective_irradiance/1000.,
+        self.dc = self.system.sapm(self.effective_irradiance,
                                    self.temps['temp_cell'])
 
         self.dc = self.system.scale_voltage_current_power(self.dc)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2009,7 +2009,7 @@ def sapm_effective_irradiance(poa_direct, poa_diffuse, airmass_absolute, aoi,
     F1 = sapm_spectral_loss(airmass_absolute, module)
     F2 = sapm_aoi_loss(aoi, module)
 
-    Ee = F1 * (poa_direct*F2 + module['FD']*poa_diffuse)
+    Ee = F1 * (poa_direct * F2 + module['FD'] * poa_diffuse)
 
     return Ee
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -469,8 +469,7 @@ class PVSystem(object):
         return sapm_aoi_loss(aoi, self.module_parameters)
 
     def sapm_effective_irradiance(self, poa_direct, poa_diffuse,
-                                  airmass_absolute, aoi,
-                                  reference_irradiance=1000):
+                                  airmass_absolute, aoi):
         """
         Use the :py:func:`sapm_effective_irradiance` function, the input
         parameters, and ``self.module_parameters`` to calculate
@@ -490,9 +489,6 @@ class PVSystem(object):
         aoi : numeric
             Angle of incidence in degrees.
 
-        reference_irradiance : numeric, default 1000
-            Reference irradiance by which to divide the input irradiance.
-
         Returns
         -------
         effective_irradiance : numeric
@@ -500,7 +496,7 @@ class PVSystem(object):
         """
         return sapm_effective_irradiance(
             poa_direct, poa_diffuse, airmass_absolute, aoi,
-            self.module_parameters, reference_irradiance=reference_irradiance)
+            self.module_parameters)
 
     def first_solar_spectral_loss(self, pw, airmass_absolute):
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -342,7 +342,7 @@ def test_PVSystem_sapm_aoi_loss(sapm_module_params, mocker):
      np.array([np.nan, np.nan, 1081.157])),
     ([pd.Series([1000]), pd.Series([100]), pd.Series([1.1]),
       pd.Series([10])],
-     pd.Series([789.166]))
+     pd.Series([1081.11573]))
 ])
 def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
 
@@ -353,7 +353,7 @@ def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
     if isinstance(test_input, pd.Series):
         assert_series_equal(out, expected, check_less_precise=4)
     else:
-        assert_allclose(out, expected, atol=1e-4)
+        assert_allclose(out, expected, atol=1e-2)
 
 
 def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
@@ -369,7 +369,7 @@ def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
         poa_direct, poa_diffuse, airmass_absolute, aoi)
     pvsystem.sapm_effective_irradiance.assert_called_once_with(
         poa_direct, poa_diffuse, airmass_absolute, aoi, sapm_module_params)
-    assert_allclose(out, 1, atol=0.1)
+    assert_allclose(out, 1000, atol=0.1)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -334,28 +334,21 @@ def test_PVSystem_sapm_aoi_loss(sapm_module_params, mocker):
 
 
 @pytest.mark.parametrize('test_input,expected', [
-    ([1000, 100, 5, 45, 1000], 1140.0510967821877),
+    ([1000, 100, 5, 45], 1140.0510967821877),
     ([np.array([np.nan, 1000, 1000]),
       np.array([100, np.nan, 100]),
       np.array([1.1, 1.1, 1.1]),
-      np.array([10, 10, 10]),
-      1000],
+      np.array([10, 10, 10])],
      np.array([np.nan, np.nan, 1081.157])),
     ([pd.Series([1000]), pd.Series([100]), pd.Series([1.1]),
-      pd.Series([10]), 1370],
+      pd.Series([10])],
      pd.Series([789.166]))
 ])
 def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
 
-    try:
-        kwargs = {'reference_irradiance': test_input[4]}
-        test_input = test_input[:-1]
-    except IndexError:
-        kwargs = {}
-
     test_input.append(sapm_module_params)
 
-    out = pvsystem.sapm_effective_irradiance(*test_input, **kwargs)
+    out = pvsystem.sapm_effective_irradiance(test_input)
 
     if isinstance(test_input, pd.Series):
         assert_series_equal(out, expected, check_less_precise=4)

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -219,7 +219,7 @@ def test_sapm(sapm_module_params):
 
     assert_frame_equal(out, expected, check_less_precise=4)
 
-    out = pvsystem.sapm(1, 25, sapm_module_params)
+    out = pvsystem.sapm(1000, 25, sapm_module_params)
 
     expected = OrderedDict()
     expected['i_sc'] = 5.09115
@@ -353,7 +353,7 @@ def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
     if isinstance(test_input, pd.Series):
         assert_series_equal(out, expected, check_less_precise=4)
     else:
-        assert_allclose(out, expected, atol=1e-2)
+        assert_allclose(out, expected, atol=1)
 
 
 def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
@@ -369,7 +369,7 @@ def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
         poa_direct, poa_diffuse, airmass_absolute, aoi)
     pvsystem.sapm_effective_irradiance.assert_called_once_with(
         poa_direct, poa_diffuse, airmass_absolute, aoi, sapm_module_params)
-    assert_allclose(out, 1000, atol=0.1)
+    assert_allclose(out, 1000, atol=1)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -348,7 +348,7 @@ def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
 
     test_input.append(sapm_module_params)
 
-    out = pvsystem.sapm_effective_irradiance(test_input)
+    out = pvsystem.sapm_effective_irradiance(*test_input)
 
     if isinstance(test_input, pd.Series):
         assert_series_equal(out, expected, check_less_precise=4)

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -195,10 +195,13 @@ def pvsyst_module_params():
 def test_sapm(sapm_module_params):
 
     times = pd.DatetimeIndex(start='2015-01-01', periods=5, freq='12H')
-    effective_irradiance = pd.Series([-1, 0.5, 1.1, np.nan, 1], index=times)
+    effective_irradiance = pd.Series([-1000, 500, 1100, np.nan, 1000],
+                                     index=times)
     temp_cell = pd.Series([10, 25, 50, 25, np.nan], index=times)
+    reference_irradiance = 1000
 
-    out = pvsystem.sapm(effective_irradiance, temp_cell, sapm_module_params)
+    out = pvsystem.sapm(effective_irradiance, temp_cell, sapm_module_params,
+                        reference_irradiance)
 
     expected = pd.DataFrame(np.array(
       [[  -5.0608322 ,   -4.65037767,           nan,           nan,
@@ -238,7 +241,7 @@ def test_sapm(sapm_module_params):
 def test_PVSystem_sapm(sapm_module_params, mocker):
     mocker.spy(pvsystem, 'sapm')
     system = pvsystem.PVSystem(module_parameters=sapm_module_params)
-    effective_irradiance = 0.5
+    effective_irradiance = 500
     temp_cell = 25
     out = system.sapm(effective_irradiance, temp_cell)
     pvsystem.sapm.assert_called_once_with(effective_irradiance, temp_cell,

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -331,16 +331,16 @@ def test_PVSystem_sapm_aoi_loss(sapm_module_params, mocker):
 
 
 @pytest.mark.parametrize('test_input,expected', [
-    ([1000, 100, 5, 45, 1000], 1.1400510967821877),
+    ([1000, 100, 5, 45, 1000], 1140.0510967821877),
     ([np.array([np.nan, 1000, 1000]),
       np.array([100, np.nan, 100]),
       np.array([1.1, 1.1, 1.1]),
       np.array([10, 10, 10]),
       1000],
-     np.array([np.nan, np.nan, 1.081157])),
+     np.array([np.nan, np.nan, 1081.157])),
     ([pd.Series([1000]), pd.Series([100]), pd.Series([1.1]),
       pd.Series([10]), 1370],
-     pd.Series([0.789166]))
+     pd.Series([789.166]))
 ])
 def test_sapm_effective_irradiance(sapm_module_params, test_input, expected):
 
@@ -368,14 +368,11 @@ def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
     poa_diffuse = 100
     airmass_absolute = 1.5
     aoi = 0
-    reference_irradiance = 1000
 
     out = system.sapm_effective_irradiance(
-        poa_direct, poa_diffuse, airmass_absolute,
-        aoi, reference_irradiance=reference_irradiance)
+        poa_direct, poa_diffuse, airmass_absolute, aoi)
     pvsystem.sapm_effective_irradiance.assert_called_once_with(
-        poa_direct, poa_diffuse, airmass_absolute, aoi, sapm_module_params,
-        reference_irradiance=reference_irradiance)
+        poa_direct, poa_diffuse, airmass_absolute, aoi, sapm_module_params)
     assert_allclose(out, 1, atol=0.1)
 
 


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes #472
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
