### PR TITLE
 Fix crash in ModelChain.infer_spectral_model due to incorrect method call (2)

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -73,3 +73,4 @@ Contributors
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Mark Mikofski (:ghuser:`mikofski`)
 * Anton Driesse (:ghuser:`adriesse`)
+* Jonathan Gaffiot (:ghuser:`jgaffiot`)

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -55,6 +55,7 @@ Bug fixes
   and < 1900, fix year 2050 which was returning 0.
 * Fix and improve :func:`~pvlib.solarposition.hour_angle` (:issue:`598`)
 * Fix error in :func:`pvlib.clearsky.detect_clearsky` (:issue:`506`)
+* Fix error in :func:`pvlib.modelchain.ModelChain.infer_spectral_model` (:issue:`619`)
 
 
 Testing

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -629,7 +629,7 @@ class ModelChain(object):
             raise ValueError('could not infer spectral model from '
                              'system.module_parameters. Check that the '
                              'parameters contain valid '
-                             'first_solar_spectral_coefficients or a valid '
+                             'first_solar_spectral_coefficients and a valid '
                              'Material or Technology value')
 
     def first_solar_spectral_loss(self):

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -629,7 +629,7 @@ class ModelChain(object):
             raise ValueError('could not infer spectral model from '
                              'system.module_parameters. Check that the '
                              'parameters contain valid '
-                             'first_solar_spectral_coefficients and a valid '
+                             'first_solar_spectral_coefficients or a valid '
                              'Material or Technology value')
 
     def first_solar_spectral_loss(self):

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -622,7 +622,7 @@ class ModelChain(object):
             return self.sapm_spectral_loss
         elif ((('Technology' in params or
                 'Material' in params) and
-               (pvsystem._infer_cell_type() is not None)) or
+               (self.system._infer_cell_type() is not None)) or
               'first_solar_spectral_coefficients' in params):
             return self.first_solar_spectral_loss
         else:


### PR DESCRIPTION
 - [X] Closes  #619 
 - [X] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [X] Fully tested. Added the test `test_model_chain.test_infer_spectral_model` to ensure correct behavior for all reasonable inputs.
 - [na] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [X] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [X] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [na] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
- Replace pull request #620 to have a clean history (I deleted my fork and created a new clean one).
