### PR TITLE
Rename ivtools.utility to ivtools.utils, and silence ivtools.sdm warnings

### DIFF
--- a/pvlib/ivtools/__init__.py
+++ b/pvlib/ivtools/__init__.py
@@ -4,4 +4,4 @@ and diode models.
 
 """
 
-from pvlib.ivtools import sde, sdm, utility  # noqa: F401
+from pvlib.ivtools import sde, sdm, utils  # noqa: F401

--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -7,7 +7,7 @@ Function names should follow the pattern "fit_" + fitting method.
 
 import numpy as np
 
-from pvlib.ivtools.utility import _schumaker_qspline
+from pvlib.ivtools.utils import _schumaker_qspline
 
 
 # set constant for numpy.linalg.lstsq parameter rcond

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pvlib.pvsystem import singlediode, v_from_i
 
-from pvlib.ivtools.utility import constants, rectify_iv_curve, _numdiff
+from pvlib.ivtools.utils import rectify_iv_curve, _numdiff
 from pvlib.ivtools.sde import _fit_sandia_cocontent
 
 
@@ -301,7 +301,7 @@ def _system_of_equations_desoto(params, specs):
     return y
 
 
-def fit_pvsyst_sandia(ivcurves, specs, const=constants, maxiter=5, eps1=1.e-3):
+def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     """
     Estimate parameters for the PVsyst module performance model.
 
@@ -416,6 +416,9 @@ def fit_pvsyst_sandia(ivcurves, specs, const=constants, maxiter=5, eps1=1.e-3):
     .. [7] PVLib MATLAB https://github.com/sandialabs/MATLAB_PV_LIB
     """
 
+    if const is None:
+        const = {'E0': 1000.0, 'T0': 25.0, 'k': 1.38066e-23, 'q': 1.60218e-19}
+
     ee = ivcurves['ee']
     tc = ivcurves['tc']
     tck = tc + 273.15
@@ -476,7 +479,7 @@ def fit_pvsyst_sandia(ivcurves, specs, const=constants, maxiter=5, eps1=1.e-3):
     return pvsyst
 
 
-def fit_desoto_sandia(ivcurves, specs, const=constants, maxiter=5, eps1=1.e-3):
+def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     """
     Estimate parameters for the De Soto module performance model.
 
@@ -574,6 +577,9 @@ def fit_desoto_sandia(ivcurves, specs, const=constants, maxiter=5, eps1=1.e-3):
         Measured IV Curves, Proc. of the 39th IEEE PVSC, June 2013.
     .. [4] PVLib MATLAB https://github.com/sandialabs/MATLAB_PV_LIB
     """
+
+    if const is None:
+        const = {'E0': 1000.0, 'T0': 25.0, 'k': 1.38066e-23, 'q': 1.60218e-19}
 
     ee = ivcurves['ee']
     tc = ivcurves['tc']
@@ -939,10 +945,11 @@ def _update_io(voc, iph, io, rs, rsh, nnsvth):
         dvoc = pvoc - voc
 
         # Update Io
-        new_io = tio * (1. + (2. * dvoc) / (2. * nnsvth - dvoc))
+        with np.errstate(invalid="ignore"):
+            new_io = tio * (1. + (2. * dvoc) / (2. * nnsvth - dvoc))
+            # Calculate Maximum Percent Difference
+            maxerr = np.max(np.abs(new_io - tio) / tio) * 100.
 
-        # Calculate Maximum Percent Difference
-        maxerr = np.max(np.abs(new_io - tio) / tio) * 100.
         tio = new_io
         k += 1.
 
@@ -1200,12 +1207,12 @@ def _calc_theta_phi_exact(vmp, imp, iph, io, rs, rsh, nnsvth):
 
     # Argument for Lambert W function involved in V = V(I) [2] Eq. 12; [3]
     # Eq. 3
-    with np.errstate(over="ignore"):
+    with np.errstate(over="ignore", invalid="ignore"):
         argw = np.where(
             nnsvth == 0,
             np.nan,
             rsh * io / nnsvth * np.exp(rsh * (iph + io - imp) / nnsvth))
-    phi = np.where(argw > 0, lambertw(argw).real, np.nan)
+        phi = np.where(argw > 0, lambertw(argw).real, np.nan)
 
     # NaN where argw overflows. Switch to log space to evaluate
     u = np.isinf(argw)
@@ -1225,13 +1232,13 @@ def _calc_theta_phi_exact(vmp, imp, iph, io, rs, rsh, nnsvth):
 
     # Argument for Lambert W function involved in I = I(V) [2] Eq. 11; [3]
     # E1. 2
-    with np.errstate(over="ignore"):
+    with np.errstate(over="ignore", invalid="ignore"):
         argw = np.where(
             nnsvth == 0,
             np.nan,
             rsh / (rsh + rs) * rs * io / nnsvth * np.exp(
                 rsh / (rsh + rs) * (rs * (iph + io) + vmp) / nnsvth))
-    theta = np.where(argw > 0, lambertw(argw).real, np.nan)
+        theta = np.where(argw > 0, lambertw(argw).real, np.nan)
 
     # NaN where argw overflows. Switch to log space to evaluate
     u = np.isinf(argw)

--- a/pvlib/ivtools/utils.py
+++ b/pvlib/ivtools/utils.py
@@ -1,5 +1,5 @@
 """
-The ``pvlib.ivtools.utility.py`` module contains utility functions related to
+The ``pvlib.ivtools.utils.py`` module contains utility functions related to
 working with IV curves, or fitting equations to IV curve data.
 
 """
@@ -10,9 +10,6 @@ import pandas as pd
 
 # A small number used to decide when a slope is equivalent to zero
 EPS = np.finfo('float').eps**(1/3)
-
-
-constants = {'E0': 1000.0, 'T0': 25.0, 'k': 1.38066e-23, 'q': 1.60218e-19}
 
 
 def _numdiff(x, f):

--- a/pvlib/tests/ivtools/test_utils.py
+++ b/pvlib/tests/ivtools/test_utils.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pandas as pd
 import pytest
-from pvlib.ivtools.utility import _numdiff, rectify_iv_curve
-from pvlib.ivtools.utility import _schumaker_qspline
+from pvlib.ivtools.utils import _numdiff, rectify_iv_curve
+from pvlib.ivtools.utils import _schumaker_qspline
 
 from conftest import DATA_DIR
 


### PR DESCRIPTION
 - [x] Closes #1046 Closes #1047 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~~Tests added~~
 - [ ] ~~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~~
 - [ ] ~~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Most warnings are from 0/0 or divide by zero operations encountered in tests. These are expected, but should be rare, when various steps of the parameter fitting fail to converge. Code should assign np.nan and proceed.
