### PR TITLE
replace Pandas item() implementation with numpy's using .values

### DIFF
--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -212,7 +212,7 @@ def _scalar_out(input):
     else:  #
         # works if it's a 1 length array and
         # will throw a ValueError otherwise
-        output = input.values.item()
+        output = np.asarray(input).item()
 
     return output
 

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -212,7 +212,7 @@ def _scalar_out(input):
     else:  #
         # works if it's a 1 length array and
         # will throw a ValueError otherwise
-        output = input.item()
+        output = input.values.item()
 
     return output
 


### PR DESCRIPTION
pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [X] Closes  #794 
 - [X] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [X] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
* More tests passed, less warnings (probably from removing the deprecated) but one more test skipped.

 - [X] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
* I'll do this once this method is review/approved.
 - [ ] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

Pandas is deprecating Series.item() and warns against it for 0.25+. I've replaced the item() call with the values.item() which is a numpy method that's not going anywhere. This is exactly how Series.item() works and shouldn't change how _scalar_out() works.

Edit: [Here's a link to the pandas source code for .item() for reference](https://github.com/pandas-dev/pandas/blob/v0.25.2/pandas/core/base.py#L724-L740)
