### PR TITLE
Get rid of `re` deprecation warnings

### DIFF
--- a/pvlib/iotools/tmy.py
+++ b/pvlib/iotools/tmy.py
@@ -468,7 +468,7 @@ def _read_tmy2(string, columns, hdr_columns, fname):
                     continue
 
                 # Read the next increment from the marker list
-                increment = int(re.findall('\d+', marker)[0])
+                increment = int(re.findall(r'\d+', marker)[0])
                 next_cursor = cursor + increment
 
                 # Extract the value from the line in the file


### PR DESCRIPTION
It seems it was the only regular expression missing an update (all the others are already written as `r'expression'`).

`DeprecationWarning` is given since Python 3.6. In some future version of Python it will be a `SyntaxError`.