### PR TITLE
compatibility with pandas 0.24 deprecations

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.2.rst
@@ -20,6 +20,7 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Compatibility with pandas 0.24 deprecations. (:issue:`659`)
 
 
 Testing
@@ -28,3 +29,5 @@ Testing
 
 Contributors
 ~~~~~~~~~~~~
+* cwhanse
+* wholmgren

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -670,7 +670,7 @@ def detect_clearsky(measured, clearsky, times, window_length,
     """
 
     # calculate deltas in units of minutes (matches input window_length units)
-    deltas = np.diff(times) / np.timedelta64(1, '60s')
+    deltas = np.diff(times.values) / np.timedelta64(1, '60s')
 
     # determine the unique deltas and if we can proceed
     unique_deltas = np.unique(deltas)

--- a/pvlib/test/test_atmosphere.py
+++ b/pvlib/test/test_atmosphere.py
@@ -45,7 +45,7 @@ def test_airmass(model, expected, zeniths):
     assert_allclose(out, expected, equal_nan=True, atol=0.001)
     # test series in/out. index does not matter
     # hits the isinstance() block in get_relative_airmass
-    times = pd.DatetimeIndex(start='20180101', periods=len(zeniths), freq='1s')
+    times = pd.date_range(start='20180101', periods=len(zeniths), freq='1s')
     zeniths = pd.Series(zeniths, index=times)
     expected = pd.Series(expected, index=times)
     out = atmosphere.get_relative_airmass(zeniths, model)

--- a/pvlib/test/test_clearsky.py
+++ b/pvlib/test/test_clearsky.py
@@ -619,8 +619,8 @@ def test_detect_clearsky_irregular_times(detect_clearsky_data):
 
 def test_bird():
     """Test Bird/Hulstrom Clearsky Model"""
-    times = pd.DatetimeIndex(start='1/1/2015 0:00', end='12/31/2015 23:00',
-                             freq='H')
+    times = pd.date_range(start='1/1/2015 0:00', end='12/31/2015 23:00',
+                          freq='H')
     tz = -7  # test timezone
     gmt_tz = pytz.timezone('Etc/GMT%+d' % -(tz))
     times = times.tz_localize(gmt_tz)  # set timezone

--- a/pvlib/test/test_irradiance.py
+++ b/pvlib/test/test_irradiance.py
@@ -389,8 +389,8 @@ def test_disc_overirradiance():
     columns = ['dni', 'kt', 'airmass']
     ghi = np.array([3000])
     solar_zenith = np.full_like(ghi, 0)
-    times = pd.DatetimeIndex(start='2016-07-19 12:00:00', freq='1s',
-                             periods=len(ghi), tz='America/Phoenix')
+    times = pd.date_range(start='2016-07-19 12:00:00', freq='1s',
+                          periods=len(ghi), tz='America/Phoenix')
     out = irradiance.disc(ghi=ghi, solar_zenith=solar_zenith,
                           datetime_or_doy=times)
     expected = pd.DataFrame(np.array(
@@ -462,7 +462,7 @@ def test_disc_min_cos_zenith_max_zenith():
 
 
 def test_dirint_value():
-    times = pd.DatetimeIndex(['2014-06-24T12-0700','2014-06-24T18-0700'])
+    times = pd.DatetimeIndex(['2014-06-24T12-0700', '2014-06-24T18-0700'])
     ghi = pd.Series([1038.62, 254.53], index=times)
     zenith = pd.Series([10.567, 72.469], index=times)
     pressure = 93193.
@@ -472,7 +472,7 @@ def test_dirint_value():
 
 
 def test_dirint_nans():
-    times = pd.DatetimeIndex(start='2014-06-24T12-0700', periods=5, freq='6H')
+    times = pd.date_range(start='2014-06-24T12-0700', periods=5, freq='6H')
     ghi = pd.Series([np.nan, 1038.62, 1038.62, 1038.62, 1038.62], index=times)
     zenith = pd.Series([10.567, np.nan, 10.567, 10.567, 10.567], index=times)
     pressure = pd.Series([93193., 93193., np.nan, 93193., 93193.], index=times)
@@ -797,7 +797,7 @@ def test_clearsky_index():
     expected = 0.01
     assert_allclose(out, expected, atol=0.001)
     # series
-    times = pd.DatetimeIndex(start='20180601', periods=2, freq='12H')
+    times = pd.date_range(start='20180601', periods=2, freq='12H')
     ghi_measured = pd.Series([100,  500], index=times)
     ghi_modeled = pd.Series([500, 1000], index=times)
     out = irradiance.clearsky_index(ghi_measured, ghi_modeled)
@@ -853,7 +853,7 @@ def test_clearness_index():
     expected = 0.725
     assert_allclose(out, expected, atol=0.001)
     # series
-    times = pd.DatetimeIndex(start='20180601', periods=2, freq='12H')
+    times = pd.date_range(start='20180601', periods=2, freq='12H')
     ghi = pd.Series([0, 1000], index=times)
     solar_zenith = pd.Series([90, 0], index=times)
     extra_radiation = pd.Series([1360, 1400], index=times)
@@ -887,7 +887,7 @@ def test_clearness_index_zenith_independent(airmass_kt):
     expected = 0.443
     assert_allclose(out, expected, atol=0.001)
     # series
-    times = pd.DatetimeIndex(start='20180601', periods=2, freq='12H')
+    times = pd.date_range(start='20180601', periods=2, freq='12H')
     clearness_index = pd.Series([0, .5], index=times)
     airmass = pd.Series([np.nan, 2], index=times)
     out = irradiance.clearness_index_zenith_independent(clearness_index,

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -75,12 +75,16 @@ def test_location_print_pytz():
     assert tus.__str__() == expected_str
 
 
+@pytest.fixture
+def times():
+    return pd.date_range(start='20160101T0600-0700',
+                         end='20160101T1800-0700',
+                         freq='3H')
+
+
 @requires_scipy
-def test_get_clearsky(mocker):
+def test_get_clearsky(mocker, times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     m = mocker.spy(pvlib.clearsky, 'ineichen')
     out = tus.get_clearsky(times)
     assert m.call_count == 1
@@ -110,11 +114,8 @@ def test_get_clearsky_ineichen_supply_linke(mocker):
     assert (out.columns.values == ['ghi', 'dni', 'dhi']).all()
 
 
-def test_get_clearsky_haurwitz():
+def test_get_clearsky_haurwitz(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     clearsky = tus.get_clearsky(times, model='haurwitz')
     expected = pd.DataFrame(data=np.array(
                             [[   0.        ],
@@ -127,11 +128,8 @@ def test_get_clearsky_haurwitz():
     assert_frame_equal(expected, clearsky)
 
 
-def test_get_clearsky_simplified_solis():
+def test_get_clearsky_simplified_solis(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     clearsky = tus.get_clearsky(times, model='simplified_solis')
     expected = pd.DataFrame(data=np.
         array([[   0.        ,    0.        ,    0.        ],
@@ -145,11 +143,8 @@ def test_get_clearsky_simplified_solis():
     assert_frame_equal(expected, clearsky, check_less_precise=2)
 
 
-def test_get_clearsky_simplified_solis_apparent_elevation():
+def test_get_clearsky_simplified_solis_apparent_elevation(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     solar_position = {'apparent_elevation': pd.Series(80, index=times),
                       'apparent_zenith': pd.Series(10, index=times)}
     clearsky = tus.get_clearsky(times, model='simplified_solis',
@@ -166,11 +161,8 @@ def test_get_clearsky_simplified_solis_apparent_elevation():
     assert_frame_equal(expected, clearsky, check_less_precise=2)
 
 
-def test_get_clearsky_simplified_solis_dni_extra():
+def test_get_clearsky_simplified_solis_dni_extra(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     clearsky = tus.get_clearsky(times, model='simplified_solis',
                                 dni_extra=1370)
     expected = pd.DataFrame(data=np.
@@ -185,11 +177,8 @@ def test_get_clearsky_simplified_solis_dni_extra():
     assert_frame_equal(expected, clearsky)
 
 
-def test_get_clearsky_simplified_solis_pressure():
+def test_get_clearsky_simplified_solis_pressure(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     clearsky = tus.get_clearsky(times, model='simplified_solis',
                                 pressure=95000)
     expected = pd.DataFrame(data=np.
@@ -204,11 +193,8 @@ def test_get_clearsky_simplified_solis_pressure():
     assert_frame_equal(expected, clearsky, check_less_precise=2)
 
 
-def test_get_clearsky_simplified_solis_aod_pw():
+def test_get_clearsky_simplified_solis_aod_pw(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     clearsky = tus.get_clearsky(times, model='simplified_solis',
                                 aod700=0.25, precipitable_water=2.)
     expected = pd.DataFrame(data=np.
@@ -223,11 +209,8 @@ def test_get_clearsky_simplified_solis_aod_pw():
     assert_frame_equal(expected, clearsky, check_less_precise=2)
 
 
-def test_get_clearsky_valueerror():
+def test_get_clearsky_valueerror(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     with pytest.raises(ValueError):
         clearsky = tus.get_clearsky(times, model='invalid_model')
 
@@ -255,7 +238,7 @@ def test_from_tmy_2():
 
 
 def test_get_solarposition(expected_solpos, golden_mst):
-    times = pd.date_range(datetime.datetime(2003,10,17,12,30,30),
+    times = pd.date_range(datetime.datetime(2003, 10, 17, 12, 30, 30),
                           periods=1, freq='D', tz=golden_mst.tz)
     ephem_data = golden_mst.get_solarposition(times, temperature=11)
     ephem_data = np.round(ephem_data, 3)
@@ -264,11 +247,8 @@ def test_get_solarposition(expected_solpos, golden_mst):
     assert_frame_equal(expected_solpos, ephem_data[expected_solpos.columns])
 
 
-def test_get_airmass():
+def test_get_airmass(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     airmass = tus.get_airmass(times)
     expected = pd.DataFrame(data=np.array(
                             [[        nan,         nan],
@@ -292,11 +272,8 @@ def test_get_airmass():
     assert_frame_equal(expected, airmass)
 
 
-def test_get_airmass_valueerror():
+def test_get_airmass_valueerror(times):
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
-    times = pd.DatetimeIndex(start='20160101T0600-0700',
-                             end='20160101T1800-0700',
-                             freq='3H')
     with pytest.raises(ValueError):
         clearsky = tus.get_airmass(times, model='invalid_model')
 
@@ -329,8 +306,8 @@ def test_get_sun_rise_set_transit(golden):
     declination = declination_spencer71(dayofyear)
     eot = equation_of_time_spencer71(dayofyear)
     result = golden.get_sun_rise_set_transit(times, method='geometric',
-                                                   declination=declination,
-                                                   equation_of_time=eot)
+                                             declination=declination,
+                                             equation_of_time=eot)
     assert all(result.columns == ['sunrise', 'sunset', 'transit'])
 
 

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -488,8 +488,8 @@ def test_deprecated_07():
 
 @requires_scipy
 def test_basic_chain_required(sam_data):
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     latitude = 32
     longitude = -111
     altitude = 700
@@ -505,8 +505,8 @@ def test_basic_chain_required(sam_data):
 
 @requires_scipy
 def test_basic_chain_alt_az(sam_data):
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     latitude = 32.2
     longitude = -111
     altitude = 700
@@ -529,8 +529,8 @@ def test_basic_chain_alt_az(sam_data):
 
 @requires_scipy
 def test_basic_chain_strategy(sam_data):
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     latitude = 32.2
     longitude = -111
     altitude = 700
@@ -551,8 +551,8 @@ def test_basic_chain_strategy(sam_data):
 
 @requires_scipy
 def test_basic_chain_altitude_pressure(sam_data):
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     latitude = 32.2
     longitude = -111
     altitude = 700

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -194,7 +194,7 @@ def pvsyst_module_params():
 
 def test_sapm(sapm_module_params):
 
-    times = pd.DatetimeIndex(start='2015-01-01', periods=5, freq='12H')
+    times = pd.date_range(start='2015-01-01', periods=5, freq='12H')
     effective_irradiance = pd.Series([-1, 0.5, 1.1, np.nan, 1], index=times)
     temp_cell = pd.Series([10, 25, 50, 25, np.nan], index=times)
 
@@ -380,7 +380,7 @@ def test_PVSystem_sapm_effective_irradiance(sapm_module_params, mocker):
 
 
 def test_calcparams_desoto(cec_module_params):
-    times = pd.DatetimeIndex(start='2015-01-01', periods=3, freq='12H')
+    times = pd.date_range(start='2015-01-01', periods=3, freq='12H')
     effective_irradiance = pd.Series([0.0, 800.0, 800.0], index=times)
     temp_cell = pd.Series([25, 25, 50], index=times)
 
@@ -408,7 +408,7 @@ def test_calcparams_desoto(cec_module_params):
 
 
 def test_calcparams_cec(cec_module_params):
-    times = pd.DatetimeIndex(start='2015-01-01', periods=3, freq='12H')
+    times = pd.date_range(start='2015-01-01', periods=3, freq='12H')
     effective_irradiance = pd.Series([0.0, 800.0, 800.0], index=times)
     temp_cell = pd.Series([25, 25, 50], index=times)
 
@@ -437,7 +437,7 @@ def test_calcparams_cec(cec_module_params):
 
 
 def test_calcparams_pvsyst(pvsyst_module_params):
-    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
+    times = pd.date_range(start='2015-01-01', periods=2, freq='12H')
     effective_irradiance = pd.Series([0.0, 800.0], index=times)
     temp_cell = pd.Series([25, 50], index=times)
 
@@ -868,7 +868,7 @@ def test_mpp_series():
 
 @requires_scipy
 def test_singlediode_series(cec_module_params):
-    times = pd.DatetimeIndex(start='2015-01-01', periods=2, freq='12H')
+    times = pd.date_range(start='2015-01-01', periods=2, freq='12H')
     effective_irradiance = pd.Series([0.0, 800.0], index=times)
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
         effective_irradiance,
@@ -957,7 +957,7 @@ def test_singlediode_floats_ivcurve():
 
 @requires_scipy
 def test_singlediode_series_ivcurve(cec_module_params):
-    times = pd.DatetimeIndex(start='2015-06-01', periods=3, freq='6H')
+    times = pd.date_range(start='2015-06-01', periods=3, freq='6H')
     effective_irradiance = pd.Series([0.0, 400.0, 800.0], index=times)
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
                                   effective_irradiance,
@@ -1049,7 +1049,7 @@ def test_sapm_celltemp_dict_like():
 
 
 def test_sapm_celltemp_with_index():
-    times = pd.DatetimeIndex(start='2015-01-01', end='2015-01-02', freq='12H')
+    times = pd.date_range(start='2015-01-01', end='2015-01-02', freq='12H')
     temps = pd.Series([0, 10, 5], index=times)
     irrads = pd.Series([0, 500, 0], index=times)
     winds = pd.Series([10, 5, 0], index=times)
@@ -1108,7 +1108,7 @@ def test_pvsyst_celltemp_model_non_option():
 
 
 def test_pvsyst_celltemp_with_index():
-    times = pd.DatetimeIndex(start="2015-01-01", end="2015-01-02", freq="12H")
+    times = pd.date_range(start="2015-01-01", end="2015-01-02", freq="12H")
     temps = pd.Series([0, 10, 5], index=times)
     irrads = pd.Series([0, 500, 0], index=times)
     winds = pd.Series([10, 5, 0], index=times)
@@ -1244,8 +1244,8 @@ def test_PVSystem_get_aoi():
 
 def test_PVSystem_get_irradiance():
     system = pvsystem.PVSystem(surface_tilt=32, surface_azimuth=135)
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     location = Location(latitude=32, longitude=-111)
     solar_position = location.get_solarposition(times)
     irrads = pd.DataFrame({'dni':[900,0], 'ghi':[600,0], 'dhi':[100,0]},

--- a/pvlib/test/test_solarposition.py
+++ b/pvlib/test/test_solarposition.py
@@ -602,8 +602,8 @@ def test_nrel_earthsun_distance():
 
 
 def test_equation_of_time():
-    times = pd.DatetimeIndex(start="1/1/2015 0:00", end="12/31/2015 23:00",
-                             freq="H")
+    times = pd.date_range(start="1/1/2015 0:00", end="12/31/2015 23:00",
+                          freq="H")
     output = solarposition.spa_python(times, 37.8, -122.25, 100)
     eot = output['equation_of_time']
     eot_rng = eot.max() - eot.min()  # range of values, around 30 minutes
@@ -614,8 +614,8 @@ def test_equation_of_time():
 
 
 def test_declination():
-    times = pd.DatetimeIndex(start="1/1/2015 0:00", end="12/31/2015 23:00",
-                             freq="H")
+    times = pd.date_range(start="1/1/2015 0:00", end="12/31/2015 23:00",
+                          freq="H")
     atmos_refract = 0.5667
     delta_t = spa.calculate_deltat(times.year, times.month)
     unixtime = np.array([calendar.timegm(t.timetuple()) for t in times])
@@ -633,8 +633,8 @@ def test_declination():
 
 
 def test_analytical_zenith():
-    times = pd.DatetimeIndex(start="1/1/2015 0:00", end="12/31/2015 23:00",
-                             freq="H").tz_localize('Etc/GMT+8')
+    times = pd.date_range(start="1/1/2015 0:00", end="12/31/2015 23:00",
+                          freq="H").tz_localize('Etc/GMT+8')
     lat, lon = 37.8, -122.25
     lat_rad = np.deg2rad(lat)
     output = solarposition.spa_python(times, lat, lon, 100)
@@ -654,8 +654,8 @@ def test_analytical_zenith():
 
 
 def test_analytical_azimuth():
-    times = pd.DatetimeIndex(start="1/1/2015 0:00", end="12/31/2015 23:00",
-                             freq="H").tz_localize('Etc/GMT+8')
+    times = pd.date_range(start="1/1/2015 0:00", end="12/31/2015 23:00",
+                          freq="H").tz_localize('Etc/GMT+8')
     lat, lon = 37.8, -122.25
     lat_rad = np.deg2rad(lat)
     output = solarposition.spa_python(times, lat, lon, 100)

--- a/pvlib/test/test_surfrad.py
+++ b/pvlib/test/test_surfrad.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 
-from pandas import Timestamp, DatetimeIndex
+import pandas as pd
 from pandas.util.testing import network
 
 from pvlib.iotools import surfrad
@@ -48,8 +48,8 @@ def test_read_surfrad_columns_map():
 
 
 def test_format_index():
-    start = Timestamp('20160101 00:00')
-    expected = DatetimeIndex(start=start, periods=1440, freq='1min', tz='UTC')
+    start = pd.Timestamp('20160101 00:00')
+    expected = pd.date_range(start=start, periods=1440, freq='1min', tz='UTC')
     actual, _ = surfrad.read_surfrad(testfile)
     assert actual.index.equals(expected)
 

--- a/pvlib/test/test_tracking.py
+++ b/pvlib/test/test_tracking.py
@@ -16,7 +16,7 @@ SINGLEAXIS_COL_ORDER = ['tracker_theta', 'aoi',
 
 
 def test_solar_noon():
-    index = pd.DatetimeIndex(start='20180701T1200', freq='1s', periods=1)
+    index = pd.date_range(start='20180701T1200', freq='1s', periods=1)
     apparent_zenith = pd.Series([10], index=index)
     apparent_azimuth = pd.Series([180], index=index)
     tracker_data = tracking.singleaxis(apparent_zenith, apparent_azimuth,
@@ -385,8 +385,8 @@ def test_get_irradiance():
     system = tracking.SingleAxisTracker(max_angle=90, axis_tilt=30,
                                         axis_azimuth=180, gcr=2.0/7.0,
                                         backtrack=True)
-    times = pd.DatetimeIndex(start='20160101 1200-0700',
-                             end='20160101 1800-0700', freq='6H')
+    times = pd.date_range(start='20160101 1200-0700',
+                          end='20160101 1800-0700', freq='6H')
     location = Location(latitude=32, longitude=-111)
     solar_position = location.get_solarposition(times)
     irrads = pd.DataFrame({'dni': [900, 0], 'ghi': [600, 0], 'dhi': [100, 0]},


### PR DESCRIPTION
 - [x] Closes #659
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

