### PR TITLE
handle warnings from temperature model tests

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -324,13 +324,15 @@ class ModelChain(object):
         # TODO: deprecated kwarg temp_model. Remove use of temp_model in v0.8
         temp_model = kwargs.pop('temp_model', None)
         if temp_model is not None:
-            warnings.warn('The temp_model keyword argument is deprecated. Use '
-                          'temperature_model instead', pvlibDeprecationWarning)
             if temperature_model is None:
+                warnings.warn('The temp_model keyword argument is deprecated.'
+                              ' Use temperature_model instead',
+                              pvlibDeprecationWarning)
                 temperature_model = temp_model
             elif temp_model == temperature_model:
                 warnings.warn('Provide only one of temperature_model or '
-                              'temp_model (deprecated).')
+                              'temp_model (deprecated).',
+                              pvlibDeprecationWarning)
             else:
                 raise ValueError(
                     'Conflicting temperature_model {} and temp_model {}. '

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -596,31 +596,34 @@ def test_deprecated_08():
     # without PVSystem.racking_model and PVSystem.module_type
     system = PVSystem(module_parameters=module_parameters)
     # deprecated temp_model kwarg
-    with pytest.warns(pvlibDeprecationWarning) as exc:
+    with pytest.warns(pvlibDeprecationWarning) as recw:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temp_model='sapm',
                    ac_model='snlinverter')
-        assert 'temp_model keyword argument is deprecated' in str(exc.info)
+        w = recw.pop(pvlibDeprecationWarning)
+        assert 'temp_model keyword argument is deprecated' in str(w.message)
     # provide both temp_model and temperature_model kwargs
-    with pytest.warns(pvlibDeprecationWarning) as exc:
+    with pytest.warns(pvlibDeprecationWarning) as recw:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temperature_model='sapm',
                    temp_model='sapm',
                    ac_model='snlinverter')
-        assert 'Provide only one of temperature_model' in str(exc.info)
+        w = recw.pop(pvlibDeprecationWarning)
+        assert 'Provide only one of temperature_model' in str(w.message)
     # conflicting temp_model and temperature_model kwargs
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError) as recw:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temperature_model='pvsyst',
                    temp_model='sapm',
                    ac_model='snlinverter')
-        assert 'Conflicting temperature_model' in str(exc.info)
+        w = recw.pop(pvlibDeprecationWarning)
+        assert 'Conflicting temperature_model' in str(w.message)
 
 
 @requires_scipy

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -596,28 +596,31 @@ def test_deprecated_08():
     # without PVSystem.racking_model and PVSystem.module_type
     system = PVSystem(module_parameters=module_parameters)
     # deprecated temp_model kwarg
-    with pytest.warns(pvlibDeprecationWarning):
+    with pytest.warns(pvlibDeprecationWarning) as exc:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temp_model='sapm',
                    ac_model='snlinverter')
+        assert 'temp_model keyword argument is deprecated' in str(exc.info)
     # provide both temp_model and temperature_model kwargs
-    with pytest.warns(pvlibDeprecationWarning):
+    with pytest.warns(pvlibDeprecationWarning) as exc:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temperature_model='sapm',
                    temp_model='sapm',
                    ac_model='snlinverter')
+        assert 'Provide only one of temperature_model' in str(exc.info)
     # conflicting temp_model and temperature_model kwargs
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temperature_model='pvsyst',
                    temp_model='sapm',
                    ac_model='snlinverter')
+        assert 'Conflicting temperature_model' in str(exc.info)
 
 
 @requires_scipy

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -593,21 +593,21 @@ def test_deprecated_08():
     module_parameters = {'R_sh_ref': 1, 'a_ref': 1, 'I_o_ref': 1,
                          'alpha_sc': 1, 'I_L_ref': 1, 'R_s': 1}
     # do not assign PVSystem.temperature_model_parameters
-    # without PVSystem.racking_model and PVSystem.module_type
+    # leave out PVSystem.racking_model and PVSystem.module_type
     system = PVSystem(module_parameters=module_parameters)
     # deprecated temp_model kwarg
     with pytest.warns(pvlibDeprecationWarning) as recw:
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temp_model='sapm')
-        w = recw.pop(pvlibDeprecationWarning)
+    w = recw.pop(pvlibDeprecationWarning)
     assert 'temp_model keyword argument is deprecated' in str(w.message)
     # provide both temp_model and temperature_model kwargs
     with pytest.warns(pvlibDeprecationWarning) as recw:
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='sapm', temp_model='sapm')
-        w = recw.pop(pvlibDeprecationWarning)
+    w = recw.pop(pvlibDeprecationWarning)
     assert 'Provide only one of temperature_model' in str(w.message)
     # conflicting temp_model and temperature_model kwargs
     with pytest.raises(ValueError) as exc:

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -601,20 +601,20 @@ def test_deprecated_08():
                    spectral_model='no_loss', ac_model='snlinverter',
                    temp_model='sapm')
         w = recw.pop(pvlibDeprecationWarning)
-        assert 'temp_model keyword argument is deprecated' in str(w.message)
+    assert 'temp_model keyword argument is deprecated' in str(w.message)
     # provide both temp_model and temperature_model kwargs
     with pytest.warns(pvlibDeprecationWarning) as recw:
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='sapm', temp_model='sapm')
         w = recw.pop(pvlibDeprecationWarning)
-        assert 'Provide only one of temperature_model' in str(w.message)
+    assert 'Provide only one of temperature_model' in str(w.message)
     # conflicting temp_model and temperature_model kwargs
     with pytest.raises(ValueError) as exc:
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='pvsyst', temp_model='sapm')
-        assert 'Conflicting temperature_model' in str(exc.info)
+    assert 'Conflicting temperature_model' in str(exc.info)
 
 
 @requires_scipy

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -597,33 +597,24 @@ def test_deprecated_08():
     system = PVSystem(module_parameters=module_parameters)
     # deprecated temp_model kwarg
     with pytest.warns(pvlibDeprecationWarning) as recw:
-        ModelChain(system, location,
-                   dc_model='desoto',
-                   aoi_model='no_loss', spectral_model='no_loss',
-                   temp_model='sapm',
-                   ac_model='snlinverter')
+        ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
+                   spectral_model='no_loss', ac_model='snlinverter',
+                   temp_model='sapm')
         w = recw.pop(pvlibDeprecationWarning)
         assert 'temp_model keyword argument is deprecated' in str(w.message)
     # provide both temp_model and temperature_model kwargs
     with pytest.warns(pvlibDeprecationWarning) as recw:
-        ModelChain(system, location,
-                   dc_model='desoto',
-                   aoi_model='no_loss', spectral_model='no_loss',
-                   temperature_model='sapm',
-                   temp_model='sapm',
-                   ac_model='snlinverter')
+        ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
+                   spectral_model='no_loss', ac_model='snlinverter',
+                   temperature_model='sapm', temp_model='sapm')
         w = recw.pop(pvlibDeprecationWarning)
         assert 'Provide only one of temperature_model' in str(w.message)
     # conflicting temp_model and temperature_model kwargs
-    with pytest.raises(ValueError) as recw:
-        ModelChain(system, location,
-                   dc_model='desoto',
-                   aoi_model='no_loss', spectral_model='no_loss',
-                   temperature_model='pvsyst',
-                   temp_model='sapm',
-                   ac_model='snlinverter')
-        w = recw.pop(pvlibDeprecationWarning)
-        assert 'Conflicting temperature_model' in str(w.message)
+    with pytest.raises(ValueError) as exc:
+        ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
+                   spectral_model='no_loss', ac_model='snlinverter',
+                   temperature_model='pvsyst', temp_model='sapm')
+        assert 'Conflicting temperature_model' in str(exc.info)
 
 
 @requires_scipy

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -614,7 +614,7 @@ def test_deprecated_08():
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='pvsyst', temp_model='sapm')
-    assert 'Conflicting temperature_model' in str(exc.info)
+    assert 'Conflicting temperature_model' in str(exc.value)
 
 
 @requires_scipy

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -593,14 +593,16 @@ def test_deprecated_08():
     module_parameters = {'R_sh_ref': 1, 'a_ref': 1, 'I_o_ref': 1,
                          'alpha_sc': 1, 'I_L_ref': 1, 'R_s': 1}
     # do not assign PVSystem.temperature_model_parameters
+    # without PVSystem.racking_model and PVSystem.module_type
     system = PVSystem(module_parameters=module_parameters)
+    # deprecated temp_model kwarg
     with pytest.warns(pvlibDeprecationWarning):
         ModelChain(system, location,
                    dc_model='desoto',
                    aoi_model='no_loss', spectral_model='no_loss',
                    temp_model='sapm',
                    ac_model='snlinverter')
-    system = PVSystem(module_parameters=module_parameters)
+    # provide both temp_model and temperature_model kwargs
     with pytest.warns(pvlibDeprecationWarning):
         ModelChain(system, location,
                    dc_model='desoto',
@@ -608,7 +610,7 @@ def test_deprecated_08():
                    temperature_model='sapm',
                    temp_model='sapm',
                    ac_model='snlinverter')
-    system = PVSystem(module_parameters=module_parameters)
+    # conflicting temp_model and temperature_model kwargs
     with pytest.raises(ValueError):
         ModelChain(system, location,
                    dc_model='desoto',

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -470,10 +470,10 @@ def test_infer_aoi_model(location, system_no_aoi, aoi_model):
 
 
 def test_infer_aoi_model_invalid(location, system_no_aoi):
-    with pytest.raises(ValueError) as excinfo:
+    exc_text = 'could not infer AOI model'
+    with pytest.raises(ValueError, match=exc_text):
         ModelChain(system_no_aoi, location, orientation_strategy='None',
                    spectral_model='no_loss')
-    assert 'could not infer AOI model' in str(excinfo.value)
 
 
 def constant_spectral_loss(mc):
@@ -596,25 +596,23 @@ def test_deprecated_08():
     # leave out PVSystem.racking_model and PVSystem.module_type
     system = PVSystem(module_parameters=module_parameters)
     # deprecated temp_model kwarg
-    with pytest.warns(pvlibDeprecationWarning) as recw:
+    warn_txt = 'temp_model keyword argument is deprecated'
+    with pytest.warns(pvlibDeprecationWarning, match=warn_txt):
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temp_model='sapm')
-    w = recw.pop(pvlibDeprecationWarning)
-    assert 'temp_model keyword argument is deprecated' in str(w.message)
     # provide both temp_model and temperature_model kwargs
-    with pytest.warns(pvlibDeprecationWarning) as recw:
+    warn_txt = 'Provide only one of temperature_model'
+    with pytest.warns(pvlibDeprecationWarning, match=warn_txt):
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='sapm', temp_model='sapm')
-    w = recw.pop(pvlibDeprecationWarning)
-    assert 'Provide only one of temperature_model' in str(w.message)
     # conflicting temp_model and temperature_model kwargs
-    with pytest.raises(ValueError) as exc:
+    exc_text = 'Conflicting temperature_model'
+    with pytest.raises(ValueError, match=exc_text):
         ModelChain(system, location, dc_model='desoto', aoi_model='no_loss',
                    spectral_model='no_loss', ac_model='snlinverter',
                    temperature_model='pvsyst', temp_model='sapm')
-    assert 'Conflicting temperature_model' in str(exc.value)
 
 
 @requires_scipy

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -428,11 +428,11 @@ def test__infer_temperature_model_params():
 
 
 def test__infer_temperature_model_params_deprec_warning():
-    with pytest.raises(pvlibDeprecationWarning):
-        system = pvsystem.PVSystem(module_parameters={},
-                                   racking_model='not_a_rack_model',
-                                   module_type='glass_polymer')
-        assert {} == system._infer_temperature_model_params()
+    with pytest.raises(pvlibDeprecationWarning) as exc:
+        pvsystem.PVSystem(module_parameters={},
+                          racking_model='not_a_rack_model',
+                          module_type='glass_polymer')
+        assert 'Reverting to deprecated default' in str(exc.value)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -428,7 +428,7 @@ def test__infer_temperature_model_params():
 
 
 def test__infer_temperature_model_params_deprec_warning():
-    with pytest.raises(pvlibDeprecationWarning) as recw:
+    with pytest.warns(pvlibDeprecationWarning) as recw:
         pvsystem.PVSystem(module_parameters={},
                           racking_model='not_a_rack_model',
                           module_type='glass_polymer')

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -432,7 +432,7 @@ def test__infer_temperature_model_params_deprec_warning():
         pvsystem.PVSystem(module_parameters={},
                           racking_model='not_a_rack_model',
                           module_type='glass_polymer')
-        w = recw.pop(pvlibDeprecationWarning)
+    w = recw.pop(pvlibDeprecationWarning)
     assert 'Reverting to deprecated default' in str(w.message)
 
 

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -428,12 +428,11 @@ def test__infer_temperature_model_params():
 
 
 def test__infer_temperature_model_params_deprec_warning():
-    with pytest.warns(pvlibDeprecationWarning) as recw:
+    warn_txt = "Reverting to deprecated default"
+    with pytest.warns(pvlibDeprecationWarning, match=warn_txt):
         pvsystem.PVSystem(module_parameters={},
                           racking_model='not_a_rack_model',
                           module_type='glass_polymer')
-    w = recw.pop(pvlibDeprecationWarning)
-    assert 'Reverting to deprecated default' in str(w.message)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -433,7 +433,7 @@ def test__infer_temperature_model_params_deprec_warning():
                           racking_model='not_a_rack_model',
                           module_type='glass_polymer')
         w = recw.pop(pvlibDeprecationWarning)
-        assert 'Reverting to deprecated default' in str(w.message)
+    assert 'Reverting to deprecated default' in str(w.message)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -428,11 +428,12 @@ def test__infer_temperature_model_params():
 
 
 def test__infer_temperature_model_params_deprec_warning():
-    with pytest.raises(pvlibDeprecationWarning) as exc:
+    with pytest.raises(pvlibDeprecationWarning) as recw:
         pvsystem.PVSystem(module_parameters={},
                           racking_model='not_a_rack_model',
                           module_type='glass_polymer')
-        assert 'Reverting to deprecated default' in str(exc.value)
+        w = recw.pop(pvlibDeprecationWarning)
+        assert 'Reverting to deprecated default' in str(w.message)
 
 
 def test_calcparams_desoto(cec_module_params):

--- a/pvlib/test/test_pvsystem.py
+++ b/pvlib/test/test_pvsystem.py
@@ -419,16 +419,20 @@ def test__infer_temperature_model_params():
     expected = temperature.TEMPERATURE_MODEL_PARAMETERS[
         'sapm']['open_rack_glass_polymer']
     assert expected == system._infer_temperature_model_params()
-    expected = temperature.TEMPERATURE_MODEL_PARAMETERS[
-        'pvsyst']['freestanding']
     system = pvsystem.PVSystem(module_parameters={},
                                racking_model='freestanding',
                                module_type='glass_polymer')
+    expected = temperature.TEMPERATURE_MODEL_PARAMETERS[
+        'pvsyst']['freestanding']
     assert expected == system._infer_temperature_model_params()
-    system = pvsystem.PVSystem(module_parameters={},
-                               racking_model='not_a_rack_model',
-                               module_type='glass_polymer')
-    assert {} == system._infer_temperature_model_params()
+
+
+def test__infer_temperature_model_params_deprec_warning():
+    with pytest.raises(pvlibDeprecationWarning):
+        system = pvsystem.PVSystem(module_parameters={},
+                                   racking_model='not_a_rack_model',
+                                   module_type='glass_polymer')
+        assert {} == system._infer_temperature_model_params()
 
 
 def test_calcparams_desoto(cec_module_params):


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes  #795 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Move one warning to avoid raising two warnings for the same cause