### PR TITLE
add irradiance.dni() function to Decomposing and combining irradiance…

### DIFF
--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -153,6 +153,7 @@ Decomposing and combining irradiance
    irradiance.beam_component
    irradiance.poa_components
    irradiance.get_ground_diffuse
+   irradiance.dni
 
 Transposition models
 --------------------


### PR DESCRIPTION
… section of api.rst. this seems to be the most reasonable section to reference the function. Issue #686.

 - [X] Closes  #686 
 - [X] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [X] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [X] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
I recommend placing the irradiance.dni() function within the 'Decomposing and combining irradiance' section because it seems the most semantically intuitive option given how the sections are structured. 
