### PR TITLE
refactor ModelChain._prep_inputs_solar_pos for wx in poa solpos

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -92,7 +92,7 @@ Bug fixes
 ~~~~~~~~~
 * Pass weather data to solar position calculations in
   :ref:meth:`~pvlib.modelchain.ModelChain.prepare_inputs_from_poa`.
-  (:issue:`1065`, :pull:``)
+  (:issue:`1065`, :pull:`1140`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -90,6 +90,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Pass weather data to solar position calculations in
+  :ref:meth:`~pvlib.modelchain.ModelChain.prepare_inputs_from_poa`.
+  (:issue:`1065`, :pull:``)
 
 Testing
 ~~~~~~~

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1210,10 +1210,19 @@ class ModelChain:
                 weather.ghi - weather.dni *
                 tools.cosd(self.results.solar_position.zenith))
 
-    def _prep_inputs_solar_pos(self, kwargs={}):
+    def _prep_inputs_solar_pos(self, weather):
         """
         Assign solar position
         """
+        # build weather kwargs for solar position calculation
+        kwargs = _build_kwargs(['pressure', 'temp_air'],
+                               weather[0] if isinstance(weather, tuple)
+                               else weather)
+        try:
+            kwargs['temperature'] = kwargs.pop('temp_air')
+        except KeyError:
+            pass
+
         self.results.solar_position = self.location.get_solarposition(
             self.times, method=self.solar_position_method,
             **kwargs)
@@ -1363,16 +1372,7 @@ class ModelChain:
         self._assign_weather(weather)
         self._assign_times()
 
-        # build kwargs for solar position calculation
-        try:
-            press_temp = _build_kwargs(['pressure', 'temp_air'],
-                                       weather[0] if isinstance(weather, tuple)
-                                       else weather)
-            press_temp['temperature'] = press_temp.pop('temp_air')
-        except KeyError:
-            pass
-
-        self._prep_inputs_solar_pos(press_temp)
+        self._prep_inputs_solar_pos(weather)
         self._prep_inputs_airmass()
 
         # PVSystem.get_irradiance and SingleAxisTracker.get_irradiance
@@ -1470,7 +1470,7 @@ class ModelChain:
                                         'poa_diffuse'])
         self._assign_total_irrad(data)
 
-        self._prep_inputs_solar_pos()
+        self._prep_inputs_solar_pos(data)
         self._prep_inputs_airmass()
 
         if isinstance(self.system, SingleAxisTracker):

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -896,8 +896,8 @@ def test_run_model_solar_position_weather(
     mc.run_model(weather)
     # assert_called_once_with cannot be used with series, so need to use
     # assert_series_equal on call_args
-    assert_series_equal(m.call_args.kwargs['temperature'], weather['temp_air'])
-    assert_series_equal(m.call_args.kwargs['pressure'], weather['pressure'])
+    assert_series_equal(m.call_args[1]['temperature'], weather['temp_air'])
+    assert_series_equal(m.call_args[1]['pressure'], weather['pressure'])
 
 
 def test_run_model_from_poa(sapm_dc_snl_ac_system, location, total_irrad):
@@ -937,8 +937,8 @@ def test_run_model_from_poa_arrays_solar_position_weather(
     m = mocker.spy(location, 'get_solarposition')
     mc.run_model_from_poa((data, data2))
     # mc uses only the first weather data for solar position corrections
-    assert_series_equal(m.call_args.kwargs['temperature'], data['temp_air'])
-    assert_series_equal(m.call_args.kwargs['pressure'], data['pressure'])
+    assert_series_equal(m.call_args[1]['temperature'], data['temp_air'])
+    assert_series_equal(m.call_args[1]['pressure'], data['pressure'])
 
 
 def test_run_model_from_poa_tracking(sapm_dc_snl_ac_system, location,

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -886,6 +886,20 @@ def test_temperature_models_arrays_multi_weather(
             != mc.results.cell_temperature[1]).all()
 
 
+def test_run_model_solar_position_weather(
+        pvwatts_dc_pvwatts_ac_system, location, weather, mocker):
+    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                    aoi_model='no_loss', spectral_model='no_loss')
+    weather['pressure'] = 90000
+    weather['temp_air'] = 25
+    m = mocker.spy(location, 'get_solarposition')
+    mc.run_model(weather)
+    # assert_called_once_with cannot be used with series, so need to use
+    # assert_series_equal on call_args
+    assert_series_equal(m.call_args.kwargs['temperature'], weather['temp_air'])
+    assert_series_equal(m.call_args.kwargs['pressure'], weather['pressure'])
+
+
 def test_run_model_from_poa(sapm_dc_snl_ac_system, location, total_irrad):
     mc = ModelChain(sapm_dc_snl_ac_system, location, aoi_model='no_loss',
                     spectral_model='no_loss')
@@ -907,6 +921,24 @@ def test_run_model_from_poa_arrays(sapm_dc_snl_ac_system_Array, location,
     # because we are the same passing POA irradiance and air
     # temperature.
     assert_frame_equal(mc.results.dc[0], mc.results.dc[1])
+
+
+def test_run_model_from_poa_arrays_solar_position_weather(
+        sapm_dc_snl_ac_system_Array, location, weather, total_irrad, mocker):
+    data = weather.copy()
+    data[['poa_global', 'poa_diffuse', 'poa_direct']] = total_irrad
+    data['pressure'] = 90000
+    data['temp_air'] = 25
+    data2 = data.copy()
+    data2['pressure'] = 95000
+    data2['temp_air'] = 30
+    mc = ModelChain(sapm_dc_snl_ac_system_Array, location, aoi_model='no_loss',
+                    spectral_model='no_loss')
+    m = mocker.spy(location, 'get_solarposition')
+    mc.run_model_from_poa((data, data2))
+    # mc uses only the first weather data for solar position corrections
+    assert_series_equal(m.call_args.kwargs['temperature'], data['temp_air'])
+    assert_series_equal(m.call_args.kwargs['pressure'], data['pressure'])
 
 
 def test_run_model_from_poa_tracking(sapm_dc_snl_ac_system, location,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1065
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Also addresses style issue raised in #1135.

#1113 is also relevant to this PR because we'd end up explicitly passing the temperature data rather than optionally bundling it in kwargs.