### PR TITLE
remove needs_pandas decorator

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.7.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.2.rst
@@ -3,6 +3,11 @@
 v0.7.2 (Month day, year)
 -------------------------
 
+API Changes
+~~~~~~~~~~~
+* :py:class:`pvlib.forecast.ForecastModel` now requires ``start`` and ``end``
+  arguments to be tz-localized. (:issue:`877`, :pull:`879`)
+
 Enhancements
 ~~~~~~~~~~~~
 * TMY3 dataframe returned by :py:func:`~pvlib.iotools.read_tmy3` now contains
@@ -15,6 +20,8 @@ Bug fixes
   a leap year (:pull:`866`)
 * Implement NREL Developer Network API key for consistent success with API
   calls in :py:mod:`pvlib.tests.iotools.test_psm3` (:pull:`873`)
+* Fix issue with :py:class:`pvlib.location.Location` creation when
+  passing ``tz=datetime.timezone.utc`` (:pull:`879`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -29,3 +36,6 @@ Contributors
 * Mark Mikofski (:ghuser:`mikofski`)
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Cameron T. Stark (:ghuser:`camerontstark`)
+* Will Holmgren (:ghuser:`wholmgren`)
+* Kevin Anderson (:ghuser:`kanderso-nrel`)
+* Karthikeyan Singaravelan (:ghuser:`tirkarthi`)

--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -86,7 +86,7 @@ def get_ecmwf_macc(filename, params, startdate, stopdate, lookup_params=True,
     key. Please read the documentation in `Access ECMWF Public Datasets
     <https://confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets>`_.
     Follow the instructions in step 4 and save the ECMWF registration key
-    as `$HOME\.ecmwfapirc` or set `ECMWF_API_KEY` as the path to the key.
+    as `$HOME/.ecmwfapirc` or set `ECMWF_API_KEY` as the path to the key.
 
     This function returns a daemon thread that runs in the background. Exiting
     Python will kill this thread, however this thread will not block the main

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -66,6 +66,9 @@ class Location(object):
         if isinstance(tz, str):
             self.tz = tz
             self.pytz = pytz.timezone(tz)
+        elif isinstance(tz, datetime.timezone):
+            self.tz = 'UTC'
+            self.pytz = pytz.UTC
         elif isinstance(tz, datetime.tzinfo):
             self.tz = tz.zone
             self.pytz = tz

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -78,6 +78,14 @@ needs_numpy_1_10 = pytest.mark.skipif(
     not numpy_1_10(), reason='requires numpy 1.10 or greater')
 
 
+def pandas_0_22():
+    return parse_version(pd.__version__) >= parse_version('0.22.0')
+
+
+needs_pandas_0_22 = pytest.mark.skipif(
+    not pandas_0_22(), reason='requires pandas 0.22 or greater')
+
+
 def has_spa_c():
     try:
         from pvlib.spa_c_files.spa_py import spa_calc

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -70,14 +70,6 @@ except ImportError:
 requires_ephem = pytest.mark.skipif(not has_ephem, reason='requires ephem')
 
 
-def pandas_0_17():
-    return parse_version(pd.__version__) >= parse_version('0.17.0')
-
-
-needs_pandas_0_17 = pytest.mark.skipif(
-    not pandas_0_17(), reason='requires pandas 0.17 or greater')
-
-
 def numpy_1_10():
     return parse_version(np.__version__) >= parse_version('1.10.0')
 

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -86,14 +86,6 @@ needs_numpy_1_10 = pytest.mark.skipif(
     not numpy_1_10(), reason='requires numpy 1.10 or greater')
 
 
-def pandas_0_22():
-    return parse_version(pd.__version__) >= parse_version('0.22.0')
-
-
-needs_pandas_0_22 = pytest.mark.skipif(
-    not pandas_0_22(), reason='requires pandas 0.22 or greater')
-
-
 def has_spa_c():
     try:
         from pvlib.spa_c_files.spa_py import spa_calc

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -4,7 +4,7 @@ test iotools for PSM3
 
 import os
 from pvlib.iotools import psm3
-from conftest import needs_pandas_0_22, DATA_DIR
+from conftest import DATA_DIR
 import numpy as np
 import pandas as pd
 import pytest
@@ -70,7 +70,6 @@ def assert_psm3_equal(header, data, expected):
     assert (data.index.tzinfo.zone == 'Etc/GMT%+d' % -header['Time Zone'])
 
 
-@needs_pandas_0_22
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_get_psm3_tmy(nrel_api_key):
     """test get_psm3 with a TMY"""
@@ -80,7 +79,6 @@ def test_get_psm3_tmy(nrel_api_key):
     assert_psm3_equal(header, data, expected)
 
 
-@needs_pandas_0_22
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_get_psm3_singleyear(nrel_api_key):
     """test get_psm3 with a single year"""
@@ -90,7 +88,6 @@ def test_get_psm3_singleyear(nrel_api_key):
     assert_psm3_equal(header, data, expected)
 
 
-@needs_pandas_0_22
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_get_psm3_check_leap_day(nrel_api_key):
     _, data_2012 = psm3.get_psm3(LATITUDE, LONGITUDE, nrel_api_key,
@@ -105,7 +102,6 @@ def test_get_psm3_check_leap_day(nrel_api_key):
                           (LATITUDE, LONGITUDE, nrel_api_key, 'bad', 60),
                           (LATITUDE, LONGITUDE, nrel_api_key, '2017', 15),
                           ])
-@needs_pandas_0_22
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_get_psm3_tmy_errors(
     latitude, longitude, api_key, names, interval
@@ -134,7 +130,6 @@ def io_input(request):
     return obj
 
 
-@needs_pandas_0_22
 def test_parse_psm3(io_input):
     """test parse_psm3"""
     header, data = psm3.parse_psm3(io_input)
@@ -142,7 +137,6 @@ def test_parse_psm3(io_input):
     assert_psm3_equal(header, data, expected)
 
 
-@needs_pandas_0_22
 def test_read_psm3():
     """test read_psm3"""
     header, data = psm3.read_psm3(MANUAL_TEST_DATA)

--- a/pvlib/tests/test_forecast.py
+++ b/pvlib/tests/test_forecast.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta
-from pytz import timezone
+from datetime import datetime, timedelta, timezone
 import warnings
 
 import pandas as pd
@@ -114,7 +113,7 @@ def test_vert_level():
 @requires_siphon
 def test_datetime():
     amodel = NAM()
-    start = datetime.now()
+    start = datetime.now(tz=timezone.utc)
     end = start + timedelta(days=1)
     amodel.get_processed_data(_latitude, _longitude, start, end)
 
@@ -138,7 +137,6 @@ def test_full():
     GFS(set_type='full')
 
 
-@requires_siphon
 def test_temp_convert():
     amodel = GFS()
     data = pd.DataFrame({'temp_air': [273.15]})
@@ -157,12 +155,17 @@ def test_temp_convert():
 #                                  variables=new_variables)
 
 
-@requires_siphon
 def test_set_location():
     amodel = GFS()
     latitude, longitude = 32.2, -110.9
-    time = datetime.now(timezone('UTC'))
+    time = 'UTC'
     amodel.set_location(time, latitude, longitude)
+
+
+def test_set_query_time_range_tzfail():
+    amodel = GFS()
+    with pytest.raises(TypeError):
+        amodel.set_query_time_range(datetime.now(), datetime.now())
 
 
 def test_cloud_cover_to_transmittance_linear():

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -13,7 +13,8 @@ from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from pvlib import irradiance
 
-from conftest import needs_numpy_1_10, requires_ephem, requires_numba
+from conftest import (needs_numpy_1_10, pandas_0_22,
+                      requires_ephem, requires_numba)
 
 
 # fixtures create realistic test input data
@@ -236,8 +237,11 @@ def test_perez_components(irrad_data, ephem_data, dni_et, relative_airmass):
         columns=['sky_diffuse', 'isotropic', 'circumsolar', 'horizon'],
         index=irrad_data.index
     )
-    expected_for_sum = expected['sky_diffuse'].copy()
-    expected_for_sum.iloc[2] = 0
+    if pandas_0_22():
+        expected_for_sum = expected['sky_diffuse'].copy()
+        expected_for_sum.iloc[2] = 0
+    else:
+        expected_for_sum = expected['sky_diffuse']
     sum_components = out.iloc[:, 1:].sum(axis=1)
     sum_components.name = 'sky_diffuse'
 

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -13,8 +13,7 @@ from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from pvlib import irradiance
 
-from conftest import (needs_numpy_1_10, pandas_0_22,
-                      requires_ephem, requires_numba)
+from conftest import needs_numpy_1_10, requires_ephem, requires_numba
 
 
 # fixtures create realistic test input data
@@ -237,11 +236,8 @@ def test_perez_components(irrad_data, ephem_data, dni_et, relative_airmass):
         columns=['sky_diffuse', 'isotropic', 'circumsolar', 'horizon'],
         index=irrad_data.index
     )
-    if pandas_0_22():
-        expected_for_sum = expected['sky_diffuse'].copy()
-        expected_for_sum.iloc[2] = 0
-    else:
-        expected_for_sum = expected['sky_diffuse']
+    expected_for_sum = expected['sky_diffuse'].copy()
+    expected_for_sum.iloc[2] = 0
     sum_components = out.iloc[:, 1:].sum(axis=1)
     sum_components.name = 'sky_diffuse'
 

--- a/pvlib/tests/test_location.py
+++ b/pvlib/tests/test_location.py
@@ -29,6 +29,7 @@ def test_location_all():
 
 @pytest.mark.parametrize('tz', [
     pytz.timezone('US/Arizona'), 'America/Phoenix',  -7, -7.0,
+    datetime.timezone.utc
 ])
 def test_location_tz(tz):
     Location(32.2, -111, tz)

--- a/pvlib/tests/test_solarposition.py
+++ b/pvlib/tests/test_solarposition.py
@@ -12,8 +12,7 @@ import pytest
 from pvlib.location import Location
 from pvlib import solarposition, spa
 
-from conftest import (requires_ephem, needs_pandas_0_17,
-                      requires_spa_c, requires_numba)
+from conftest import requires_ephem, requires_spa_c, requires_numba
 
 
 # setup times and locations to be tested.
@@ -164,7 +163,6 @@ def test_spa_python_numpy_physical_dst(expected_solpos, golden):
     assert_frame_equal(expected_solpos, ephem_data[expected_solpos.columns])
 
 
-@needs_pandas_0_17
 def test_sun_rise_set_transit_spa(expected_rise_set_spa, golden):
     # solution from NREL SAP web calculator
     south = Location(-35.0, 0.0, tz='UTC')


### PR DESCRIPTION
 - [x] Closes #883
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Decorators meant to deal with advances in pandas in the test suite are now antiquated and can be removed. Tests passed locally but it's TBD for everything on the CI.
