### PR TITLE
Fix big-endian buffer not supported on little-endian compiler bug

### DIFF
--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -376,6 +376,11 @@ class ForecastModel(object):
             if key not in query_variables:
                 continue
             squeezed = data[:].squeeze()
+
+            # If the data is big endian, swap the byte order to make it little endian
+            if squeezed.dtype.byteorder == '>':
+                squeezed = squeezed.byteswap().newbyteorder()
+                
             if squeezed.ndim == 1:
                 data_dict[key] = squeezed
             elif squeezed.ndim == 2:

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -377,7 +377,7 @@ class ForecastModel(object):
                 continue
             squeezed = data[:].squeeze()
 
-            # If the data is big endian, swap the byte order to make it 
+            # If the data is big endian, swap the byte order to make it
             # little endian
             if squeezed.dtype.byteorder == '>':
                 squeezed = squeezed.byteswap().newbyteorder()

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -377,10 +377,10 @@ class ForecastModel(object):
                 continue
             squeezed = data[:].squeeze()
 
-            # If the data is big endian, swap the byte order to make it little endian
+            # If the data is big endian, swap the byte order to make it 
+            # little endian
             if squeezed.dtype.byteorder == '>':
                 squeezed = squeezed.byteswap().newbyteorder()
-                
             if squeezed.ndim == 1:
                 data_dict[key] = squeezed
             elif squeezed.ndim == 2:


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #920 
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Issue #920 fully describes the problem and links to a Stack Overflow post where another user ran into the same problem.  
