### PR TITLE
clarify units for U1 and Uv temperature model coeff

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,7 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
-.. include:: whatsnew/v0.7.3.rst
+.. include:: whatsnew/v0.8.0.rst
 .. include:: whatsnew/v0.7.2.rst
 .. include:: whatsnew/v0.7.1.rst
 .. include:: whatsnew/v0.7.0.rst

--- a/docs/sphinx/source/whatsnew/v0.8.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.0.rst
@@ -1,4 +1,4 @@
-.. _whatsnew_0730:
+.. _whatsnew_0800:
 
 v0.8.0 (Month day, year)
 -------------------------
@@ -17,7 +17,12 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
-* Improved formatting and content of docstrings in `pvlib.atmosphere`
+* Improved formatting and content of docstrings in :py:mod:`pvlib.atmosphere`.
+  (:pull:`969`)
+* Fix LaTeX rendering in :py:func:`pvlib.singlediode.bishop88`. (:pull:`967`)
+* Clarify units for heat loss factors in
+  :py:func:`pvlib.temperature.pvsyst_cell` and
+  :py:func:`pvlib.temperature.faiman`. (:pull:`960`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -25,3 +30,5 @@ Requirements
 Contributors
 ~~~~~~~~~~~~
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Kevin Anderson (:ghuser:`kanderso-nrel`)
+* Mark Mikofski (:ghuser:`mikofski`)

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -293,7 +293,8 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
 
     u_v : float, default 0.0
         Combined heat loss factor influenced by wind. Parameter :math:`U_{v}`
-        in :eq:`pvsyst` :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
+        in :eq:`pvsyst`
+        :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
 
     eta_m : numeric, default 0.1
         Module external efficiency as a fraction, i.e., DC power / poa_global.
@@ -356,7 +357,7 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
 
 
 def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
-    '''
+    r'''
     Calculate cell or module temperature using the Faiman model.  The Faiman
     model uses an empirical heat loss factor model [1]_ and is adopted in the
     IEC 61853 standards [2]_ and [3]_.

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -293,7 +293,7 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
 
     u_v : float, default 0.0
         Combined heat loss factor influenced by wind. Parameter :math:`U_{v}`
-        in :eq:`pvsyst` [(W/m^2 C)(m/s)].
+        in :eq:`pvsyst` [W/(m^2 C)/(m/s)].
 
     eta_m : numeric, default 0.1
         Module external efficiency as a fraction, i.e., DC power / poa_global.
@@ -383,7 +383,7 @@ def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
 
     u1 : numeric, default 6.84
         Combined heat loss factor influenced by wind. The default value is one
-        determined by Faiman for 7 silicon modules. [(W/m^2 C)(m/s)].
+        determined by Faiman for 7 silicon modules. [W/(m^2 C)/(m/s)].
 
     Returns
     -------

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -289,12 +289,13 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
         Combined heat loss factor coefficient. The default value is
         representative of freestanding modules with the rear surfaces exposed
         to open air (e.g., rack mounted). Parameter :math:`U_{c}` in
-        :eq:`pvsyst` [W/(m^2 C)].
+        :eq:`pvsyst`.
+        :math:`\left[\frac{\text{W}/{\text{m}^2}}{\text{C}}\right]`
 
     u_v : float, default 0.0
         Combined heat loss factor influenced by wind. Parameter :math:`U_{v}`
-        in :eq:`pvsyst`
-        :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
+        in :eq:`pvsyst`.
+        :math:`\left[ \frac{\text{W}/\text{m}^2}{\text{C}\ \left( \text{m/s} \right)} \right]`
 
     eta_m : numeric, default 0.1
         Module external efficiency as a fraction, i.e., DC power / poa_global.
@@ -380,12 +381,13 @@ def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
 
     u0 : numeric, default 25.0
         Combined heat loss factor coefficient. The default value is one
-        determined by Faiman for 7 silicon modules. [W/(m^2 C)].
+        determined by Faiman for 7 silicon modules.
+        :math:`\left[\frac{\text{W}/{\text{m}^2}}{\text{C}}\right]`
 
     u1 : numeric, default 6.84
         Combined heat loss factor influenced by wind. The default value is one
         determined by Faiman for 7 silicon modules.
-        :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
+        :math:`\left[ \frac{\text{W}/\text{m}^2}{\text{C}\ \left( \text{m/s} \right)} \right]`
 
     Returns
     -------

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -293,7 +293,7 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
 
     u_v : float, default 0.0
         Combined heat loss factor influenced by wind. Parameter :math:`U_{v}`
-        in :eq:`pvsyst` [W/(m^2 C)/(m/s)].
+        in :eq:`pvsyst` :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
 
     eta_m : numeric, default 0.1
         Module external efficiency as a fraction, i.e., DC power / poa_global.
@@ -383,7 +383,8 @@ def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
 
     u1 : numeric, default 6.84
         Combined heat loss factor influenced by wind. The default value is one
-        determined by Faiman for 7 silicon modules. [W/(m^2 C)/(m/s)].
+        determined by Faiman for 7 silicon modules.
+        :math:`\left[\frac{W/{\left(m^2 C\right)}}{m/s}\right]`.
 
     Returns
     -------


### PR DESCRIPTION
* closes #945 
* group denominator together, same way it was done for U0 and Uc, ie: `W/(m^2 C)` instead of `(W/m^2 C)` which is ambiguous because it could mean `W/m^2 * C = W * C / m^2` which is not the same thing
* add missing division symbol before 2nd denominator `(m/s)` to get `W / (m^2 C) / (m/s)` instead of `(W/m^2 C) (m/s)` which looks like `WmC/ (m^2 s)` so it's ambiguous
* pvsyst help docs (https://www.pvsyst.com/help/thermal_loss.htm) say  `W/m²·k / m/s` which is also ambiguous but you can't win em all

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] ~Tests added~
 - [x] ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
