### PR TITLE
Location object creation from epw metadata

### DIFF
--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -376,6 +376,7 @@ in some files.
    :toctree: generated/
 
    location.Location.from_tmy
+   location.Location.from_epw
 
 
 TMY

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -123,6 +123,8 @@ Enhancements
 * Add `timeout` to :py:func:`pvlib.iotools.get_psm3`.
 * Created one new incidence angle modifier (IAM) function for diffuse irradiance:
   :py:func:`pvlib.iam.martin_ruiz_diffuse`. (:issue:`751`)
+* Add :py:meth:`~pvlib.location.Location.from_epw`, a method to create a Location
+  object from epw metadata, typically coming from `pvlib.iotools.epw.read_epw`.
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -130,16 +130,16 @@ class Location(object):
         return new_object
 
     @classmethod
-    def from_epw(cls, epw_metadata, epw_data=None, **kwargs):
+    def from_epw(cls, metadata, data=None, **kwargs):
         """
         Create a Location object based on a metadata
         dictionary from epw data readers.
 
         Parameters
         ----------
-        epw_metadata : dict
+        metadata : dict
             Returned from epw.read_epw
-        epw_data : None or DataFrame, default None
+        data : None or DataFrame, default None
             Optionally attach the epw data to this object.
 
         Returns
@@ -148,19 +148,19 @@ class Location(object):
         called this method from).
         """
 
-        latitude = epw_metadata['latitude']
-        longitude = epw_metadata['longitude']
+        latitude = metadata['latitude']
+        longitude = metadata['longitude']
 
-        name = epw_metadata['city']
+        name = metadata['city']
 
-        tz = epw_metadata['TZ']
-        altitude = epw_metadata['altitude']
+        tz = metadata['TZ']
+        altitude = metadata['altitude']
 
         new_object = cls(latitude, longitude, tz=tz, altitude=altitude,
                          name=name, **kwargs)
 
-        if epw_data is not None:
-            new_object.weather = epw_data
+        if data is not None:
+            new_object.weather = data
 
         return new_object
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -125,6 +125,42 @@ class Location(object):
         # not sure if this should be assigned regardless of input.
         if tmy_data is not None:
             new_object.tmy_data = tmy_data
+            new_object.weather = tmy_data
+
+        return new_object
+
+    @classmethod
+    def from_epw(cls, epw_metadata, epw_data=None, **kwargs):
+        """
+        Create a Location object based on a metadata
+        dictionary from epw data readers.
+
+        Parameters
+        ----------
+        epw_metadata : dict
+            Returned from epw.read_epw
+        epw_data : None or DataFrame, default None
+            Optionally attach the epw data to this object.
+
+        Returns
+        -------
+        Location object (or the child class of Location that you
+        called this method from).
+        """
+
+        latitude = epw_metadata['latitude']
+        longitude = epw_metadata['longitude']
+
+        name = epw_metadata['city']
+
+        tz = epw_metadata['TZ']
+        altitude = epw_metadata['altitude']
+
+        new_object = cls(latitude, longitude, tz=tz, altitude=altitude,
+                         name=name, **kwargs)
+
+        if epw_data is not None:
+            new_object.weather = epw_data
 
         return new_object
 

--- a/pvlib/test/test_location.py
+++ b/pvlib/test/test_location.py
@@ -218,7 +218,7 @@ def test_from_tmy_3():
     assert loc.name is not None
     assert loc.altitude != 0
     assert loc.tz != 'UTC'
-    assert_frame_equal(loc.tmy_data, data)
+    assert_frame_equal(loc.weather, data)
 
 
 def test_from_tmy_2():
@@ -229,7 +229,18 @@ def test_from_tmy_2():
     assert loc.name is not None
     assert loc.altitude != 0
     assert loc.tz != 'UTC'
-    assert_frame_equal(loc.tmy_data, data)
+    assert_frame_equal(loc.weather, data)
+
+
+def test_from_epw():
+    from test_epw import epw_testfile
+    from pvlib.iotools import read_epw
+    data, meta = read_epw(epw_testfile)
+    loc = Location.from_epw(meta, data)
+    assert loc.name is not None
+    assert loc.altitude != 0
+    assert loc.tz != 'UTC'
+    assert_frame_equal(loc.weather, data)
 
 
 def test_get_solarposition(expected_solpos, golden_mst):


### PR DESCRIPTION

 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [x] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - [x] Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes LGTM and SticklerCI checks.
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.

Brief description of the problem and proposed solution (if not already fully described in the issue linked to above):

My PR is for allowing creation of a Location object from the metadata coming from epw weather file. My first thought was to create a new `from_epw()` which works as `from_tmy()`, but I rethought it and considered the option of changing `from_tmy()` in `from_tmy_or_epw()` for allowing it to accept epw files as well. I personally think that the second option is better since tmy files can be formatted in epw format, and thus it would simplify life for users.
I've let both options in my draft PR, give me your opinion on what is best according to you.