### PR TITLE
Improve clarity of code in pvsyst_celltemp (names and doc)

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.1.rst
@@ -101,3 +101,4 @@ Contributors
 * Cameron Stark (:ghuser:`camerontstark`)
 * Jonathan Gaffiot (:ghuser:`jgaffiot`)
 * Marc Anoma (:ghuser:`anomam`)
+* Anton Driesse (:ghuser:`adriesse`)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -521,7 +521,7 @@ class PVSystem(object):
             poa_direct, poa_diffuse, airmass_absolute, aoi,
             self.module_parameters, reference_irradiance=reference_irradiance)
 
-    def pvsyst_celltemp(self, poa_global, wind_speed, temp_air):
+    def pvsyst_celltemp(self, poa_global, temp_air, wind_speed):
         """Uses :py:func:`pvsyst_celltemp` to calculate module temperatures
         based on ``self.racking_model`` and the input parameters.
 
@@ -535,7 +535,7 @@ class PVSystem(object):
         """
         kwargs = _build_kwargs(['eta_m', 'alpha_absorption'],
                                self.module_parameters)
-        return pvsyst_celltemp(poa_global, wind_speed, temp_air,
+        return pvsyst_celltemp(poa_global, temp_air, wind_speed,
                                model_params=self.racking_model, **kwargs)
 
     def first_solar_spectral_loss(self, pw, airmass_absolute):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -521,7 +521,7 @@ class PVSystem(object):
             poa_direct, poa_diffuse, airmass_absolute, aoi,
             self.module_parameters, reference_irradiance=reference_irradiance)
 
-    def pvsyst_celltemp(self, poa_global, temp_air, wind_speed):
+    def pvsyst_celltemp(self, poa_global, temp_air, wind_speed=1.0):
         """Uses :py:func:`pvsyst_celltemp` to calculate module temperatures
         based on ``self.racking_model`` and the input parameters.
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1915,7 +1915,7 @@ def pvsyst_celltemp(poa_global, temp_air, wind_speed=1.0, eta_m=0.1,
     as implemented in PVsyst.
 
     The heat loss factors provided through the 'model_params' argument
-    represent the combined effect of convection, radiation and conduction, 
+    represent the combined effect of convection, radiation and conduction,
     and their values are experimentally determined.
 
     Parameters
@@ -1926,18 +1926,18 @@ def pvsyst_celltemp(poa_global, temp_air, wind_speed=1.0, eta_m=0.1,
     temp_air : numeric
         Ambient dry bulb temperature in degrees C.
 
-    wind_speed : numeric
-        Wind speed in m/s measured at the same height for which the wind loss 
-        factor was determined.  The default value is 1.0, which is the wind 
-        speed at module height used to determine NOCT.   (Sorry André!).
+    wind_speed : numeric, default 1.0
+        Wind speed in m/s measured at the same height for which the wind loss
+        factor was determined.  The default value is 1.0, which is the wind
+        speed at module height used to determine NOCT.
 
-    eta_m : numeric
+    eta_m : numeric, default 0.1
         Module external efficiency as a fraction, i.e., DC power / poa_global.
 
-    alpha_absorption : float
-        Absorption coefficient, default is 0.9.
+    alpha_absorption : numeric, default 0.9
+        Absorption coefficient
 
-    model_params : string, tuple, or list, default 'freestanding' (no dict)
+    model_params : string, tuple, or list (no dict), default 'freestanding'
         Heat loss factors to be used.
 
         If string, can be:
@@ -1952,7 +1952,7 @@ def pvsyst_celltemp(poa_global, temp_air, wind_speed=1.0, eta_m=0.1,
         If tuple/list, supply parameters in the following order:
 
             * constant_loss_factor : float
-                Combined heat loss factor coefficient. Freestanding 
+                Combined heat loss factor coefficient. Freestanding
                 default is 29, fully insulated arrays is 15.
 
             * wind_loss_factor : float

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1079,17 +1079,17 @@ def test_PVSystem_sapm_celltemp(mocker):
 
 
 def test_pvsyst_celltemp_default():
-    default = pvsystem.pvsyst_celltemp(900, 5, 20, 0.1)
+    default = pvsystem.pvsyst_celltemp(900, 5, 20)
     assert_allclose(default, 45.137, 0.001)
 
 
 def test_pvsyst_celltemp_non_model():
     tup_non_model = pvsystem.pvsyst_celltemp(900, 5, 20, 0.1,
-                                             temp_model=(23.5, 6.25))
+                                             loss_factors=(23.5, 6.25))
     assert_allclose(tup_non_model, 33.315, 0.001)
 
     list_non_model = pvsystem.pvsyst_celltemp(900, 5, 20, 0.1,
-                                              temp_model=[26.5, 7.68])
+                                              loss_factors=[26.5, 7.68])
     assert_allclose(list_non_model, 31.233, 0.001)
 
 
@@ -1097,14 +1097,14 @@ def test_pvsyst_celltemp_model_wrong_type():
     with pytest.raises(TypeError):
         pvsystem.pvsyst_celltemp(
             900, 5, 20, 0.1,
-            temp_model={"won't": 23.5, "work": 7.68})
+            loss_factors={"won't": 23.5, "work": 7.68})
 
 
 def test_pvsyst_celltemp_model_non_option():
     with pytest.raises(KeyError):
         pvsystem.pvsyst_celltemp(
             900, 5, 20, 0.1,
-            temp_model="not_an_option")
+            loss_factors="not_an_option")
 
 
 def test_pvsyst_celltemp_with_index():

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1113,7 +1113,7 @@ def test_pvsyst_celltemp_with_index():
     irrads = pd.Series([0, 500, 0], index=times)
     winds = pd.Series([10, 5, 0], index=times)
 
-    pvtemps = pvsystem.pvsyst_celltemp(irrads, temps, winds)
+    pvtemps = pvsystem.pvsyst_celltemp(irrads, temps, wind_speed=winds)
     expected = pd.Series([0.0, 23.96551, 5.0], index=times)
     assert_series_equal(expected, pvtemps)
 
@@ -1131,9 +1131,9 @@ def test_PVSystem_pvsyst_celltemp(mocker):
     irrad = 800
     temp = 45
     wind = 0.5
-    out = system.pvsyst_celltemp(irrad, temp, wind)
+    out = system.pvsyst_celltemp(irrad, temp, wind_speed=wind)
     pvsystem.pvsyst_celltemp.assert_called_once_with(
-        irrad, wind, temp, eta_m, alpha_absorption, racking_model)
+        irrad, temp, wind, eta_m, alpha_absorption, racking_model)
     assert isinstance(out, float)
     assert out < 90 and out > 70
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -1079,32 +1079,32 @@ def test_PVSystem_sapm_celltemp(mocker):
 
 
 def test_pvsyst_celltemp_default():
-    default = pvsystem.pvsyst_celltemp(900, 5, 20)
+    default = pvsystem.pvsyst_celltemp(900, 20, 5)
     assert_allclose(default, 45.137, 0.001)
 
 
 def test_pvsyst_celltemp_non_model():
-    tup_non_model = pvsystem.pvsyst_celltemp(900, 5, 20, 0.1,
-                                             loss_factors=(23.5, 6.25))
+    tup_non_model = pvsystem.pvsyst_celltemp(900, 20, 5, 0.1,
+                                             model_params=(23.5, 6.25))
     assert_allclose(tup_non_model, 33.315, 0.001)
 
-    list_non_model = pvsystem.pvsyst_celltemp(900, 5, 20, 0.1,
-                                              loss_factors=[26.5, 7.68])
+    list_non_model = pvsystem.pvsyst_celltemp(900, 20, 5, 0.1,
+                                              model_params=[26.5, 7.68])
     assert_allclose(list_non_model, 31.233, 0.001)
 
 
 def test_pvsyst_celltemp_model_wrong_type():
     with pytest.raises(TypeError):
         pvsystem.pvsyst_celltemp(
-            900, 5, 20, 0.1,
-            loss_factors={"won't": 23.5, "work": 7.68})
+            900, 20, 5, 0.1,
+            model_params={"won't": 23.5, "work": 7.68})
 
 
 def test_pvsyst_celltemp_model_non_option():
     with pytest.raises(KeyError):
         pvsystem.pvsyst_celltemp(
-            900, 5, 20, 0.1,
-            loss_factors="not_an_option")
+            900, 20, 5, 0.1,
+            model_params="not_an_option")
 
 
 def test_pvsyst_celltemp_with_index():
@@ -1113,7 +1113,7 @@ def test_pvsyst_celltemp_with_index():
     irrads = pd.Series([0, 500, 0], index=times)
     winds = pd.Series([10, 5, 0], index=times)
 
-    pvtemps = pvsystem.pvsyst_celltemp(irrads, winds, temps)
+    pvtemps = pvsystem.pvsyst_celltemp(irrads, temps, winds)
     expected = pd.Series([0.0, 23.96551, 5.0], index=times)
     assert_series_equal(expected, pvtemps)
 
@@ -1131,7 +1131,7 @@ def test_PVSystem_pvsyst_celltemp(mocker):
     irrad = 800
     temp = 45
     wind = 0.5
-    out = system.pvsyst_celltemp(irrad, wind, temp)
+    out = system.pvsyst_celltemp(irrad, temp, wind)
     pvsystem.pvsyst_celltemp.assert_called_once_with(
         irrad, wind, temp, eta_m, alpha_absorption, racking_model)
     assert isinstance(out, float)


### PR DESCRIPTION
 - [x] Improves on the implementation of issue #552
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

I have tried to improve clarity of code in `pvsyst_celltemp` through changes to variables names and docstring, and also changed the name of one function parameter.

