### PR TITLE
update whatsnew.rst, add contributors, v0.7.0 release date, address #809

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -1,7 +1,7 @@
 ﻿.. _whatsnew_0700:
 
 v0.7.0 (December 18, 2019)
-------------------------
+--------------------------
 
 This is a major release that drops support for Python 2 and Python 3.4. We
 recommend all users of v0.6.3 upgrade to this release after checking API

--- a/docs/sphinx/source/whatsnew/v0.7.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.0.rst
@@ -1,6 +1,6 @@
 ﻿.. _whatsnew_0700:
 
-v0.7.0 (MONTH DAY, YEAR)
+v0.7.0 (December 18, 2019)
 ------------------------
 
 This is a major release that drops support for Python 2 and Python 3.4. We
@@ -198,7 +198,7 @@ Removal of prior version deprecations
 * Removed `ModelChain.singlediode` method.
 * Removed `ModelChain.prepare_inputs` clearsky assumption when no irradiance
   data was provided.
-  
+
 Requirements
 ~~~~~~~~~~~~
 * numpy minimum increased to v1.12.0, released in 2017. (:issue:`830`)
@@ -220,3 +220,12 @@ Contributors
 * Todd Karin (:ghuser:`toddkarin`)
 * Mark Mikofski (:ghuser:`mikofski`)
 * Kevin Anderson (:ghuser:`kevinsa5`)
+* Cameron Stark (:ghuser:`camerontstark`)
+* Janine Freeman (:ghuser:`janinefreeman`)
+* Roel Loonen (:ghuser:`roelloonen`)
+* Birgit Schachler (:ghuser:`birgits`)
+* Hamilton Kibbe (:ghuser:`hamiltonkibbe`)
+* Adam Peretti (:ghuser:`aperetti`)
+* Cedric Leroy (:ghuser:`cedricleroy`)
+* Joseph Palakapilly (:ghuser:`JPalakapillyKWH`)
+* (:ghuser:`shall-resurety`)


### PR DESCRIPTION
 - [x] Closes #809
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
* N/A
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
* N/A
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
* N/A
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This updates whatsnew.rst with the proposed release date (2019-12-18), contributors to PRs and issues and includes the v0.7.0 tag.

The method I used to catch all the contributors from PRs is to use the Contributors section and select the dates on the graph since the previous release until now. The url api "from" and "to" fields can be used to make this exact. E.g. https://github.com/pvlib/pvlib-python/graphs/contributors?from=2019-05-17&to=2019-12-17&type=c . To get all the contributors to issues I performed a search in issues with the parameters "sort:created-asc closed:2019-05-16..2019-12-31 " and scanned for people who weren't on the list. I have found [a utility ](https://github.com/all-contributors/all-contributors)that we can implement that could make this process more thorough and I will create an issue for us to discuss its use.  
