### PR TITLE
add numfocus affiliation to sphinx docs

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -76,7 +76,7 @@ Additional pvlib python publications include:
 NumFOCUS
 ========
 
-pvlib python is a [NumFOCUS Affiliated Project](https://numfocus.org/sponsored-projects/affiliated-projects)
+pvlib python is a `NumFOCUS Affiliated Project <https://numfocus.org/sponsored-projects/affiliated-projects>`_
 
 .. image:: https://i0.wp.com/numfocus.org/wp-content/uploads/2019/06/AffiliatedProject.png
   :width: 100%

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -73,6 +73,17 @@ Additional pvlib python publications include:
   in 43rd Photovoltaic Specialists Conference, 2016.
 
 
+NumFOCUS
+========
+
+pvlib python is a [NumFOCUS Affiliated Project](https://numfocus.org/sponsored-projects/affiliated-projects)
+
+.. image:: https://i0.wp.com/numfocus.org/wp-content/uploads/2019/06/AffiliatedProject.png
+  :width: 100%
+  :target: https://numfocus.org/sponsored-projects/affiliated-projects
+  :alt: NumFocus Affliated Projects
+
+
 Contents
 ========
 

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -79,7 +79,6 @@ NumFOCUS
 pvlib python is a `NumFOCUS Affiliated Project <https://numfocus.org/sponsored-projects/affiliated-projects>`_
 
 .. image:: https://i0.wp.com/numfocus.org/wp-content/uploads/2019/06/AffiliatedProject.png
-  :width: 100%
   :target: https://numfocus.org/sponsored-projects/affiliated-projects
   :alt: NumFocus Affliated Projects
 

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.7.2.rst
 .. include:: whatsnew/v0.7.1.rst
 .. include:: whatsnew/v0.7.0.rst
 .. include:: whatsnew/v0.6.3.rst

--- a/docs/sphinx/source/whatsnew/v0.7.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.2.rst
@@ -9,4 +9,4 @@ Documentation
 
 Contributors
 ~~~~~~~~~~~~
-* mikofski (:ghuser:`mikofski`)
+* Mark Mikofski (:ghuser:`mikofski`)

--- a/docs/sphinx/source/whatsnew/v0.7.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.2.rst
@@ -1,0 +1,7 @@
+Documentation
+=============
+* Add NumFOCUS affiliation to Sphinx documentation :pull:`862`
+
+Contributors
+============
+* mikofski (ghuser:`mikofski`)

--- a/docs/sphinx/source/whatsnew/v0.7.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.2.rst
@@ -1,7 +1,12 @@
+.. _whatsnew_0720:
+
+v0.7.2 (Month day, year)
+-------------------------
+
 Documentation
-=============
+~~~~~~~~~~~~~
 * Add NumFOCUS affiliation to Sphinx documentation :pull:`862`
 
 Contributors
-============
-* mikofski (ghuser:`mikofski`)
+~~~~~~~~~~~~
+* mikofski (:ghuser:`mikofski`)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
