### PR TITLE
add testpaths to setup.cfg pytest section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,4 @@ exclude = pvlib/_version.py docs dist
 
 [tool:pytest]
 junit_family=xunit2
+norecursedirs = benchmarks .git* dist pvlib.egg-info junit htmlcov paper ci .vscode .ipynb_checkpoints

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,4 @@ exclude = pvlib/_version.py docs dist
 
 [tool:pytest]
 junit_family=xunit2
-norecursedirs = benchmarks .git* dist pvlib.egg-info junit htmlcov paper ci .vscode .ipynb_checkpoints
+testpaths = pvlib/tests


### PR DESCRIPTION

 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.


I had been running into odd behavior with vscode no longer able to automatically discover pvlib tests and with strange errors when trying to run `pytest` from the root pvlib directory - sometimes I'd get numpy import errors in good environments and sometimes I'd see errors with old pvlib version numbers. But `pytest pvlib` worked just fine. It turns out that the presence of conda environments in `benchmarks/` led to bad numpy imports and the presence of old pvlib versions in `dist/` led to other issues. Adding these directories to the `setup.cfg` pytest section solved the issues, and I added a bunch of extra directories for safety.