### PR TITLE
Don't expose model parameter dictionaries to users

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -77,7 +77,6 @@ API Changes
          - `pvsystem.physicaliam` is `iam.physical`
          - `pvsystem.ashraeiam` is `iam.ashrae`
          - `pvsystem.sapm_aoi_loss` is `iam.sapm`
-      - Created dict `iam._IAM_MODEL_PARAMS` to aid in identifying IAM models
    * Changes to `PVSystem` class
       - IAM models are provided by `PVSystem.get_iam` with kwarg `iam_model`.
       - Methods `PVSystem.ashraeiam`, `PVSystem.physicaliam` and
@@ -94,7 +93,8 @@ API Changes
   The `weather` argument of the above methods is now the first, required
   positional argument and the `times` argument is kept as the second keyword
   argument for capability during the deprecation period.
-* Parameter `pvsystem.DC_MODEL_PARAMS` is renamed to `pvsystem._DC_MODEL_PARAMS`
+* Parameter `pvsystem.DC_MODEL_PARAMS` is renamed to `pvsystem._DC_MODEL_PARAMS`.
+  Users should not rely on this dictionary's existence or structure.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -77,7 +77,7 @@ API Changes
          - `pvsystem.physicaliam` is `iam.physical`
          - `pvsystem.ashraeiam` is `iam.ashrae`
          - `pvsystem.sapm_aoi_loss` is `iam.sapm`
-      - Created dict `iam.IAM_MODEL_PARAMS` to aid in identifying IAM models
+      - Created dict `iam._IAM_MODEL_PARAMS` to aid in identifying IAM models
    * Changes to `PVSystem` class
       - IAM models are provided by `PVSystem.get_iam` with kwarg `iam_model`.
       - Methods `PVSystem.ashraeiam`, `PVSystem.physicaliam` and
@@ -94,6 +94,7 @@ API Changes
   The `weather` argument of the above methods is now the first, required
   positional argument and the `times` argument is kept as the second keyword
   argument for capability during the deprecation period.
+* Parameter `pvsystem.DC_MODEL_PARAMS` is renamed to `pvsystem._DC_MODEL_PARAMS`
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -15,7 +15,7 @@ from pvlib.tools import cosd, sind, tand, asind
 
 # a dict of required parameter names for each IAM model
 # keys are the function names for the IAM models
-IAM_MODEL_PARAMS = {
+_IAM_MODEL_PARAMS = {
     'ashrae': set(['b']),
     'physical': set(['n', 'K', 'L']),
     'martin_ruiz': set(['a_r']),

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -13,7 +13,7 @@ from pvlib import (atmosphere, clearsky, pvsystem, solarposition, temperature,
                    tools)
 from pvlib.tracking import SingleAxisTracker
 import pvlib.irradiance  # avoid name conflict with full import
-from pvlib.pvsystem import DC_MODEL_PARAMS
+from pvlib.pvsystem import _DC_MODEL_PARAMS
 from pvlib._deprecation import pvlibDeprecationWarning
 
 
@@ -395,9 +395,9 @@ class ModelChain(object):
         # Set model and validate parameters
         if isinstance(model, str):
             model = model.lower()
-            if model in DC_MODEL_PARAMS.keys():
+            if model in _DC_MODEL_PARAMS.keys():
                 # validate module parameters
-                missing_params = DC_MODEL_PARAMS[model] - \
+                missing_params = _DC_MODEL_PARAMS[model] - \
                                  set(self.system.module_parameters.keys())
                 if missing_params:  # some parameters are not in module.keys()
                     raise ValueError(model + ' selected for the DC model but '

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -21,7 +21,7 @@ from pvlib._deprecation import pvlibDeprecationWarning
 
 
 # a dict of required parameter names for each DC power model
-DC_MODEL_PARAMS = {
+_DC_MODEL_PARAMS = {
     'sapm': set([
         'A0', 'A1', 'A2', 'A3', 'A4', 'B0', 'B1', 'B2', 'B3',
         'B4', 'B5', 'C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6',
@@ -345,7 +345,7 @@ class PVSystem(object):
         """
         model = iam_model.lower()
         if model in ['ashrae', 'physical', 'martin_ruiz']:
-            param_names = iam.IAM_MODEL_PARAMS[model]
+            param_names = iam._IAM_MODEL_PARAMS[model]
             kwargs = _build_kwargs(param_names, self.module_parameters)
             func = getattr(iam, model)
             return func(aoi, **kwargs)

--- a/pvlib/test/test_modelchain.py
+++ b/pvlib/test/test_modelchain.py
@@ -461,7 +461,7 @@ def test_aoi_model_user_func(system, location, weather, mocker):
     'sapm', 'ashrae', 'physical', 'martin_ruiz'
 ])
 def test_infer_aoi_model(location, system_no_aoi, aoi_model):
-    for k in iam.IAM_MODEL_PARAMS[aoi_model]:
+    for k in iam._IAM_MODEL_PARAMS[aoi_model]:
         system_no_aoi.module_parameters.update({k: 1.0})
     mc = ModelChain(system_no_aoi, location,
                     orientation_strategy='None',


### PR DESCRIPTION
 - [x] Closes  #789 
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
