### PR TITLE
edit DIRINDEX docstring

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1745,10 +1745,10 @@ def dirindex(ghi, ghi_clearsky, dni_clearsky, zenith, times, pressure=101325.,
     Determine DNI from GHI using the DIRINDEX model.
 
     The DIRINDEX model [1] modifies the DIRINT model implemented in
-    ``pvlib.irradiance.dirint`` by taking into account information from a
-    clear sky model. It is recommended that ``ghi_clearsky`` be calculated
-    using the Ineichen clear sky model ``pvlib.clearsky.ineichen`` with
-    ``perez_enhancement=True``.
+    :py:func:``pvlib.irradiance.dirint`` by taking into account information
+    from a clear sky model. It is recommended that ``ghi_clearsky`` be
+    calculated using the Ineichen clear sky model
+    :py:func:``pvlib.clearsky.ineichen`` with ``perez_enhancement=True``.
 
     The pvlib implementation limits the clearness index to 1.
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1742,11 +1742,13 @@ def dirindex(ghi, ghi_clearsky, dni_clearsky, zenith, times, pressure=101325.,
              use_delta_kt_prime=True, temp_dew=None, min_cos_zenith=0.065,
              max_zenith=87):
     """
-    Determine DNI from GHI using the DIRINDEX model, which is a modification of
-    the DIRINT model with information from a clear sky model.
+    Determine DNI from GHI using the DIRINDEX model.
 
-    DIRINDEX [1] improves upon the DIRINT model by taking into account
-    turbidity when used with the Ineichen clear sky model results.
+    The DIRINDEX model [1] modifies the DIRINT model implemented in
+    ``pvlib.irradiance.dirint`` by taking into account information from a
+    clear sky model. It is recommended that ``ghi_clearsky`` be calculated
+    using the Ineichen clear sky model ``pvlib.clearsky.ineichen`` with
+    ``perez_enhancement=True``.
 
     The pvlib implementation limits the clearness index to 1.
 


### PR DESCRIPTION
 - [x] Closes  #738 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):
Adds to `pvlib.irradiance.dirindex` docstring to specify that DIRINDEX should be used with the Ineichen clear sky model with `perez_enhancement = True`
