### PR TITLE
Update test suite PVGIS copyright check for new year

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.8.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.8.1.rst
@@ -42,6 +42,8 @@ Testing
 * Add airspeed velocity performance testing configuration and a few benchmarks.
   (:issue:`419`, :pull:`1049`, :pull:`1059`)
 * Add Python 3.9 CI configurations. (:issue:`1102`, :pull:`1112`)
+* Update ``test_pvgis.py`` to be more flexible about the PVGIS copyright notice
+  (:pull:`1121`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/tests/iotools/test_pvgis.py
+++ b/pvlib/tests/iotools/test_pvgis.py
@@ -159,7 +159,8 @@ def _compare_pvgis_tmy_csv(expected, month_year_expected, inputs_expected,
     for meta_value in meta:
         if not meta_value:
             continue
-        if meta_value == 'PVGIS (c) European Communities, 2001-2020':
+        # don't check end year because it changes every year
+        if meta_value[:-4] == 'PVGIS (c) European Communities, 2001-':
             continue
         assert meta_value in csv_meta
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

---

The PVGIS tests check for a hard-coded copyright string:

https://github.com/pvlib/pvlib-python/blob/926d2f95bf45b33783741837dab9f4113de4de52/pvlib/tests/iotools/test_pvgis.py#L162

But the PVGIS API now returns an updated string that ends in `2021` instead of `2020` (see e.g. this [azure failure log](https://dev.azure.com/solararbiter/pvlib%20python/_build/results?buildId=4666&view=logs&j=e1592cb8-2816-5754-b393-3839a187d454&t=377c4fd6-97bd-5996-bc02-4d072a8786ea&l=327)).  I considered updating the string to 2021 so that we could have an annual tradition of updating it every January, but decided to be boring and just not check the last four characters in the string. 

Happy new year!
