### PR TITLE
Add parsing for non 1-minute data to UO SRML parser

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.2.rst
@@ -51,6 +51,8 @@ Bug fixes
   :py:func:`~pvlib.irradiance.klucher` and
   :py:func:`~pvlib.pvsystem.calcparams_desoto`. (:issue:`698`)
 * Fix :py:class:`~pvlib.forecast.NDFD` model by updating variables.
+* Fix :py:func:`~pvlib.iotools.srml.format_index` to parse non
+  one-minute data correctly. (:issue:`709`)
 
 
 Testing
@@ -67,3 +69,4 @@ Contributors
 * Kevin Anderson (:ghuser:`kevinsa5`)
 * :ghuser:`bentomlinson`
 * Jonathan Gaffiot (:ghuser:`jgaffiot`)
+* Leland Boeman (:ghuser: `lboeman`)

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -44,9 +44,10 @@ def read_srml(filename):
     -----
     The time index is shifted back by one interval to account for the
     daily endtime of 2400, and to avoid time parsing errors on leap
-    years. The returned data values should be understood to occur
-    during the interval from the time of the row until the time of the
-    next row. This is consistent with pandas' default labeling behavior.
+    years. The returned data values are labeled by the left endpoint of
+    interval, and should be understood to occur during the interval from
+    the time of the row until the time of the next row. This is consistent
+    with pandas' default labeling behavior.
 
     See SRML's `Archival Files`_ page for more information.
 

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -42,11 +42,11 @@ def read_srml(filename):
 
     Notes
     -----
-    The time index is shifted back one minute to account for 2400 hours,
-    and to avoid time parsing errors on leap years. The returned data
-    values should be understood to occur during the interval from the
-    time of the row until the time of the next row. This is consistent
-    with pandas' default labeling behavior.
+    The time index is shifted back by one interval to account for the
+    daily endtime of 2400, and to avoid time parsing errors on leap
+    years. The returned data values should be understood to occur
+    during the interval from the time of the row until the time of the
+    next row. This is consistent with pandas' default labeling behavior.
 
     See SRML's `Archival Files`_ page for more information.
 

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -149,8 +149,8 @@ def format_index(df):
         # Because hours are represented by some multiple of 100, shifting
         # results in invalid values.
         #
-        # e.g. 200 (for 02:00) shifted becomes 185, the desired result is
-        #      145 (for 01:45)
+        # e.g. 200 (for 02:00) shifted by 15 minutes becomes 185, the
+        #      desired result is 145 (for 01:45)
         #
         # So we find all times with minutes greater than 60 and remove 40
         # to correct to valid times.

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -138,7 +138,7 @@ def format_index(df):
     # subracting the length of one interval and then correcting the times
     # at each former hour. interval_length is determined by taking the
     # difference of the first two rows of the time column.
-    interval_length = int(df[df.columns[1]][:2].diff()[1])
+    interval_length = df[df.columns[1]][1] - df[df.columns[1]][0]
     df_time = df[df.columns[1]] - interval_length
     if interval_length == 100:
         # Hourly files do not require fixing the former hour timestamps.

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -176,12 +176,11 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO'):
 
     Notes
     -----
-    File types designate the time interval of a file and if it is
-    raw or processed data. For instance, `RO` designates raw one
-    minute data and `PO` designates processed one minute data. The
-    availability of file types varies between sites. Below is a
-    table of file types and their time intervals. See [1] for site
-    information.
+    File types designate the time interval of a file and if it contains
+    raw or processed data. For instance, `RO` designates raw, one minute
+    data and `PO` designates processed one minute data. The availability
+    of file types varies between sites. Below is a table of file types
+    and their time intervals. See [1] for site information.
 
     ============= ============ ==================
     time interval raw filetype processed filetype

--- a/pvlib/test/test_srml.py
+++ b/pvlib/test/test_srml.py
@@ -75,6 +75,7 @@ def test_read_srml_month_from_solardat():
     assert file_data.equals(requested)
 
 
+@network
 @pytest.mark.parametrize('station, year, month, filetype', [
     ('TW', 2019, 4, 'RQ'),
 ])
@@ -90,6 +91,7 @@ def test_15_minute_dt_index(
     assert (data.index[3::4].minute == 45).all()
 
 
+@network
 @pytest.mark.parametrize('station, year, month, filetype', [
     ('CD', 1986, 4, 'PH'),
 ])

--- a/pvlib/test/test_srml.py
+++ b/pvlib/test/test_srml.py
@@ -73,3 +73,33 @@ def test_read_srml_month_from_solardat():
     file_data = srml.read_srml(url)
     requested = srml.read_srml_month_from_solardat('EU', 2018, 1)
     assert file_data.equals(requested)
+
+
+@pytest.mark.parametrize('station, year, month, filetype', [
+    ('TW', 2019, 4, 'RQ'),
+])
+def test_15_minute_dt_index(
+        station, year, month, filetype):
+    data = srml.read_srml_month_from_solardat(station, year, month, filetype)
+    start = pd.Timestamp('{:04d}{:02d}01 00:00'.format(year, month))
+    start = start.tz_localize('Etc/GMT+8')
+    end = pd.Timestamp('{:04d}{:02d}30 23:45'.format(year, month))
+    end = end.tz_localize('Etc/GMT+8')
+    assert data.index[0] == start
+    assert data.index[-1] == end
+    assert (data.index[3::4].minute == 45).all()
+
+
+@pytest.mark.parametrize('station, year, month, filetype', [
+    ('CD', 1986, 4, 'PH'),
+])
+def test_hourly_dt_index(
+        station, year, month, filetype):
+    data = srml.read_srml_month_from_solardat(station, year, month, filetype)
+    start = pd.Timestamp('{:04d}{:02d}01 00:00'.format(year, month))
+    start = start.tz_localize('Etc/GMT+8')
+    end = pd.Timestamp('{:04d}{:02d}30 23:00'.format(year, month))
+    end = end.tz_localize('Etc/GMT+8')
+    assert data.index[0] == start
+    assert data.index[-1] == end
+    assert (data.index.minute == 0).all()

--- a/pvlib/test/test_srml.py
+++ b/pvlib/test/test_srml.py
@@ -76,15 +76,11 @@ def test_read_srml_month_from_solardat():
 
 
 @network
-@pytest.mark.parametrize('station, year, month, filetype', [
-    ('TW', 2019, 4, 'RQ'),
-])
-def test_15_minute_dt_index(
-        station, year, month, filetype):
-    data = srml.read_srml_month_from_solardat(station, year, month, filetype)
-    start = pd.Timestamp('{:04d}{:02d}01 00:00'.format(year, month))
+def test_15_minute_dt_index():
+    data = srml.read_srml_month_from_solardat('TW', 2019, 4, 'RQ')
+    start = pd.Timestamp('20190401 00:00')
     start = start.tz_localize('Etc/GMT+8')
-    end = pd.Timestamp('{:04d}{:02d}30 23:45'.format(year, month))
+    end = pd.Timestamp('20190430 23:45')
     end = end.tz_localize('Etc/GMT+8')
     assert data.index[0] == start
     assert data.index[-1] == end
@@ -92,15 +88,11 @@ def test_15_minute_dt_index(
 
 
 @network
-@pytest.mark.parametrize('station, year, month, filetype', [
-    ('CD', 1986, 4, 'PH'),
-])
-def test_hourly_dt_index(
-        station, year, month, filetype):
-    data = srml.read_srml_month_from_solardat(station, year, month, filetype)
-    start = pd.Timestamp('{:04d}{:02d}01 00:00'.format(year, month))
+def test_hourly_dt_index():
+    data = srml.read_srml_month_from_solardat('CD', 1986, 4, 'PH')
+    start = pd.Timestamp('19860401 00:00')
     start = start.tz_localize('Etc/GMT+8')
-    end = pd.Timestamp('{:04d}{:02d}30 23:00'.format(year, month))
+    end = pd.Timestamp('19860430 23:00')
     end = end.tz_localize('Etc/GMT+8')
     assert data.index[0] == start
     assert data.index[-1] == end


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes  #709 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.