### PR TITLE
reduce codecov tests target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ coverage:
         paths:
           - "pvlib/(\w+/)?[^/]+\.py$"
       tests:
-        target: 96%
+        target: 95%
         paths:
           - "pvlib/test/.*"
 


### PR DESCRIPTION
The percentage of automatically executed lines in the `pvlib/tests` directory dropped recently due to some new helper functions and try/except statements. This PR slightly reduces the codecov target for the test directory.

 - [x] Pull request is nearly complete and ready for detailed review.

