### PR TITLE
Correction on the application of losses in pvwatts_losses()

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -731,7 +731,7 @@ class ModelChain(object):
 
     def pvwatts_losses(self):
         self.losses = (100 - self.system.pvwatts_losses()) / 100.
-        self.dc *= self.losses
+        self.dc[['v_mp', 'p_mp']] *= self.losses
         return self
 
     def no_extra_losses(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Until now, the consideration of losses in a system is made with the pvwatts model which apply a coefficient to all electrical outputs (''i_sc', 'v_oc', 'i_x', 'i_xx', 'v_mp', 'i_mp', 'p_mp') in pvwatts_losses():
`self.dc *= self.losses`
It results in inconsistent figures because after this line, the following equality is not respected anymore:
>  v_mp * i_mp = p_mp

As I think losses can be considered as an increase in R_s (Not 100% sure, we can discuss it), I propose to correct it with:
self.dc[['v_mp', 'p_mp']] *= self.losses


