### PR TITLE
fix documentation home page title

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -1,7 +1,8 @@
 .. image:: _images/pvlib_logo_horiz.png
   :width: 600
 
-========================================
+pvlib python
+==========================================================================================================
 
 pvlib python is a community supported tool that provides a set of
 functions and classes for simulating the performance of photovoltaic

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -2,7 +2,7 @@
   :width: 600
 
 pvlib python
-==========================================================================================================
+============
 
 pvlib python is a community supported tool that provides a set of
 functions and classes for simulating the performance of photovoltaic

--- a/docs/sphinx/source/whatsnew/v0.7.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.7.2.rst
@@ -22,6 +22,8 @@ Bug fixes
   calls in :py:mod:`pvlib.tests.iotools.test_psm3` (:pull:`873`)
 * Fix issue with :py:class:`pvlib.location.Location` creation when
   passing ``tz=datetime.timezone.utc`` (:pull:`879`)
+* Fix documentation homepage title to "pvlib python" based on first heading on
+  the page. (:pull:`890`) (:issue:`888`)
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
 - [x] Closes #888 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This PR fixes the homepage title misnaming by ensuring that "pvlib python" is the first section title. I opted for the short title rather than the longer one proposed by @wholmgren since it duplicated what was in the following paragraph. 