### PR TITLE
conftest.fail_on_pvlib_version applied to functions that require args or kwargs

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.8.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.0.rst
@@ -14,6 +14,8 @@ Bug fixes
 
 Testing
 ~~~~~~~
+* Decorator :py:func:`pvlib.conftest.fail_on_pvlib_version` now accepts
+  arguments that are passed to the decorated function. (:pull:`973`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.8.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.0.rst
@@ -14,8 +14,8 @@ Bug fixes
 
 Testing
 ~~~~~~~
-* Decorator :py:func:`pvlib.conftest.fail_on_pvlib_version` now accepts
-  arguments that are passed to the decorated function. (:pull:`973`)
+* Decorator :py:func:`pvlib.conftest.fail_on_pvlib_version` can now be
+  applied to functions that require args or kwargs. (:pull:`973`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -19,7 +19,7 @@ pvlib_base_version = \
 # test function may not take args, kwargs, or fixtures.
 def fail_on_pvlib_version(version, *args):
     # second level of decorator takes the function under consideration
-    def wrapper(func, args=args):
+    def wrapper(func):
         # third level defers computation until the test is called
         # this allows the specific test to fail at test runtime,
         # rather than at decoration time (when the module is imported)

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -19,11 +19,11 @@ pvlib_base_version = \
 # test function may not take args, kwargs, or fixtures.
 def fail_on_pvlib_version(version, *args):
     # second level of decorator takes the function under consideration
-    def wrapper(func, *args):
+    def wrapper(func, args=args):
         # third level defers computation until the test is called
         # this allows the specific test to fail at test runtime,
         # rather than at decoration time (when the module is imported)
-        def inner(*args):
+        def inner():
             # fail if the version is too high
             if pvlib_base_version >= parse_version(version):
                 pytest.fail('the tested function is scheduled to be '

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -16,7 +16,7 @@ pvlib_base_version = \
 # decorator takes one argument: the base version for which it should fail
 # for example @fail_on_pvlib_version('0.7') will cause a test to fail
 # on pvlib versions 0.7a, 0.7b, 0.7rc1, etc.
-# test function may not take args, kwargs, or fixtures.
+# args will be passed to the function being decorated.
 def fail_on_pvlib_version(version, *args):
     # second level of decorator takes the function under consideration
     def wrapper(func):

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -17,20 +17,20 @@ pvlib_base_version = \
 # for example @fail_on_pvlib_version('0.7') will cause a test to fail
 # on pvlib versions 0.7a, 0.7b, 0.7rc1, etc.
 # test function may not take args, kwargs, or fixtures.
-def fail_on_pvlib_version(version):
+def fail_on_pvlib_version(version, *args):
     # second level of decorator takes the function under consideration
-    def wrapper(func):
+    def wrapper(func, *args):
         # third level defers computation until the test is called
         # this allows the specific test to fail at test runtime,
         # rather than at decoration time (when the module is imported)
-        def inner():
+        def inner(*args):
             # fail if the version is too high
             if pvlib_base_version >= parse_version(version):
                 pytest.fail('the tested function is scheduled to be '
                             'removed in %s' % version)
             # otherwise return the function to be executed
             else:
-                return func()
+                return func(*args)
         return inner
     return wrapper
 

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -16,8 +16,8 @@ pvlib_base_version = \
 # decorator takes one argument: the base version for which it should fail
 # for example @fail_on_pvlib_version('0.7') will cause a test to fail
 # on pvlib versions 0.7a, 0.7b, 0.7rc1, etc.
-# args will be passed to the function being decorated.
-def fail_on_pvlib_version(version, *args):
+# args and kwargs will be passed to the function being decorated.
+def fail_on_pvlib_version(version, *args, **kwargs):
     # second level of decorator takes the function under consideration
     def wrapper(func):
         # third level defers computation until the test is called
@@ -30,7 +30,7 @@ def fail_on_pvlib_version(version, *args):
                             'removed in %s' % version)
             # otherwise return the function to be executed
             else:
-                return func(*args)
+                return func(*args, **kwargs)
         return inner
     return wrapper
 

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from pkg_resources import parse_version
 import pytest
+from functools import wraps
 
 import pvlib
 
@@ -23,7 +24,8 @@ def fail_on_pvlib_version(version, *args, **kwargs):
         # third level defers computation until the test is called
         # this allows the specific test to fail at test runtime,
         # rather than at decoration time (when the module is imported)
-        def inner():
+        @wraps(func)
+        def inner(*args, **kwargs):
             # fail if the version is too high
             if pvlib_base_version >= parse_version(version):
                 pytest.fail('the tested function is scheduled to be '
@@ -33,7 +35,6 @@ def fail_on_pvlib_version(version, *args, **kwargs):
                 return func(*args, **kwargs)
         return inner
     return wrapper
-
 
 # commonly used directories in the tests
 TEST_DIR = Path(__file__).parent

--- a/pvlib/tests/conftest.py
+++ b/pvlib/tests/conftest.py
@@ -17,8 +17,7 @@ pvlib_base_version = \
 # decorator takes one argument: the base version for which it should fail
 # for example @fail_on_pvlib_version('0.7') will cause a test to fail
 # on pvlib versions 0.7a, 0.7b, 0.7rc1, etc.
-# args and kwargs will be passed to the function being decorated.
-def fail_on_pvlib_version(version, *args, **kwargs):
+def fail_on_pvlib_version(version):
     # second level of decorator takes the function under consideration
     def wrapper(func):
         # third level defers computation until the test is called

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -23,21 +23,23 @@ def test_fail_on_pvlib_version_fail_in_test():
 
 
 # set up to test passing arguments to conftest.fail_on_pvlib_version
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def some_data():
     return "some data"
 
 
 def alt_func(*args):
-    print(args[0])
-    return
+    return args
 
 
 deprec_func = deprecated('0.8', alternative='alt_func',
                          name='deprec_func', removal='0.9')(alt_func)
 
 
-@fail_on_pvlib_version('0.9', some_data)
-def test_deprecated_09(some_data):
-    with pytest.warns(pvlibDeprecationWarning):
-        deprec_func(some_data)
+@fail_on_pvlib_version('0.9', some_data, test_string="test")
+def test_deprecated_09(some_data, test_string=None):
+    with pytest.warns(pvlibDeprecationWarning):  # test for deprecation warning
+        # use assert to test that alternate function was called
+        assert some_data == deprec_func(some_data)[0]
+        # check that the kwarg was accepted
+        assert test_string == "test"

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -32,11 +32,11 @@ def alt_func(*args):
     return args
 
 
-deprec_func = deprecated('0.8', alternative='alt_func',
-                         name='deprec_func', removal='0.9')(alt_func)
+deprec_func = deprecated('350.8', alternative='alt_func',
+                         name='deprec_func', removal='350.9')(alt_func)
 
 
-@fail_on_pvlib_version('0.9')
+@fail_on_pvlib_version('350.9')
 def test_deprecated_09(some_data):
     # test that data is returned by the fixture
     assert some_data == "some data"

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from conftest import fail_on_pvlib_version
 
+from pvlib._deprecation import pvlibDeprecationWarning, deprecated
 
 @pytest.mark.xfail(strict=True,
                    reason='fail_on_pvlib_version should cause test to fail')
@@ -19,3 +20,23 @@ def test_fail_on_pvlib_version_pass():
 @fail_on_pvlib_version('100000.0')
 def test_fail_on_pvlib_version_fail_in_test():
     raise Exception
+
+
+# set up to test passing arguments to conftest.fail_on_pvlib_version
+@pytest.fixture(scope='function')
+def some_data():
+    return "some data"
+
+def alt_func(*args):
+    print(args[0])
+    return
+
+
+deprec_func = deprecated('0.8', alternative='alt_func',
+                         name='deprec_func', removal='0.9')(alt_func)
+
+
+@fail_on_pvlib_version('0.9', some_data)
+def test_deprecated_09():
+    with pytest.warns(pvlibDeprecationWarning):
+        deprec_func(some_data())

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -37,7 +37,7 @@ deprec_func = deprecated('0.8', alternative='alt_func',
                          name='deprec_func', removal='0.9')(alt_func)
 
 
-@fail_on_pvlib_version('0.9', some_data)
+@fail_on_pvlib_version('0.9')
 def test_deprecated_09(some_data):
     with pytest.warns(pvlibDeprecationWarning):
         deprec_func(some_data)

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -36,10 +36,9 @@ deprec_func = deprecated('0.8', alternative='alt_func',
                          name='deprec_func', removal='0.9')(alt_func)
 
 
-@fail_on_pvlib_version('0.9', some_data, test_string="test")
-def test_deprecated_09(some_data, test_string=None):
+@fail_on_pvlib_version('0.9')
+def test_deprecated_09(some_data):
+    # test that data is returned by the fixture
+    assert some_data == "some data"
     with pytest.warns(pvlibDeprecationWarning):  # test for deprecation warning
-        # use assert to test that alternate function was called
-        assert some_data == deprec_func(some_data)[0]
-        # check that the kwarg was accepted
-        assert test_string == "test"
+        deprec_func(some_data)[0]

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -41,4 +41,4 @@ def test_deprecated_09(some_data):
     # test that data is returned by the fixture
     assert some_data == "some data"
     with pytest.warns(pvlibDeprecationWarning):  # test for deprecation warning
-        deprec_func(some_data)[0]
+        deprec_func(some_data)

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -22,7 +22,8 @@ def test_fail_on_pvlib_version_fail_in_test():
     raise Exception
 
 
-# set up to test passing arguments to conftest.fail_on_pvlib_version
+# set up to test using fixtures with function decorated with
+# conftest.fail_on_pvlib_version
 @pytest.fixture()
 def some_data():
     return "some data"
@@ -37,8 +38,8 @@ deprec_func = deprecated('350.8', alternative='alt_func',
 
 
 @fail_on_pvlib_version('350.9')
-def test_deprecated_09(some_data):
-    # test that data is returned by the fixture
+def test_use_fixture_with_decorator(some_data):
+    # test that the correct data is returned by the some_data fixture
     assert some_data == "some data"
     with pytest.warns(pvlibDeprecationWarning):  # test for deprecation warning
         deprec_func(some_data)

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -37,7 +37,7 @@ deprec_func = deprecated('0.8', alternative='alt_func',
                          name='deprec_func', removal='0.9')(alt_func)
 
 
-@fail_on_pvlib_version('0.9')
+@fail_on_pvlib_version('0.9', some_data)
 def test_deprecated_09(some_data):
     with pytest.warns(pvlibDeprecationWarning):
         deprec_func(some_data)

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -27,6 +27,7 @@ def test_fail_on_pvlib_version_fail_in_test():
 def some_data():
     return "some data"
 
+
 def alt_func(*args):
     print(args[0])
     return
@@ -37,6 +38,6 @@ deprec_func = deprecated('0.8', alternative='alt_func',
 
 
 @fail_on_pvlib_version('0.9', some_data)
-def test_deprecated_09():
+def test_deprecated_09(some_data):
     with pytest.warns(pvlibDeprecationWarning):
-        deprec_func(some_data())
+        deprec_func(some_data)


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Adding capability to pass arguments to a function decorated with `fail_on_pvlib_version`. Allows use of fixtures when testing for deprecation message.
