### PR TITLE
Improve `make clean` to remove all generated files

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -48,6 +48,9 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf source/generated
+	rm -rf source/auto_examples
+	rm -rf source/savefig
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/sphinx/make.bat
+++ b/docs/sphinx/make.bat
@@ -12,6 +12,17 @@ set BUILDDIR=build
 
 if "%1" == "" goto help
 
+
+if "%1" == "clean" (
+    REM override the default `make clean` behavior of sphinx-build;
+    REM this lets us clean out the various build files in sphinx/source/
+	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
+	rmdir /q /s %SOURCEDIR%\generated >nul 2>&1
+	rmdir /q /s %SOURCEDIR%\auto_examples >nul 2>&1
+	rmdir /q /s %SOURCEDIR%\savefig >nul 2>&1
+	goto end
+)
+
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I am often annoyed by sphinx build artifacts persisting across builds and across branches and adding warning noise to the build logs.  `make clean` ought to be the solution, but it doesn't know about some of the generated directories so it doesn't do a full clean.  This adds the generated directories to the makefiles so that they get removed and `make clean` does a full clean. 
