### PR TITLE
add macOS 10.14 Mojave to Azure Pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,6 +134,43 @@ jobs:
       testRunTitle: 'Windows $(python.version)'
 
 
+- job: 'Test_bare_macOS_Mojave'
+
+  pool:
+    vmImage: 'macOS-10.14'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - script: |
+      pip install pytest pytest-cov pytest-mock pytest-timeout pytest-azurepipelines
+      pip install -e .
+      pytest pvlib/test --junitxml=junit/test-results.xml --cov=pvlib --cov-report=xml --cov-report=html
+    displayName: 'Test with pytest'
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+
+
 - job: 'Publish'
   dependsOn: 'Test_conda_linux'
   pool:


### PR DESCRIPTION
 - [X] Closes  #719
 - [X] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [ ] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [ ] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [ ] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.

Adds Azure test functionality for the macOS 10.14 Mojave system. This implementation was simple (for now) and replicates the standard Linux job.

I wanted to ask you @wholmgren if we should be mindful of increasing the time duration of Azure Pipelines with another three test cycles. This may lengthen each iteration a contributor must wait after a change so I think it's worth considering.

If it is a concern, would it a better use of time be to only test the "bare_linux" version and not the 'Test_conda_linux'? I would argue that the "bare_linux" is the least stable from an infrastructure POV. I'd also guess, and I could be completely wrong, that most people that choose to run on Linux aren't going the Anaconda route. 

If that's not the case and we want to be sure about Anaconda installs would we then add a 'Test_conda_macOS' job? If so, we'd be increasing the CI time by 66%. =S

