### PR TITLE
fix empty "PV Modeling > Other" section in API reference

### DIFF
--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -311,8 +311,10 @@ Functions for fitting diode models
 
 Other
 -----
+
 .. autosummary::
    :toctree: generated/
+
    pvsystem.retrieve_sam
    pvsystem.systemdef
    pvsystem.scale_voltage_current_power


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

#937 deleted a blank separator line in `api.rst` which caused a small section of the reference to stop rendering in the built documentation, this just adds the whitespace back.  

Current docs:https://pvlib-python.readthedocs.io/en/stable/api.html#other
PR docs: https://pvlib-python--961.org.readthedocs.build/en/961/api.html#other