### PR TITLE
add minimum requirements configuration to azure conda linux

### DIFF
--- a/ci/azure/conda_linux.yml
+++ b/ci/azure/conda_linux.yml
@@ -10,6 +10,9 @@ jobs:
     matrix:
       Python35:
         python.version: '35'
+      Python35-min:
+        python.version: '35'
+        suffix: '-min'
       Python36:
         python.version: '36'
         coverage: true
@@ -21,7 +24,7 @@ jobs:
   steps:
   - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
     displayName: Add conda to PATH
-  - script: conda env create --quiet --file ci/requirements-py$(python.version).yml
+  - script: conda env create --quiet --file ci/requirements-py$(python.version)$(suffix).yml
     displayName: Create Anaconda environment
   - script: |
       source activate test_env

--- a/docs/sphinx/source/whatsnew/v0.8.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.0.rst
@@ -35,6 +35,8 @@ Testing
   applied to functions that require args or kwargs. (:pull:`973`)
 * Test added for :py:class:`pvlib.modelchain.ModelChain` to confirm ValueError when
   ``ac_model`` is an invalid string. (:pull:`886`)
+* Add minimum requirements configuration to Azure Pipelines build.
+  (:pull:`1006`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -63,3 +65,4 @@ Contributors
 * Mark Mikofski (:ghuser:`mikofski`)
 * Joshua S. Stein (:ghuser:`jsstein`)
 * Marc A. Anoma (:ghuser:`anomam`)
+* Will Holmgren (:ghuser:`wholmgren`)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Travis is no longer posting build results to PRs, as discussed in https://github.com/pvlib/pvlib-python/pull/1003#issuecomment-659827234. We want to move away from Travis anyways (#950), so I don't think it's worth fixing that. 

This PR adds the `requirements-35-min.yml` configuration to the azure build matrix. We're not quite ready to fully deprecate Travis because we use it for deploying tagged versions, but I don't want to tackle that in this quick fix PR.

@kanderso-nrel if you agree with this strategy then I suggest merging now so that we can more confidently address the PR backlog. 