### PR TITLE
Handle poa_global and effective_irradiance for cell temperature models

### DIFF
--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -918,6 +918,18 @@ def test_run_model_from_effective_irradiance(sapm_dc_snl_ac_system, location,
     assert_series_equal(ac, expected)
 
 
+def test_run_model_from_effective_irradiance_no_poa_global(
+        sapm_dc_snl_ac_system, location, weather, total_irrad):
+    data = weather.copy()
+    data['effective_irradiance'] = data['poa_global']
+    mc = ModelChain(sapm_dc_snl_ac_system, location, aoi_model='no_loss',
+                    spectral_model='no_loss')
+    ac = mc.run_model_from_effective_irradiance(data).results.ac
+    expected = pd.Series(np.array([149.280238, 96.678385]),
+                         index=data.index)
+    assert_series_equal(ac, expected)
+
+
 @pytest.mark.parametrize("input_type", [tuple, list])
 def test_run_model_from_effective_irradiance_arrays_error(
         sapm_dc_snl_ac_system_Array, location, weather, total_irrad,


### PR DESCRIPTION
 - [ ] Closes #1120 #1044
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

For the irradiance input to cell temperature models, uses 'poa_global' if available in `ModelChain.results.total_irrad`, if not, uses `ModelChain.results.effective_irradiance`
