### PR TITLE
Add missing modules to init.py

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.8.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.1.rst
@@ -26,6 +26,8 @@ Bug fixes
   inputs. (:issue:`1071`, :pull:`1072`)
 * Raise ``ValueError`` from  :py:meth:`pvlib.modelchain.ModelChain.prepare_inputs`
   when input does not have a 'dhi' column. (:issue:`1092`, :pull:`1093`)
+* Add missing modules (including ``shading`` and ``scaling``) to ``__init__.py``.
+  (:pull:`1103`)
 
 Testing
 ~~~~~~~

--- a/pvlib/__init__.py
+++ b/pvlib/__init__.py
@@ -1,23 +1,26 @@
 from pvlib.version import __version__  # noqa: F401
-from pvlib import tools  # noqa: F401
-from pvlib import atmosphere  # noqa: F401
-from pvlib import clearsky  # noqa: F401
-# from pvlib import forecast  # noqa: F401
-from pvlib import irradiance  # noqa: F401
-from pvlib import location  # noqa: F401
-from pvlib import solarposition  # noqa: F401
-from pvlib import iotools  # noqa: F401
-from pvlib import ivtools  # noqa: F401
-from pvlib import tracking  # noqa: F401
-from pvlib import pvsystem  # noqa: F401
-from pvlib import spa  # noqa: F401
-from pvlib import modelchain  # noqa: F401
-from pvlib import singlediode  # noqa: F401
-from pvlib import bifacial  # noqa: F401
-from pvlib import soiling  # noqa: F401
-from pvlib import snow  # noqa: F401
-from pvlib import shading  # noqa: F401
-from pvlib import iam  # noqa: F401
-from pvlib import inverter  # noqa: F401
-from pvlib import scaling  # noqa: F401
-from pvlib import temperature # noqa: F401
+
+from pvlib import (  # noqa: F401
+    atmosphere,
+    bifacial,
+    clearsky,
+    # forecast
+    iam,
+    inverter,
+    iotools,
+    irradiance,
+    ivtools,
+    location,
+    modelchain,
+    pvsystem,
+    scaling,
+    shading,
+    singlediode,
+    snow,
+    soiling,
+    solarposition,
+    spa,
+    temperature,
+    tools,
+    tracking,
+)

--- a/pvlib/__init__.py
+++ b/pvlib/__init__.py
@@ -16,3 +16,8 @@ from pvlib import singlediode  # noqa: F401
 from pvlib import bifacial  # noqa: F401
 from pvlib import soiling  # noqa: F401
 from pvlib import snow  # noqa: F401
+from pvlib import shading  # noqa: F401
+from pvlib import iam  # noqa: F401
+from pvlib import inverter  # noqa: F401
+from pvlib import scaling  # noqa: F401
+from pvlib import temperature # noqa: F401


### PR DESCRIPTION
 - ~Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~Tests added~
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

`__init__.py` is missing several modules.  Some of the omissions don't make a practical difference, maybe because they get imported by other modules.   For `shading` and `scaling`, some import patterns fail:

```
$ python -c 'from pvlib import shading'  # works; this is how the test suite does it
$ python -c 'import pvlib; pvlib.shading'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'pvlib' has no attribute 'shading'
```

I think I got all the missing modules but another pair of eyes never hurts. 