### PR TITLE
mark xfail of test_get_psm3

### DIFF
--- a/pvlib/test/test_psm3.py
+++ b/pvlib/test/test_psm3.py
@@ -24,7 +24,7 @@ HEADER_FIELDS = [
 PVLIB_EMAIL = 'pvlib-admin@googlegroups.com'
 DEMO_KEY = 'DEMO_KEY'
 
-
+@pytest.mark.xfail(strict=True)
 @needs_pandas_0_22
 def test_get_psm3():
     """test get_psm3"""

--- a/pvlib/test/test_psm3.py
+++ b/pvlib/test/test_psm3.py
@@ -24,6 +24,7 @@ HEADER_FIELDS = [
 PVLIB_EMAIL = 'pvlib-admin@googlegroups.com'
 DEMO_KEY = 'DEMO_KEY'
 
+
 @pytest.mark.xfail(strict=True)
 @needs_pandas_0_22
 def test_get_psm3():


### PR DESCRIPTION
 - [X] Closes  #802 
 - [X] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [X] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [X] Updates entries to `docs/sphinx/source/api.rst` for API changes.
* unnecessary
 - [X] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [X] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [X] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.

This PR temporarily addresses NREL's change to the data retrieved by pvlib.iotools.psm3() that causes test_get_psm3() to fail. The test is marked with xfail(strict=True) to pass CI tests. 