### PR TITLE
fix python 3.7 build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - CONDA_ENV=py36
         - TASK="coverage"
         - DEPLOY_ENV="true"
-    - python: 3.7
+    - python: 3.7-dev
       env: CONDA_ENV=py37
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - CONDA_ENV=py36
         - TASK="coverage"
         - DEPLOY_ENV="true"
-    - python: 3.6
+    - python: 3.7
       env: CONDA_ENV=py37
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - CONDA_ENV=py36
         - TASK="coverage"
         - DEPLOY_ENV="true"
-    - python: 3.7-dev
+    - python: 3.6
       env: CONDA_ENV=py37
 
 addons:

--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -70,6 +70,7 @@ Bug fixes
 * Fix error in :func:`pvlib.clearsky.detect_clearsky` (:issue:`506`)
 * Fix documentation errors when using IPython >= 7.0.
 * Fix error in :func:`pvlib.modelchain.ModelChain.infer_spectral_model` (:issue:`619`)
+* Fix error in ``pvlib.spa`` when using Python 3.7 on some platforms.
 
 
 Testing

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -259,8 +259,8 @@ resize_mapping = {
     'L1': (64, 3), 'L2': (64, 3), 'L3': (64, 3), 'L4': (64, 3), 'L5': (64, 3),
     'B1': (5, 3), 'R1': (40, 3), 'R2': (40, 3), 'R3': (40, 3), 'R4': (40, 3)}
 
-# make arrays uniform size for efficient broadcasting in numba
-# fill with 0s
+# make arrays uniform size for efficient broadcasting in numba, fill with 0s
+# np.resize does not work because it fills with repeated copies
 for key, dims in resize_mapping.items():
     new_rows = dims[0] - TABLE_1_DICT[key].shape[0]
     TABLE_1_DICT[key] = np.append(TABLE_1_DICT[key], np.zeros((new_rows, 3)),

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -255,19 +255,16 @@ TABLE_1_DICT = {
         [[4.0, 2.56, 6283.08]])
 }
 
+resize_mapping = {
+    'L1': (64, 3), 'L2': (64, 3), 'L3': (64, 3), 'L4': (64, 3), 'L5': (64, 3),
+    'B1': (5, 3), 'R1': (40, 3), 'R2': (40, 3), 'R3': (40, 3), 'R4': (40, 3)}
 
-TABLE_1_DICT['L1'].resize((64, 3))
-TABLE_1_DICT['L2'].resize((64, 3))
-TABLE_1_DICT['L3'].resize((64, 3))
-TABLE_1_DICT['L4'].resize((64, 3))
-TABLE_1_DICT['L5'].resize((64, 3))
-
-TABLE_1_DICT['B1'].resize((5, 3))
-
-TABLE_1_DICT['R1'].resize((40, 3))
-TABLE_1_DICT['R2'].resize((40, 3))
-TABLE_1_DICT['R3'].resize((40, 3))
-TABLE_1_DICT['R4'].resize((40, 3))
+# make arrays uniform size for efficient broadcasting in numba
+# fill with 0s
+for key, dims in resize_mapping.items():
+    new_rows = dims[0] - TABLE_1_DICT[key].shape[0]
+    TABLE_1_DICT[key] = np.append(TABLE_1_DICT[key], np.zeros((new_rows, 3)),
+                                  axis=0)
 
 
 HELIO_LONG_TABLE = np.array([TABLE_1_DICT['L0'],


### PR DESCRIPTION
 - [x] no issue
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

We've been seeing issues with the `spa.py` file on the Python 3.7 build on Travis for a few months. The error is related to resizing some arrays in place. For some reason, this works fine on Python 2.7 - 3.6 and but fails on some platforms on 3.7. I could never reproduce it locally on my mac or linux machines. This PR takes a different approach to resizing the arrays.

Worked on my fork, hopefully works in this PR...