### PR TITLE
PSM3 updates

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.8.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.1.rst
@@ -17,7 +17,8 @@ Enhancements
   option to :py:class:`~pvlib.modelchain.ModelChain`. (:pull:`1042`) (:issue:`1073`)
 * Added :py:func:`pvlib.temperature.ross` for cell temperature modeling using
   only NOCT. (:pull:`1045`)
-
+* Added optional ``attributes`` parameter to :py:func:`pvlib.iotools.get_psm3`
+  and added the option of fetching 5- and 15-minute PSM3 data. (:pull:`1086`)
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -15,9 +15,9 @@ TMY_URL = NSRDB_API_BASE + "/api/nsrdb/v2/solar/psm3-tmy-download.csv"
 PSM5MIN_URL = NSRDB_API_BASE + "/api/nsrdb/v2/solar/psm3-5min-download.csv"
 
 # 'relative_humidity', 'total_precipitable_water' are not available
-ATTRIBUTES = [
+ATTRIBUTES = (
     'air_temperature', 'dew_point', 'dhi', 'dni', 'ghi', 'surface_albedo',
-    'surface_pressure', 'wind_direction', 'wind_speed']
+    'surface_pressure', 'wind_direction', 'wind_speed')
 PVLIB_PYTHON = 'pvlib python'
 
 

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -97,8 +97,10 @@ def test_get_psm3_5min(nrel_api_key):
     """test get_psm3 for 5-minute data"""
     header, data = psm3.get_psm3(LATITUDE, LONGITUDE, nrel_api_key,
                                  PVLIB_EMAIL, names='2019', interval=5)
+    assert len(data) == 525600/5
+    first_day = data.loc['2019-01-01']
     expected = pd.read_csv(YEAR_TEST_DATA_5MIN)
-    assert_psm3_equal(header, data, expected)
+    assert_psm3_equal(header, first_day, expected)
 
 
 @pytest.mark.remote_data

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -14,6 +14,7 @@ import warnings
 
 TMY_TEST_DATA = DATA_DIR / 'test_psm3_tmy-2017.csv'
 YEAR_TEST_DATA = DATA_DIR / 'test_psm3_2017.csv'
+YEAR_TEST_DATA_5MIN = DATA_DIR / 'test_psm3_2019_5min.csv'
 MANUAL_TEST_DATA = DATA_DIR / 'test_read_psm3.csv'
 LATITUDE, LONGITUDE = 40.5137, -108.5449
 HEADER_FIELDS = [
@@ -87,6 +88,16 @@ def test_get_psm3_singleyear(nrel_api_key):
     header, data = psm3.get_psm3(LATITUDE, LONGITUDE, nrel_api_key,
                                  PVLIB_EMAIL, names='2017', interval=30)
     expected = pd.read_csv(YEAR_TEST_DATA)
+    assert_psm3_equal(header, data, expected)
+
+
+@pytest.mark.remote_data
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+def test_get_psm3_5min(nrel_api_key):
+    """test get_psm3 for 5-minute data"""
+    header, data = psm3.get_psm3(LATITUDE, LONGITUDE, nrel_api_key,
+                                 PVLIB_EMAIL, names='2019', interval=5)
+    expected = pd.read_csv(YEAR_TEST_DATA_5MIN)
     assert_psm3_equal(header, data, expected)
 
 


### PR DESCRIPTION
 - [x] Closes #1079
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I'm lumping a few `get_psm3` updates into this PR:
- Add optional attributes parameter to address #1079 
- Update list of acceptable years in docstring
- Add support for the new 5-minute and 15-minute API endpoint

I'm not wild about including a 10MB csv file for the test -- okay to trim it down to a single day, or fine as is?