### PR TITLE
Add scale_voltage_current_power to ModelChain.pvwatts_dc

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -84,8 +84,8 @@ Enhancements
   cell temperature models, when ``'poa_global'`` is not provided in input
   weather or calculated from input weather data.
 * :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` now scales the DC power
-  by `pvsystem.PVSystem.modules_per_strings` and
-  `pvsystem.PVSystem.strings_per_inverter`. Note that both attributes still
+  by ``pvsystem.PVSystem.modules_per_strings`` and
+  ``pvsystem.PVSystem.strings_per_inverter``. Note that both attributes still
   default to 1. (:pull:`1138`)
 
 Bug fixes

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -83,6 +83,10 @@ Enhancements
   automatically switch to using ``'effective_irradiance'`` (if available) for
   cell temperature models, when ``'poa_global'`` is not provided in input
   weather or calculated from input weather data.
+* :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` now scales the DC power
+  by `pvsystem.PVSystem.modules_per_strings` and
+  `pvsystem.PVSystem.strings_per_inverter`. Note that both attributes still
+  default to 1. (:pull:`XXXX`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -86,7 +86,7 @@ Enhancements
 * :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` now scales the DC power
   by `pvsystem.PVSystem.modules_per_strings` and
   `pvsystem.PVSystem.strings_per_inverter`. Note that both attributes still
-  default to 1. (:pull:`XXXX`)
+  default to 1. (:pull:`1138`)
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -752,14 +752,11 @@ class ModelChain:
                 pd.DataFrame(s, columns=['p_mp']) for s in self.results.dc)
         else:
             temp = pd.DataFrame(self.results.dc, columns=['p_mp'])
-        scaled = self.system.scale_voltage_current_power(
-            temp,
-            unwrap=False
-        )
+        scaled = self.system.scale_voltage_current_power(temp)
         if isinstance(scaled, tuple):
-            self.results.dc = tuple(pd.Series(s) for s in scaled)
+            self.results.dc = tuple(s['p_mp'] for s in scaled)
         else:
-            self.results.dc = pd.Series(scaled)
+            self.results.dc = scaled['p_mp']
         return self
 
     @property

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -730,8 +730,27 @@ class ModelChain:
         return self._singlediode(self.system.calcparams_pvsyst)
 
     def pvwatts_dc(self):
+        """Calculate DC power using the PVWatts model.
+
+        Results are stored in ModelChain.results.dc. DC power is computed
+        from PVSystem.module_parameters['pdc0'] and then scaled by
+        PVSystem.modules_per_string and PVSystem.strings_per_inverter.
+
+        Returns
+        -------
+        self
+
+        See also
+        --------
+        pvlib.pvsystem.PVSystem.pvwatts_dc
+        pvlib.pvsystem.PVSystem.scale_voltage_current_power
+        """
         self.results.dc = self.system.pvwatts_dc(
             self.results.effective_irradiance, self.results.cell_temperature)
+        self.results.dc = self.system.scale_voltage_current_power(
+            self.results.dc,
+            unwrap=False
+        )
         return self
 
     @property

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -747,10 +747,19 @@ class ModelChain:
         """
         self.results.dc = self.system.pvwatts_dc(
             self.results.effective_irradiance, self.results.cell_temperature)
-        self.results.dc = self.system.scale_voltage_current_power(
-            self.results.dc,
+        if isinstance(self.results.dc, tuple):
+            temp = tuple(
+                pd.DataFrame(s, columns=['p_mp']) for s in self.results.dc)
+        else:
+            temp = pd.DataFrame(self.results.dc, columns=['p_mp'])
+        scaled = self.system.scale_voltage_current_power(
+            temp,
             unwrap=False
         )
+        if isinstance(scaled, tuple):
+            self.results.dc = tuple(pd.Series(s) for s in scaled)
+        else:
+            self.results.dc = pd.Series(scaled)
         return self
 
     @property

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2626,14 +2626,15 @@ def i_from_v(resistance_shunt, resistance_series, nNsVth, voltage,
 
 def scale_voltage_current_power(data, voltage=1, current=1):
     """
-    Scales the voltage, current, and power of the DataFrames
-    returned by :py:func:`singlediode` and :py:func:`sapm`.
+    Scales the voltage, current, and power in data by the voltage
+    and current factors.
 
     Parameters
     ----------
-    data: DataFrame
-        Must contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
-        'i_sc', 'p_mp'`.
+    data: DataFrame or Series
+        May contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
+        'i_sc', 'p_mp'`. If Series, the content must be indicated using
+        one of these keys as the Series name.
     voltage: numeric, default 1
         The amount by which to multiply the voltages.
     current: numeric, default 1
@@ -2641,20 +2642,31 @@ def scale_voltage_current_power(data, voltage=1, current=1):
 
     Returns
     -------
-    scaled_data: DataFrame
+    scaled_data: DataFrame or Series
         A scaled copy of the input data.
         `'p_mp'` is scaled by `voltage * current`.
     """
 
     # as written, only works with a DataFrame
     # could make it work with a dict, but it would be more verbose
+    voltage_keys = ['v_mp', 'v_oc']
+    current_keys = ['i_mp', 'i_x', 'i_xx', 'i_sc']
+    power_keys = ['p_mp']
     data = data.copy()
-    voltages = ['v_mp', 'v_oc']
-    currents = ['i_mp', 'i_x', 'i_xx', 'i_sc']
-    data[voltages] *= voltage
-    data[currents] *= current
-    data['p_mp'] *= voltage * current
-
+    if isinstance(data, pd.DataFrame):
+        voltages = voltage_keys and data.columns
+        currents = current_keys and data.columns
+        powers = power_keys and data.columns
+        data[voltages] *= voltage
+        data[currents] *= current
+        data[powers] *= voltage * current
+    else:
+        if data.name in voltage_keys:
+            data *= voltage
+        elif data.name in current_keys:
+            data *= current
+        elif data.name in power_keys:
+            data *= voltage * current
     return data
 
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -891,7 +891,7 @@ class PVSystem:
         Parameters
         ----------
         data: DataFrame or tuple of DataFrame
-            Must contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
+            May contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
             'i_sc', 'p_mp'`.
 
         Returns
@@ -2631,10 +2631,9 @@ def scale_voltage_current_power(data, voltage=1, current=1):
 
     Parameters
     ----------
-    data: DataFrame or Series
+    data: DataFrame
         May contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
-        'i_sc', 'p_mp'`. If Series, the content must be indicated using
-        one of these keys as the Series name.
+        'i_sc', 'p_mp'`.
     voltage: numeric, default 1
         The amount by which to multiply the voltages.
     current: numeric, default 1
@@ -2642,7 +2641,7 @@ def scale_voltage_current_power(data, voltage=1, current=1):
 
     Returns
     -------
-    scaled_data: DataFrame or Series
+    scaled_data: DataFrame
         A scaled copy of the input data.
         `'p_mp'` is scaled by `voltage * current`.
     """
@@ -2653,20 +2652,12 @@ def scale_voltage_current_power(data, voltage=1, current=1):
     current_keys = ['i_mp', 'i_x', 'i_xx', 'i_sc']
     power_keys = ['p_mp']
     data = data.copy()
-    if isinstance(data, pd.DataFrame):
-        voltages = voltage_keys and data.columns
-        currents = current_keys and data.columns
-        powers = power_keys and data.columns
-        data[voltages] *= voltage
-        data[currents] *= current
-        data[powers] *= voltage * current
-    else:
-        if data.name in voltage_keys:
-            data *= voltage
-        elif data.name in current_keys:
-            data *= current
-        elif data.name in power_keys:
-            data *= voltage * current
+    voltages = voltage_keys and data.columns
+    currents = current_keys and data.columns
+    powers = power_keys and data.columns
+    data[voltages] *= voltage
+    data[currents] *= current
+    data[powers] *= voltage * current
     return data
 
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2654,7 +2654,9 @@ def scale_voltage_current_power(data, voltage=1, current=1):
     voltage_df = data.filter(voltage_keys, axis=1) * voltage
     current_df = data.filter(current_keys, axis=1) * current
     power_df = data.filter(power_keys, axis=1) * voltage * current
-    return pd.concat([voltage_df, current_df, power_df], axis=1)
+    df = pd.concat([voltage_df, current_df, power_df], axis=1)
+    df_sorted = df[data.columns]  # retain original column order
+    return df_sorted
 
 
 def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2675,20 +2675,20 @@ def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
     Parameters
     ----------
     g_poa_effective: numeric
-        Irradiance transmitted to the PV cells in units of W/m**2. To be
+        Irradiance transmitted to the PV cells. To be
         fully consistent with PVWatts, the user must have already
         applied angle of incidence losses, but not soiling, spectral,
-        etc.
+        etc. [W/m^2]
     temp_cell: numeric
-        Cell temperature in degrees C.
+        Cell temperature [C].
     pdc0: numeric
-        Power of the modules at 1000 W/m2 and cell reference temperature.
+        Power of the modules at 1000 W/m^2 and cell reference temperature. [W]
     gamma_pdc: numeric
-        The temperature coefficient in units of 1/C. Typically -0.002 to
-        -0.005 per degree C.
+        The temperature coefficient of power. Typically -0.002 to
+        -0.005 per degree C. [1/C]
     temp_ref: numeric, default 25.0
         Cell reference temperature. PVWatts defines it to be 25 C and
-        is included here for flexibility.
+        is included here for flexibility. [C]
 
     Returns
     -------

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2651,11 +2651,10 @@ def scale_voltage_current_power(data, voltage=1, current=1):
     voltage_keys = ['v_mp', 'v_oc']
     current_keys = ['i_mp', 'i_x', 'i_xx', 'i_sc']
     power_keys = ['p_mp']
-    data = data.copy()
-    data.filter(voltage_keys, axis=1) * voltage
-    data.filter(current_keys, axis=1) * current
-    data.filter(power_keys, axis=1) * voltage * current
-    return data
+    voltage_df = data.filter(voltage_keys, axis=1) * voltage
+    current_df = data.filter(current_keys, axis=1) * current
+    power_df = data.filter(power_keys, axis=1) * voltage * current
+    return pd.concat([voltage_df, current_df, power_df], axis=1)
 
 
 def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2652,12 +2652,9 @@ def scale_voltage_current_power(data, voltage=1, current=1):
     current_keys = ['i_mp', 'i_x', 'i_xx', 'i_sc']
     power_keys = ['p_mp']
     data = data.copy()
-    voltages = voltage_keys and data.columns
-    currents = current_keys and data.columns
-    powers = power_keys and data.columns
-    data[voltages] *= voltage
-    data[currents] *= current
-    data[powers] *= voltage * current
+    data.filter(voltage_keys, axis=1) * voltage
+    data.filter(current_keys, axis=1) * current
+    data.filter(power_keys, axis=1) * voltage * current
     return data
 
 

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1194,7 +1194,9 @@ def test_pvwatts_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
     mc2.run_model(weather)
     assert isinstance(mc2.results.ac, (pd.Series, pd.DataFrame))
     assert not mc2.results.ac.empty
-    assert np.all(np.isclose(mc2.results.dc / mc1.results.dc, 2.0))
+    expected = pd.Series(data=[2., np.nan], index=mc2.results.dc.index,
+                         name='p_mp')
+    assert_series_equal(mc2.results.dc / mc1.results.dc, expected)
 
 
 def acdc(mc):

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1182,16 +1182,16 @@ def test_dc_model_user_func(pvwatts_dc_pvwatts_ac_system, location, weather,
 
 def test_pvwatts_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
                                      weather, mocker):
-    system = pvwatts_dc_pvwatts_ac_system.copy()
-    system.modules_per_string = 2
+    system = pvwatts_dc_pvwatts_ac_system
     m = mocker.spy(system, 'scale_voltage_current_power')
-    mc1 = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+    mc1 = ModelChain(system, location,
                      aoi_model='no_loss', spectral_model='no_loss')
     mc1.run_model(weather)
+    assert m.call_count == 1
+    system.modules_per_string = 2
     mc2 = ModelChain(system, location,
                      aoi_model='no_loss', spectral_model='no_loss')
     mc2.run_model(weather)
-    assert m.call_count == 1
     assert isinstance(mc2.results.ac, (pd.Series, pd.DataFrame))
     assert not mc2.results.ac.empty
     assert np.isclose(mc2.results.dc / mc1.results.dc, 2.0)

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1180,6 +1180,23 @@ def test_dc_model_user_func(pvwatts_dc_pvwatts_ac_system, location, weather,
     assert not mc.results.ac.empty
 
 
+def test_pvwatts_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
+                                     weather, mocker):
+    system = pvwatts_dc_pvwatts_ac_system.copy()
+    system.modules_per_string = 2
+    m = mocker.spy(system, 'scale_voltage_current_power')
+    mc1 = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                     aoi_model='no_loss', spectral_model='no_loss')
+    mc1.run_model(weather)
+    mc2 = ModelChain(system, location,
+                     aoi_model='no_loss', spectral_model='no_loss')
+    mc2.run_model(weather)
+    assert m.call_count == 1
+    assert isinstance(mc2.results.ac, (pd.Series, pd.DataFrame))
+    assert not mc2.results.ac.empty
+    assert np.isclose(mc2.results.dc / mc1.results.dc, 2.0)
+
+
 def acdc(mc):
     mc.results.ac = mc.results.dc
 

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1188,13 +1188,13 @@ def test_pvwatts_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
                      aoi_model='no_loss', spectral_model='no_loss')
     mc1.run_model(weather)
     assert m.call_count == 1
-    system.modules_per_string = 2
+    system.arrays[0].modules_per_string = 2
     mc2 = ModelChain(system, location,
                      aoi_model='no_loss', spectral_model='no_loss')
     mc2.run_model(weather)
     assert isinstance(mc2.results.ac, (pd.Series, pd.DataFrame))
     assert not mc2.results.ac.empty
-    assert np.isclose(mc2.results.dc / mc1.results.dc, 2.0)
+    assert np.all(np.isclose(mc2.results.dc / mc1.results.dc, 2.0))
 
 
 def acdc(mc):


### PR DESCRIPTION
 - [x] Closes #476 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Adds scaling by modules per string and strings per inverter to the ModelChain.pvwatts_dc method. This behavior parallels ModelChain.sapm and ModelChain.singlediode. User code is not likely to be affected since PVSystem.modules_per_strings and PVSystem.strings_per_inverter both default to 1.