### PR TITLE
fix handful of documentation warnings

### DIFF
--- a/docs/sphinx/source/introexamples.rst
+++ b/docs/sphinx/source/introexamples.rst
@@ -164,7 +164,7 @@ by examining the parameters defined for the module.
                         orientation_strategy='south_at_latitude_tilt')
         # model results (ac, dc) and intermediates (aoi, temps, etc.)
         # assigned as mc object attributes
-        mc.run_model(times=times, weather=weather)
+        mc.run_model(weather)
         annual_energy = mc.ac.sum()
         energies[name] = annual_energy
 

--- a/docs/sphinx/source/modelchain.rst
+++ b/docs/sphinx/source/modelchain.rst
@@ -81,7 +81,7 @@ Next, we run a model with some simple weather data.
                            columns=['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed'],
                            index=[pd.Timestamp('20170401 1200', tz='US/Arizona')])
 
-    mc.run_model(times=weather.index, weather=weather);
+    mc.run_model(weather);
 
 ModelChain stores the modeling results on a series of attributes. A few
 examples are shown below.
@@ -157,7 +157,7 @@ model, AC model, AOI loss model, and spectral loss model.
 
 .. ipython:: python
 
-    mc.run_model(times=weather.index, weather=weather);
+    mc.run_model(weather);
     mc.ac
 
 Alternatively, we could have specified single diode or PVWatts related
@@ -180,7 +180,7 @@ information to determine which of those models to choose.
 
 .. ipython:: python
 
-    mc.run_model(times=weather.index, weather=weather);
+    mc.run_model(weather);
     mc.ac
 
 User-supplied keyword arguments override ModelChain’s inspection
@@ -198,7 +198,7 @@ functions for a PVSystem that contains SAPM-specific parameters.
 
 .. ipython:: python
 
-    mc.run_model(times=weather.index, weather=weather);
+    mc.run_model(weather);
     mc.ac
 
 Of course, these choices can also lead to failure when executing
@@ -461,5 +461,5 @@ The end result is that ModelChain.run_model works as expected!
 
 .. ipython:: python
 
-    mc.run_model(times=weather.index, weather=weather);
+    mc.run_model(weather);
     mc.dc

--- a/docs/sphinx/source/timetimezones.rst
+++ b/docs/sphinx/source/timetimezones.rst
@@ -328,7 +328,7 @@ below? The solar position calculator will assume UTC time.
 
 .. ipython:: python
 
-    index = pd.DatetimeIndex(start='1997-01-01 01:00', freq='1h', periods=24)
+    index = pd.date_range(start='1997-01-01 01:00', freq='1h', periods=24)
     index
 
     solar_position_notz = pvlib.solarposition.get_solarposition(index,

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -63,8 +63,8 @@ API Changes
       - If `PVSystem.temperature_model_parameters` is not specified, `ModelChain`
         defaults to old behavior, using the SAPM temperature model with parameter
         set `open_rack_glass_glass`. This behavior is deprecated, and will be
-         removed in v0.8. In v0.8 `PVSystem.temperature_model_parameters` will
-          be required for `ModelChain`.
+        removed in v0.8. In v0.8 `PVSystem.temperature_model_parameters` will
+        be required for `ModelChain`.
       - Implemented `pvsyst` as an option for `ModelChain.temperature_model`.
       - `modelchain.basic_chain` has a new required argument
         `temperature_model_parameters`.
@@ -72,7 +72,7 @@ API Changes
 * Changes related to IAM (AOI loss) functions (:issue:`680`):
    * Changes to functions
       - Moved functions from `pvsystem.py` to `iam.py`. `pvsystem` IAM
-       functions are deprecated and will be removed in v0.8.
+        functions are deprecated and will be removed in v0.8.
       - Functions are renamed to a consistent pattern:
          - `pvsystem.physicaliam` is `iam.physical`
          - `pvsystem.ashraeiam` is `iam.ashrae`
@@ -80,7 +80,7 @@ API Changes
    * Changes to `PVSystem` class
       - IAM models are provided by `PVSystem.get_iam` with kwarg `iam_model`.
       - Methods `PVSystem.ashraeiam`, `PVSystem.physicaliam` and
-       `PVSystem.sapm_aoi_loss` are deprecated and will be removed in v0.8.
+        `PVSystem.sapm_aoi_loss` are deprecated and will be removed in v0.8.
 
 * Calling :py:func:`pvlib.pvsystem.retrieve_sam` with no parameters will raise
   an exception instead of displaying a dialog.

--- a/pvlib/bifacial.py
+++ b/pvlib/bifacial.py
@@ -18,7 +18,7 @@ def pvfactors_timeseries(
     """
     Calculate front and back surface plane-of-array irradiance on
     a fixed tilt or single-axis tracker PV array configuration, and using
-    the open-source "pvfactors" package.
+    the open-source "pvfactors" package [1]_.
     Please refer to pvfactors online documentation for more details:
     https://sunpower.github.io/pvfactors/
 

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -398,12 +398,12 @@ def interp(aoi, theta_ref, iam_ref, method='linear', normalize=True):
 
     method : str, default 'linear'
         Specifies the interpolation method.
-        Useful options are: 'linear', 'quadratic','cubic'.
+        Useful options are: 'linear', 'quadratic', 'cubic'.
         See scipy.interpolate.interp1d for more options.
 
     normalize : boolean, default True
         When true, the interpolated values are divided by the interpolated
-        value at zero degrees.  This ensures that ``iam``=1.0 at normal
+        value at zero degrees.  This ensures that ``iam=1.0`` at normal
         incidence.
 
     Returns

--- a/pvlib/iotools/midc.py
+++ b/pvlib/iotools/midc.py
@@ -178,9 +178,7 @@ def read_midc(filename, variable_map={}, raw_data=False):
              passing the dictionary below will rename the column to 'ghi' in
              the returned Dataframe.
 
-             {
-                 'Global Horizontal [W/m^2]': ghi,
-             }
+             {'Global Horizontal [W/m^2]': 'ghi'}
 
     See the MIDC_VARIABLE_MAP for collection of mappings by site.
     For a full list of pvlib variable names see the `Variable Style Rules

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1176,7 +1176,7 @@ def clearness_index(ghi, solar_zenith, extra_radiation, min_cos_zenith=0.065,
     Calculate the clearness index.
 
     The clearness index is the ratio of global to extraterrestrial
-    irradiance on a horizontal plane.
+    irradiance on a horizontal plane [1]_.
 
     Parameters
     ----------
@@ -1226,7 +1226,7 @@ def clearness_index(ghi, solar_zenith, extra_radiation, min_cos_zenith=0.065,
 def clearness_index_zenith_independent(clearness_index, airmass,
                                        max_clearness_index=2.0):
     """
-    Calculate the zenith angle independent clearness index.
+    Calculate the zenith angle independent clearness index [1]_.
 
     Parameters
     ----------
@@ -1764,7 +1764,8 @@ def gti_dirint(poa_global, aoi, solar_zenith, solar_azimuth, times,
                model='perez', model_perez='allsitescomposite1990',
                calculate_gt_90=True, max_iterations=30):
     """
-    Determine GHI, DNI, DHI from POA global using the GTI DIRINT model.
+    Determine GHI, DNI, DHI from POA global using the GTI DIRINT model
+    [1]_.
 
     .. warning::
 


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
~Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.~
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

documentation emitted a bunch of warnings:

<details>

```
reading sources... [ 96%] introexamples

>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/introexamples.rst at block ending on line 182
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------
reading sources... [ 97%] modelchain

>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/modelchain.rst at block ending on line 85
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------


>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/modelchain.rst at block ending on line 162
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------


>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/modelchain.rst at block ending on line 185
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------


>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/modelchain.rst at block ending on line 203
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------


>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/modelchain.rst at block ending on line 465
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/git_repos/pvlib-python/pvlib/modelchain.py:934: pvlibDeprecationWarning: times keyword argument is deprecated and will be removed in 0.8. The index of the weather DataFrame is used for times.
  'is used for times.', pvlibDeprecationWarning)
<<<-------------------------------------------------------------------------
reading sources... [ 99%] timetimezones

>>>-------------------------------------------------------------------------
Warning in /Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/timetimezones.rst at block ending on line 347
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
/Users/holmgren/miniconda3/envs/pvlibdocs/bin/sphinx-build:1: FutureWarning: Creating a DatetimeIndex by passing range endpoints is deprecated.  Use `pandas.date_range` instead.
  #!/Users/holmgren/miniconda3/envs/pvlibdocs/bin/python
<<<-------------------------------------------------------------------------
reading sources... [100%] whatsnew
WARNING: failed to import tmy.readtmy2
WARNING: failed to import tmy.readtmy3
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst.rst:391: WARNING: autosummary: stub file not found 'tmy.readtmy2'. Check your autosummary_generate setting.
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst.rst:391: WARNING: autosummary: stub file not found 'tmy.readtmy3'. Check your autosummary_generate setting.
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:60:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:110:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:263:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "2".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "2".
/Users/holmgren/git_repos/pvlib-python/pvlib/atmosphere.py:docstring of pvlib.atmosphere.gueymard94_pw:43: WARNING: Footnote [1] is not referenced.
/Users/holmgren/git_repos/pvlib-python/pvlib/bifacial.py:docstring of pvlib.bifacial.pvfactors_timeseries:64: WARNING: Footnote [1] is not referenced.
/Users/holmgren/git_repos/pvlib-python/pvlib/iam.py:docstring of pvlib.iam.interp:15: WARNING: Inline literal start-string without end-string.
/Users/holmgren/git_repos/pvlib-python/pvlib/iotools/midc.py:docstring of pvlib.iotools.read_midc:27: WARNING: Definition list ends without a blank line; unexpected unindent.
/Users/holmgren/git_repos/pvlib-python/pvlib/irradiance.py:docstring of pvlib.irradiance.clearness_index:25: WARNING: Footnote [1] is not referenced.
/Users/holmgren/git_repos/pvlib-python/pvlib/irradiance.py:docstring of pvlib.irradiance.clearness_index_zenith_independent:17: WARNING: Footnote [1] is not referenced.
/Users/holmgren/git_repos/pvlib-python/pvlib/irradiance.py:docstring of pvlib.irradiance.gti_dirint:69: WARNING: Footnote [1] is not referenced.
source/whatsnew/v0.7.0.rst:66: WARNING: Unexpected indentation.
source/whatsnew/v0.7.0.rst:75: WARNING: Bullet list ends without a blank line; unexpected unindent.
source/whatsnew/v0.7.0.rst:76: WARNING: Block quote ends without a blank line; unexpected unindent.
source/whatsnew/v0.7.0.rst:83: WARNING: Bullet list ends without a blank line; unexpected unindent.
```

</details>

now emits:

<details>

```
reading sources... [100%] whatsnew
WARNING: failed to import tmy.readtmy2
WARNING: failed to import tmy.readtmy3
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst.rst:391: WARNING: autosummary: stub file not found 'tmy.readtmy2'. Check your autosummary_generate setting.
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst.rst:391: WARNING: autosummary: stub file not found 'tmy.readtmy3'. Check your autosummary_generate setting.
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:60:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:110:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:187:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:198:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:263:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:299:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "2".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:371:<autosummary>:1: WARNING: Unknown target name: "2".
/Users/holmgren/git_repos/pvlib-python/docs/sphinx/source/api.rst:568:<autosummary>:1: WARNING: Unknown target name: "1".
/Users/holmgren/git_repos/pvlib-python/pvlib/atmosphere.py:docstring of pvlib.atmosphere.gueymard94_pw:43: WARNING: Footnote [1] is not referenced.
```

</details>


Better, not perfect. I think it's safe to ignore the warnings about the deprecated `pvlib.tmy` module. I don't know what to do about the warnings like `api.rst:60:<autosummary>:1: WARNING: Unknown target name: "1".` Finally, the `gueymard94_pw:43: WARNING: Footnote [1] is not referenced.` warning has me wondering if that reference is actually needed.