### PR TITLE
put SERVER in try and catch KeyError

### DIFF
--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -25,7 +25,10 @@ except ImportError:
         )
     SERVER = None
 else:
-    SERVER = ECMWFDataServer()
+    try:
+        SERVER = ECMWFDataServer()
+    except KeyError:
+        SERVER = None
 
 #: map of ECMWF MACC parameter keynames and codes used in API
 PARAMS = {

--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -23,12 +23,6 @@ except ImportError:
             'To download data from ECMWF requires the API client.\nSee https:/'
             '/confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets'
         )
-    SERVER = None
-else:
-    try:
-        SERVER = ECMWFDataServer()
-    except KeyError:
-        SERVER = None
 
 #: map of ECMWF MACC parameter keynames and codes used in API
 PARAMS = {
@@ -61,7 +55,7 @@ def _ecmwf(server, startdate, stopdate, params, targetname):
 
 
 def get_ecmwf_macc(filename, params, startdate, stopdate, lookup_params=True,
-                   server=SERVER, target=_ecmwf):
+                   server=None, target=_ecmwf):
     """
     Download data from ECMWF MACC Reanalysis API.
 
@@ -78,7 +72,7 @@ def get_ecmwf_macc(filename, params, startdate, stopdate, lookup_params=True,
     lookup_params : bool, default True
         optional flag, if ``False``, then codes are already formatted
     server : ecmwfapi.api.ECMWFDataServer
-        optionally provide a server object, default is given
+        optionally provide a server object, default is ``None``
     target : callable
         optional function that calls ``server.retrieve`` to pass to thread
 
@@ -90,7 +84,7 @@ def get_ecmwf_macc(filename, params, startdate, stopdate, lookup_params=True,
     Notes
     -----
     To download data from ECMWF requires the API client and a registration
-    key. Please read the documentation in `Access ECMWF Public Datasets 
+    key. Please read the documentation in `Access ECMWF Public Datasets
     <https://confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets>`_.
     Follow the instructions in step 4 and save the ECMWF registration key
     as `$HOME\.ecmwfapirc` or set `ECMWF_API_KEY` as the path to the key.

--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -89,9 +89,11 @@ def get_ecmwf_macc(filename, params, startdate, stopdate, lookup_params=True,
 
     Notes
     -----
-    To download data from ECMWF requires the API client. For more information,
-    see the `documentation
+    To download data from ECMWF requires the API client and a registration
+    key. Please read the documentation in `Access ECMWF Public Datasets 
     <https://confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets>`_.
+    Follow the instructions in step 4 and save the ECMWF registration key
+    as `$HOME\.ecmwfapirc` or set `ECMWF_API_KEY` as the path to the key.
 
     This function returns a daemon thread that runs in the background. Exiting
     Python will kill this thread, however this thread will not block the main


### PR DESCRIPTION
*  if `.ecmwfapirc` not in `$HOME`
* or `ECMWF_API_KEY` not set to path to `.ecmwfapirc`

pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes issue #649
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
