### PR TITLE
Add kwargs to forecast.get_data with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ If you use pvlib-python in a published work, please cite:
 Please also cite the DOI corresponding to the specific version of
 pvlib-python that you used. pvlib-python DOIs are listed at
 [Zenodo.org](https://zenodo.org/search?page=1&size=20&q=conceptrecid:593284&all_versions&sort=-version)
+
+NumFOCUS
+========
+
+pvlib python is a [NumFOCUS Affiliated Project](https://numfocus.org/sponsored-projects/affiliated-projects)
+
+[![NumFocus Affliated Projects](https://i0.wp.com/numfocus.org/wp-content/uploads/2019/06/AffiliatedProject.png)](https://numfocus.org/sponsored-projects/affiliated-projects)

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -8,8 +8,13 @@ recommend all users of v0.6.3 upgrade to this release.
 
 **Python 2.7 support ended on June 1, 2019**. (:issue:`501`)
 
+Bug fixes
+~~~~~~~~~
+* Fix handling of keyword arguments in `forecasts.get_processed_data`.
+  (:issue:`745`)
 
 Contributors
 ~~~~~~~~~~~~
 * Mark Campanellli (:ghuser:`markcampanelli`)
 * Will Holmgren (:ghuser:`wholmgren`)
+* Oscar Dowson (:ghuser:`odow`)

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -201,7 +201,7 @@ class ForecastModel(object):
 
     def get_data(self, latitude, longitude, start, end,
                  vert_level=None, query_variables=None,
-                 close_netcdf_data=True):
+                 close_netcdf_data=True, **kwargs):
         """
         Submits a query to the UNIDATA servers using Siphon NCSS and
         converts the netcdf data to a pandas DataFrame.
@@ -223,6 +223,8 @@ class ForecastModel(object):
         close_netcdf_data: bool, default True
             Controls if the temporary netcdf data file should be closed.
             Set to False to access the raw data.
+        **kwargs:
+            Additional keyword arguments are silently ignored.
 
         Returns
         -------

--- a/pvlib/test/test_forecast.py
+++ b/pvlib/test/test_forecast.py
@@ -77,6 +77,8 @@ def test_process_data(model):
 
 @requires_siphon
 def test_bad_kwarg_get_data():
+    # For more information on why you would want to pass an unknown keyword
+    # argument, see Github issue #745.
     amodel = NAM()
     data = amodel.get_data(_latitude, _longitude, _start, _end,
                            bad_kwarg=False)
@@ -85,15 +87,12 @@ def test_bad_kwarg_get_data():
 
 @requires_siphon
 def test_bad_kwarg_get_processed_data():
+    # For more information on why you would want to pass an unknown keyword
+    # argument, see Github issue #745.
     amodel = NAM()
     data = amodel.get_processed_data(_latitude, _longitude, _start, _end,
                                      bad_kwarg=False)
-    for variable in _nonnan_variables:
-        try:
-            assert not data[variable].isnull().values.any()
-        except AssertionError:
-            warnings.warn('{}, {}, data contained null values'
-                          .format(model, variable))
+    assert not data.empty
 
 
 @requires_siphon
@@ -101,12 +100,7 @@ def test_how_kwarg_get_processed_data():
     amodel = NAM()
     data = amodel.get_processed_data(_latitude, _longitude, _start, _end,
                                      how='clearsky_scaling')
-    for variable in _nonnan_variables:
-        try:
-            assert not data[variable].isnull().values.any()
-        except AssertionError:
-            warnings.warn('{}, {}, data contained null values'
-                          .format(model, variable))
+    assert not data.empty
 
 
 @requires_siphon

--- a/pvlib/test/test_forecast.py
+++ b/pvlib/test/test_forecast.py
@@ -76,6 +76,40 @@ def test_process_data(model):
 
 
 @requires_siphon
+def test_bad_kwarg_get_data():
+    amodel = NAM()
+    data = amodel.get_data(_latitude, _longitude, _start, _end,
+                           bad_kwarg=False)
+    assert not data.empty
+
+
+@requires_siphon
+def test_bad_kwarg_get_processed_data():
+    amodel = NAM()
+    data = amodel.get_processed_data(_latitude, _longitude, _start, _end,
+                                     bad_kwarg=False)
+    for variable in _nonnan_variables:
+        try:
+            assert not data[variable].isnull().values.any()
+        except AssertionError:
+            warnings.warn('{}, {}, data contained null values'
+                          .format(model, variable))
+
+
+@requires_siphon
+def test_how_kwarg_get_processed_data():
+    amodel = NAM()
+    data = amodel.get_processed_data(_latitude, _longitude, _start, _end,
+                                     how='clearsky_scaling')
+    for variable in _nonnan_variables:
+        try:
+            assert not data[variable].isnull().values.any()
+        except AssertionError:
+            warnings.warn('{}, {}, data contained null values'
+                          .format(model, variable))
+
+
+@requires_siphon
 def test_vert_level():
     amodel = NAM()
     vert_level = 5000


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

 - [x] Closes  #745 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.

Running locally, I get some warnings. Should I fix these? Also, the tests take 60 seconds on my machine which seems a bit long for this one file. Shall I merge some tests? Or any other ideas for speeding it up?

```
(tonopah) Oscars-MBP:pvlib-python oscar$ pytest pvlib/test/test_forecast.py
============================= test session starts ==============================
platform darwin -- Python 3.7.3, pytest-5.0.0, py-1.8.0, pluggy-0.12.0
rootdir: /Users/oscar/Documents/Code/pvlib-python
plugins: mock-1.10.4
collected 18 items                                                             

pvlib/test/test_forecast.py .....X............                           [100%]

=============================== warnings summary ===============================
/anaconda3/envs/tonopah/lib/python3.7/site-packages/_pytest/mark/structures.py:332
  /anaconda3/envs/tonopah/lib/python3.7/site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

pvlib/test/test_forecast.py::test_process_data[HRRR_ESRL]
  /Users/oscar/Documents/Code/pvlib-python/pvlib/test/test_forecast.py:56: UserWarning: Exception getting data for GSD HRRR CONUS 3km surface, best.
  latitude, longitude, start, end = 32.2 -110.9 2019-07-02 20:21:41.477024-07:00 2019-07-03 20:21:41.477024-07:00
  Error accessing https://thredds.ucar.edu/thredds/ncss/grib/HRRR/CONUS_3km/surface/Best?var=Medium_cloud_cover_UnknownLevelType-224&var=Total_cloud_cover_entire_atmosphere&var=High_cloud_cover_UnknownLevelType-234&var=Downward_short-wave_radiation_flux_surface&var=Temperature_surface&var=Wind_speed_gust_surface&var=Low_cloud_cover_UnknownLevelType-214&time_start=2019-07-02T20%3A21%3A41.477024-07%3A00&time_end=2019-07-03T20%3A21%3A41.477024-07%3A00&longitude=-110.9&latitude=32.2&accept=netcdf
  Server Error (400: Requested time range 2019-07-03T03:21:41.477Z - 2019-07-04T03:21:41.477Z does not intersect actual time range 2019-06-29T00:01:00Z - 2019-07-02T23:36:00Z)
    .format(amodel, _latitude, _longitude, _start, _end, e))

pvlib/test/test_forecast.py::test_process_data[HRRR_ESRL]
  /Users/oscar/Documents/Code/pvlib-python/pvlib/test/test_forecast.py:67: UserWarning: Could not test GSD HRRR CONUS 3km surface, best process_data with how=liujordan because raw_data was empty
    'because raw_data was empty'.format(model, how))

pvlib/test/test_forecast.py::test_process_data[HRRR_ESRL]
  /Users/oscar/Documents/Code/pvlib-python/pvlib/test/test_forecast.py:67: UserWarning: Could not test GSD HRRR CONUS 3km surface, best process_data with how=clearsky_scaling because raw_data was empty
    'because raw_data was empty'.format(model, how))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============== 17 passed, 1 xpassed, 4 warnings in 66.84 seconds ===============
```

 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.