### PR TITLE
Formatting of ModelChain.diode_params in pandas.DataFrame

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -19,6 +19,8 @@ API Breaking Changes
   of W/m2 rather than suns.
 * Calling :py:func:`pvlib.pvsystem.retrieve_sam` with no parameters will raise
   an exception instead of displaying a dialog.
+* The `modelchain.ModelChain.diode_params` attribute is now formatted in
+  a pandas.DataFrame with `DatetimeIndex`, rather than in a tuple.
 
 API Changes with Deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -8,6 +8,7 @@ the time to read the source code for the module.
 
 from functools import partial
 import warnings
+import pandas as pd
 
 from pvlib import (atmosphere, clearsky, pvsystem, solarposition, temperature,
                    tools)
@@ -453,9 +454,11 @@ class ModelChain(object):
             calcparams_model_function(self.effective_irradiance,
                                       self.cell_temperature))
 
-        self.diode_params = (photocurrent, saturation_current,
-                             resistance_series,
-                             resistance_shunt, nNsVth)
+        self.diode_params = pd.DataFrame({'I_L': photocurrent,
+                                          'I_o': saturation_current,
+                                          'R_s': resistance_series,
+                                          'R_sh': resistance_shunt,
+                                          'nNsVth': nNsVth})
 
         self.dc = self.system.singlediode(
             photocurrent, saturation_current, resistance_series,
@@ -924,9 +927,11 @@ class ModelChain(object):
         -------
         self
 
-        Assigns attributes: solar_position, airmass, irradiance,
-        total_irrad, effective_irradiance, weather, cell_temperature, aoi,
-        aoi_modifier, spectral_modifier, dc, ac, losses.
+        Assigns attributes: ``solar_position``, ``airmass``, ``irradiance``,
+        ``total_irrad``, ``effective_irradiance``, ``weather``,
+        ``cell_temperature``, ``aoi``, ``aoi_modifier``, ``spectral_modifier``,
+        ``dc``, ``ac``, ``losses``,
+        ``diode_params`` (if dc_model is a single diode model)
         """
         if times is not None:
             warnings.warn('times keyword argument is deprecated and will be '


### PR DESCRIPTION

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR is for changing the type of the attribute ModelChain object `diode_params` from tuple to pandas.DataFrame. It would standardize the attributes of ModelChain, since all array-like attributes are either pandas.DataFrame or pandas.Series, except diode_params which is a tuple. Moreover it simplifies the use of the diode_params attribute for using it in other simulations (like simuling the direct coupling with an electrical load).
