### PR TITLE
better nan handling in singleaxis

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.2.rst
@@ -40,7 +40,11 @@ Bug fixes
 * Fixed :py:func:`~pvlib.irradiance.erbs` behavior when zenith is
   near 90 degrees. (:issue:`681`)
 * :py:func:`~pvlib.irradiance.dni` now referenced in API under
-  Decomposing and Combining irradiance header. (:issue:`686`)  
+  Decomposing and Combining irradiance header. (:issue:`686`)
+* Fixed NaN output from :py:func:`~pvlib.tracking.singleaxis` when sun
+  near horizon. (:issue:`656`)
+* Fixed numpy warnings in :py:func:`~pvlib.tracking.singleaxis` when
+  comparing NaN values to limits. (:issue:`622`)
 
 
 Testing
@@ -53,4 +57,5 @@ Contributors
 * Will Holmgren (:ghuser:`wholmgren`)
 * Roel Loonen (:ghuser:`roelloonen`)
 * Todd Hendricks (:ghuser:`tahentx`)
-
+* Kevin Anderson (:ghuser:`kevinsa5`)
+* :ghuser:`bentomlinson`

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -441,6 +441,7 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     # angle convention being used here.
     if backtrack:
         axes_distance = 1/gcr
+        # clip needed for low angles. GH 656
         temp = np.clip(axes_distance*cosd(wid), -1, 1)
 
         # backtrack angle
@@ -449,6 +450,7 @@ def singleaxis(apparent_zenith, apparent_azimuth,
 
         # Eq 4 applied when wid in QIV (wid < 0 evalulates True), QI
         with np.errstate(invalid='ignore'):
+            # errstate for GH 622
             tracker_theta = np.where(wid < 0, wid + wc, wid - wc)
     else:
         tracker_theta = wid


### PR DESCRIPTION
 - [x] Closes  #622 Closes #656
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.


