### PR TITLE
add SingleAxisArray. Array to BaseArray, FixedTiltArray

### DIFF
--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1546,7 +1546,7 @@ class SingleAxisArray(BaseArray):
                  'cross_axis_tilt']
         return self._extend_repr('SingleAxisArray', attrs)
 
-    def _singleaxis(self, apparent_zenith, apparent_azimuth):
+    def singleaxis(self, apparent_zenith, apparent_azimuth):
         """
         Get tracking data. See :py:func:`pvlib.tracking.singleaxis` more
         detail.
@@ -1587,7 +1587,7 @@ class SingleAxisArray(BaseArray):
         aoi : Series
             Then angle of incidence.
         """
-        tracking = self._singleaxis(solar_zenith, solar_azimuth)
+        tracking = self.singleaxis(solar_zenith, solar_azimuth)
         return tracking['aoi']
 
     def get_irradiance(self, solar_zenith, solar_azimuth, dni, ghi, dhi,
@@ -1636,7 +1636,7 @@ class SingleAxisArray(BaseArray):
         if airmass is None:
             airmass = atmosphere.get_relative_airmass(solar_zenith)
 
-        tracking = self._singleaxis(solar_zenith, solar_azimuth)
+        tracking = self.singleaxis(solar_zenith, solar_azimuth)
 
         return irradiance.get_total_irradiance(
             tracking['surface_tilt'],

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -15,7 +15,7 @@ import pandas as pd
 from pvlib._deprecation import deprecated
 
 from pvlib import (atmosphere, iam, inverter, irradiance,
-                   singlediode as _singlediode, temperature, tracking)
+                   singlediode as _singlediode, temperature, tools)
 from pvlib.tools import _build_kwargs
 from pvlib._deprecation import pvlibDeprecationWarning
 
@@ -1129,14 +1129,12 @@ class BaseArray:
 
         self.name = name
 
-    def __repr__(self):
+    def __repr__(self, name='BaseArray'):
         attrs = ['name', 'module',
                  'albedo', 'racking_model', 'module_type',
                  'temperature_model_parameters',
                  'strings', 'modules_per_string']
-        return 'BaseArray:\n  ' + '\n  '.join(
-            f'{attr}: {getattr(self, attr)}' for attr in attrs
-        )
+        return tools.repr(self, attrs, name=name, level=1)
 
     def _extend_repr(self, name, attributes):
         """refactor into non-cringy super() gymnastics"""
@@ -1321,7 +1319,7 @@ class FixedTiltArray(BaseArray):
         racking_model=None,
         name=None
     ):
-
+        self.name = name
         self.surface_tilt = surface_tilt
         self.surface_azimuth = surface_azimuth
 
@@ -1339,8 +1337,10 @@ class FixedTiltArray(BaseArray):
         )
 
     def __repr__(self):
-        attrs = ['surface_tilt', 'surface_azimuth']
-        return self._extend_repr('FixedTiltArray', attrs)
+        parent_repr = super().__repr__(name='FixedArray')
+        attrs = ['name', 'surface_tilt', 'surface_azimuth']
+        this_repr = tools.repr(self, attrs, level=1)
+        return parent_repr + '\n' + this_repr
 
     def get_aoi(self, solar_zenith, solar_azimuth):
         """
@@ -1521,6 +1521,7 @@ class SingleAxisArray(BaseArray):
         name=None
     ):
 
+        self.name = name
         self.axis_tilt = axis_tilt
         self.axis_azimuth = axis_azimuth
         self.max_angle = max_angle
@@ -1542,9 +1543,11 @@ class SingleAxisArray(BaseArray):
         )
 
     def __repr__(self):
-        attrs = ['axis_tilt', 'axis_azimuth', 'max_angle', 'backtrack', 'gcr',
-                 'cross_axis_tilt']
-        return self._extend_repr('SingleAxisArray', attrs)
+        parent_repr = super().__repr__(name='SingleAxisArray')
+        attrs = ['name', 'axis_tilt', 'axis_azimuth', 'max_angle', 'backtrack',
+                 'gcr', 'cross_axis_tilt']
+        this_repr = tools.repr(self, attrs, level=1)
+        return parent_repr + '\n' + this_repr
 
     def singleaxis(self, apparent_zenith, apparent_azimuth):
         """
@@ -1563,6 +1566,7 @@ class SingleAxisArray(BaseArray):
         -------
         tracking data
         """
+        from pvlib import tracking
         tracking_data = tracking.singleaxis(
             apparent_zenith, apparent_azimuth,
             self.axis_tilt, self.axis_azimuth,

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1588,12 +1588,7 @@ class SingleAxisArray(BaseArray):
             Then angle of incidence.
         """
         tracking = self._singleaxis(solar_zenith, solar_azimuth)
-        return irradiance.aoi(
-            tracking['surface_tilt'],
-            tracking['surface_azimuth'],
-            solar_zenith,
-            solar_azimuth
-        )
+        return tracking['aoi']
 
     def get_irradiance(self, solar_zenith, solar_azimuth, dni, ghi, dhi,
                        dni_extra=None, airmass=None, model='haydavies',

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -318,3 +318,15 @@ def _golden_sect_DataFrame(params, VL, VH, func):
             raise Exception("EXCEPTION:iterations exceeded maximum (50)")
 
     return func(df, 'V1'), df['V1']
+
+
+def repr(obj, attributes, name=None, level=1):
+    if name is not None:
+        prefix = ' ' * (level - 1)
+        this_repr = f'{prefix}{name}:\n'
+    else:
+        this_repr = ''
+    indent = ' ' * level
+    this_repr += '\n'.join(
+        f'{indent}{attr}: {getattr(obj, attr)}' for attr in attributes)
+    return this_repr

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -6,6 +6,7 @@ from pvlib.pvsystem import PVSystem
 from pvlib import irradiance, atmosphere
 
 
+# add deprecation warning?
 class SingleAxisTracker(PVSystem):
     """
     A class for single-axis trackers that inherits the PV modeling methods from
@@ -75,7 +76,6 @@ class SingleAxisTracker(PVSystem):
 
     def __init__(self, axis_tilt=0, axis_azimuth=0, max_angle=90,
                  backtrack=True, gcr=2.0/7.0, cross_axis_tilt=0.0, **kwargs):
-
         arrays = kwargs.get('arrays', [])
         if len(arrays) > 1:
             raise ValueError("SingleAxisTracker does not support "


### PR DESCRIPTION
 - [x] Closes #1109
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Initial implementation of the ideas first discussed in https://github.com/pvlib/pvlib-python/pull/1076#discussion_r539704316 and #1109. I'm looking for feedback on this approach before integrating it with ModelChain. Also fine to discard it if we decide it's not the right approach or the right time for it.

As first discussed in the linked issues, this pattern leads to repeated calls to `tracking.singleaxis`: one call to get AOI and another to get POA irradiance. Add yet another call if you want to save the actual tracking data like we do in `ModelChainResults`. We could get around the repeated calls by adding a `tracking_data=None` kwarg to the methods (`if tracking_data is None: tracking_data = self.singleaxis()`). That wouldn't be horrible, but it also doesn't look great to me. In principle we could add a cache to `SingleAxisArray`, but I'd rather leave that to other libraries to do right.