### PR TITLE
Correting times in modelchain

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -805,7 +805,7 @@ class ModelChain(object):
 
         if {'ghi', 'dhi'} <= icolumns and 'dni' not in icolumns:
             clearsky = self.location.get_clearsky(
-                times, solar_position=self.solar_position)
+                self.times, solar_position=self.solar_position)
             self.weather.loc[:, 'dni'] = pvlib.irradiance.dni(
                 self.weather.loc[:, 'ghi'], self.weather.loc[:, 'dhi'],
                 self.solar_position.zenith,

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -793,6 +793,8 @@ class ModelChain(object):
             self.weather = weather
         if times is not None:
             self.times = times
+        elif isinstance(weather.index, pd.DatetimeIndex):
+            self.times = weather.index
         self.solar_position = self.location.get_solarposition(
             self.times, method=self.solar_position_method)
         icolumns = set(self.weather.columns)


### PR DESCRIPTION
In modelchain, when calculating `complete_irradiance`, the times `self.times` where not set to `weather.index` so the output could output wrong index.
This is my first contribution to the project, please excuse any misunderstanding.