### PR TITLE
add python 3.9 CI configurations

### DIFF
--- a/ci/azure/conda_linux.yml
+++ b/ci/azure/conda_linux.yml
@@ -18,6 +18,8 @@ jobs:
         python.version: '37'
       Python38:
         python.version: '38'
+      Python39:
+        python.version: '39'
 
   steps:
   - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"

--- a/ci/azure/conda_windows.yml
+++ b/ci/azure/conda_windows.yml
@@ -14,6 +14,8 @@ jobs:
         python.version: '37'
       Python38-windows:
         python.version: '38'
+      Python39-windows:
+        python.version: '39'
 
   steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -14,6 +14,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
 
   steps:
   - task: UsePythonVersion@0

--- a/ci/requirements-py39.yml
+++ b/ci/requirements-py39.yml
@@ -1,0 +1,31 @@
+name: test_env
+channels:
+    - defaults
+    - conda-forge
+dependencies:
+    - coveralls
+    - cython
+    - ephem
+    - netcdf4
+    - nose
+    - numba
+    - numpy >= 1.12.0
+    - pandas >= 0.22.0
+    - pip
+    - pytables  # tables when using pip+PyPI
+    - pytest
+    - pytest-cov
+    - pytest-mock
+    - pytest-timeout
+    - pytest-rerunfailures
+    - pytest-remotedata
+    - python=3.8
+    - pytz
+    - requests
+    - scipy >= 1.2.0
+    - shapely  # pvfactors dependency
+    - siphon  # conda-forge
+    - statsmodels
+    - pip:
+        - nrel-pysam>=2.0
+        - pvfactors==1.4.1

--- a/ci/requirements-py39.yml
+++ b/ci/requirements-py39.yml
@@ -6,9 +6,9 @@ dependencies:
     - coveralls
     - cython
     - ephem
-    - netcdf4
+    # - netcdf4
     - nose
-    - numba
+    # - numba
     - numpy >= 1.12.0
     - pandas >= 0.22.0
     - pip
@@ -19,12 +19,12 @@ dependencies:
     - pytest-timeout
     - pytest-rerunfailures
     - pytest-remotedata
-    - python=3.8
+    - python=3.9
     - pytz
     - requests
     - scipy >= 1.2.0
     - shapely  # pvfactors dependency
-    - siphon  # conda-forge
+    # - siphon  # conda-forge
     - statsmodels
     - pip:
         - nrel-pysam>=2.0

--- a/ci/requirements-py39.yml
+++ b/ci/requirements-py39.yml
@@ -6,9 +6,9 @@ dependencies:
     - coveralls
     - cython
     - ephem
-    # - netcdf4
+    # - netcdf4  # pulls in a different version of numpy with ImportError
     - nose
-    # - numba
+    # - numba  # python 3.9 compat in early 2021
     - numpy >= 1.12.0
     - pandas >= 0.22.0
     - pip
@@ -27,5 +27,5 @@ dependencies:
     # - siphon  # conda-forge
     - statsmodels
     - pip:
-        - nrel-pysam>=2.0
+        # - nrel-pysam>=2.0  # install error on windows
         - pvfactors==1.4.1

--- a/docs/sphinx/source/whatsnew/v0.8.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.1.rst
@@ -41,6 +41,7 @@ Testing
 ~~~~~~~
 * Add airspeed velocity performance testing configuration and a few benchmarks.
   (:issue:`419`, :pull:`1049`, :pull:`1059`)
+* Add Python 3.9 CI configurations. (:issue:`1102`, :pull:`1112`)
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
 - [x] Closes #1102 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

All of the base functionality works. Optional functionality that does not work:

- The `forecast.py` code needs `netcdf4`. As of now, `netcdf4` needs a different build of numpy than would otherwise be pulled by the environment solver. This build of numpy spits out an `ImportError` on my mac. 
- Numba is not yet compatible with 3.9. 
- pysam installation issue on windows. Maybe related to https://github.com/NREL/pysam/issues/56. The easiest way to deal with this is to comment out the pysam line in the environment file and thus skip it on all platforms. That's my preference.