### PR TITLE
pass temperature, pressure to modelchain sol pos call

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -16,7 +16,7 @@ from pvlib.tracking import SingleAxisTracker
 import pvlib.irradiance  # avoid name conflict with full import
 from pvlib.pvsystem import _DC_MODEL_PARAMS
 from pvlib._deprecation import pvlibDeprecationWarning
-
+from pvlib.tools import _build_kwargs
 
 def basic_chain(times, latitude, longitude,
                 module_parameters, temperature_model_parameters,
@@ -870,9 +870,15 @@ class ModelChain(object):
                           'is used for times.', pvlibDeprecationWarning)
 
         self.times = self.weather.index
+        try:
+            kwargs = _build_kwargs(['pressure', 'temp_air'], weather)
+            kwargs['temperature'] = kwargs.pop('temp_air')
+        except KeyError:
+            pass
 
         self.solar_position = self.location.get_solarposition(
-            self.weather.index, method=self.solar_position_method)
+            self.weather.index, method=self.solar_position_method,
+            **kwargs)
 
         self.airmass = self.location.get_airmass(
             solar_position=self.solar_position, model=self.airmass_model)


### PR DESCRIPTION
This PR handles, the case where pressure or temp_air is not in weather, using the pvlib.tools._build_kwargs method, as keyword arguments. #893

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #893 #523 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
