### PR TITLE
use pip for py35-min numpy/pandas

### DIFF
--- a/ci/requirements-py35-min.yml
+++ b/ci/requirements-py35-min.yml
@@ -13,5 +13,5 @@ dependencies:
     - pytz
     - requests
     - pip:
-        - numpy==1.10.1
-        - pandas==0.18.0
+        - numpy==1.10.4
+        - pandas==0.18.1

--- a/ci/requirements-py35-min.yml
+++ b/ci/requirements-py35-min.yml
@@ -4,8 +4,6 @@ channels:
 dependencies:
     - coveralls
     - nose
-    - numpy=1.10.1
-    - pandas=0.18.0
     - pip
     - pytest
     - pytest-cov
@@ -14,3 +12,6 @@ dependencies:
     - python=3.5
     - pytz
     - requests
+    - pip:
+        - numpy==1.10.1
+        - pandas==0.18.0

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -4,9 +4,12 @@ v0.7.0 (MONTH DAY, YEAR)
 ---------------------
 
 This is a major release that drops support for Python 2 and Python 3.4. We
-recommend all users of v0.6.3 upgrade to this release.
+recommend all users of v0.6.3 upgrade to this release after checking API
+compatibility notes.
 
 **Python 2.7 support ended on June 1, 2019**. (:issue:`501`)
+
+**Minimum numpy version is now 1.10.4. Minimum pandas version is now 0.18.1.**
 
 
 Contributors

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ AUTHOR = 'pvlib python Developers'
 MAINTAINER_EMAIL = 'holmgren@email.arizona.edu'
 URL = 'https://github.com/pvlib/pvlib-python'
 
-INSTALL_REQUIRES = ['numpy >= 1.10.1',
-                    'pandas >= 0.18.0',
+INSTALL_REQUIRES = ['numpy >= 1.10.4',
+                    'pandas >= 0.18.1',
                     'pytz',
                     'requests']
 TESTS_REQUIRE = ['nose', 'pytest', 'pytest-cov', 'pytest-mock',


### PR DESCRIPTION
The py35-min builds are failing because the pinned numpy/pandas builds are no longer available on the `defaults` conda channel. I think it's because Anaconda recently cleaned up their package repositories and removed some old package combinations, including the numpy/pandas builds in that test environment. See [here](https://www.anaconda.com/why-we-removed-the-free-channel-in-conda-4-7/) for more info on their cleanup. 

This PR gets the builds working again by switching the numpy/pandas installations from conda to pip.