### PR TITLE
Implement PVSystem.get_ac

### DIFF
--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -292,6 +292,7 @@ Inverter models (DC to AC conversion)
 .. autosummary::
    :toctree: generated/
 
+   pvsystem.PVSystem.get_ac
    inverter.sandia
    inverter.sandia_multi
    inverter.adr

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -56,6 +56,15 @@ Deprecations
   * ``ModelChain.total_irrad``
   * ``ModelChain.tracking``
 
+* The following ``PVSystem`` methods are deprecated. Use ``PVsystem.get_ac``
+  instead.
+  * ``PVSystem.snlinverter``
+  * ``PVSystem.sandia_multi``
+  * ``PVSystem.adrinverter``
+  * ``PVSystem.pvwatts``
+  * ``PVSystem.pvwatts_multi``
+
+
 Enhancements
 ~~~~~~~~~~~~
 * In :py:class:`~pvlib.modelchain.ModelChain`, attributes which contain
@@ -87,6 +96,9 @@ Enhancements
   by ``pvsystem.PVSystem.modules_per_strings`` and
   ``pvsystem.PVSystem.strings_per_inverter``. Note that both attributes still
   default to 1. (:pull:`1138`)
+* :py:meth:`~pvlib.pvsystem.PVSystem.get_ac` is added to calculate AC power
+  from DC power. Use parameter 'model' to specify which inverter model to use.
+  (:pull:`1147`, :issue:`998`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -56,15 +56,6 @@ Deprecations
   * ``ModelChain.total_irrad``
   * ``ModelChain.tracking``
 
-* The following ``PVSystem`` methods are deprecated. Use ``PVsystem.get_ac``
-  instead.
-  * ``PVSystem.snlinverter``
-  * ``PVSystem.sandia_multi``
-  * ``PVSystem.adrinverter``
-  * ``PVSystem.pvwatts``
-  * ``PVSystem.pvwatts_multi``
-
-
 Enhancements
 ~~~~~~~~~~~~
 * In :py:class:`~pvlib.modelchain.ModelChain`, attributes which contain

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -852,7 +852,6 @@ class PVSystem:
         return i_from_v(resistance_shunt, resistance_series, nNsVth, voltage,
                         saturation_current, photocurrent)
 
-    @_unwrap_single_value
     def get_ac(self, model, p_dc, v_dc=None):
         r"""Calculates AC power from p_dc using the inverter model indicated
         by model and self.inverter_parameters.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -907,7 +907,7 @@ class PVSystem:
                 inv_fun = inverter.pvwatts
             return inv_fun(p_dc, self.inverter_parameters['pdc0'], **kwargs)
         elif model == 'adr':
-            return inverter.adrinverter(v_dc, p_dc, self.inverter_parameters)
+            return inverter.adr(v_dc, p_dc, self.inverter_parameters)
         else:
             raise ValueError(
                 model + ' is not a valid AC power model.',

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -922,28 +922,33 @@ class PVSystem:
                 ' model must be one of "sandia", "adr" or "pvwatts"')
 
     def snlinverter(self, v_dc, p_dc):
+        """Uses :py:func:`pvlib.inverter.sandia` to calculate AC power based on
+        ``self.inverter_parameters`` and the input voltage and power.
+
+        See :py:func:`pvlib.inverter.sandia` for details
         """
-        Deprecated. Use ``PVSystem.get_ac`` instead.
-        """
-        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
-                      ' removed in v0.10. Use PVSystem.get_ac instead')
-        return self.get_ac('sandia', p_dc, v_dc)
+        return inverter.sandia(v_dc, p_dc, self.inverter_parameters)
 
     def sandia_multi(self, v_dc, p_dc):
+        """Uses :py:func:`pvlib.inverter.sandia_multi` to calculate AC power
+        based on ``self.inverter_parameters`` and the input voltage and power.
+
+        The parameters `v_dc` and `p_dc` must be tuples with length equal to
+        ``self.num_arrays`` if the system has more than one array.
+
+        See :py:func:`pvlib.inverter.sandia_multi` for details.
         """
-        Deprecated. Use ``PVSystem.get_ac`` instead.
-        """
-        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
-                      ' removed in v0.10. Use PVSystem.get_ac instead')
-        return self.get_ac('sandia', p_dc, v_dc)
+        v_dc = self._validate_per_array(v_dc)
+        p_dc = self._validate_per_array(p_dc)
+        return inverter.sandia_multi(v_dc, p_dc, self.inverter_parameters)
 
     def adrinverter(self, v_dc, p_dc):
+        """Uses :py:func:`pvlib.inverter.adr` to calculate AC power based on
+        ``self.inverter_parameters`` and the input voltage and power.
+
+        See :py:func:`pvlib.inverter.adr` for details
         """
-        Deprecated. Use ``PVSystem.get_ac`` instead.
-        """
-        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
-                      ' removed in v0.10. Use PVSystem.get_ac instead')
-        return self.get_ac('adr', p_dc, v_dc)
+        return inverter.adr(v_dc, p_dc, self.inverter_parameters)
 
     @_unwrap_single_value
     def scale_voltage_current_power(self, data):
@@ -1006,20 +1011,32 @@ class PVSystem:
 
     def pvwatts_ac(self, pdc):
         """
-        Deprecated. Use ``PVSystem.get_ac`` instead.
+        Calculates AC power according to the PVWatts model using
+        :py:func:`pvlib.inverter.pvwatts`, `self.module_parameters["pdc0"]`,
+        and `eta_inv_nom=self.inverter_parameters["eta_inv_nom"]`.
+
+        See :py:func:`pvlib.inverter.pvwatts` for details.
         """
-        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
-                      ' removed in v0.10. Use PVSystem.get_ac instead')
-        return self.get_ac('pvwatts', pdc)
+        kwargs = _build_kwargs(['eta_inv_nom', 'eta_inv_ref'],
+                               self.inverter_parameters)
+
+        return inverter.pvwatts(pdc, self.inverter_parameters['pdc0'],
+                                **kwargs)
 
     def pvwatts_multi(self, p_dc):
-        """
-        Deprecated. Use ``PVSystem.get_ac`` instead.
-        """
-        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
-                      ' removed in v0.10. Use PVSystem.get_ac instead')
-        return self.get_ac('pvwatts', p_dc)
+        """Uses :py:func:`pvlib.inverter.pvwatts_multi` to calculate AC power
+        based on ``self.inverter_parameters`` and the input voltage and power.
 
+        The parameter `p_dc` must be a tuple with length equal to
+        ``self.num_arrays`` if the system has more than one array.
+
+        See :py:func:`pvlib.inverter.pvwatts_multi` for details.
+        """
+        p_dc = self._validate_per_array(p_dc)
+        kwargs = _build_kwargs(['eta_inv_nom', 'eta_inv_ref'],
+                               self.inverter_parameters)
+        return inverter.pvwatts_multi(p_dc, self.inverter_parameters['pdc0'],
+                                      **kwargs)
     @property
     @_unwrap_single_value
     def module_parameters(self):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -856,10 +856,37 @@ class PVSystem:
         r"""Calculates AC power from p_dc using the inverter model indicated
         by model and self.inverter_parameters.
 
-        Parameter model must be one of 'sandia', 'adr', or 'pvwatts'.
+        Parameters
+        ----------
+        model : str
+            Must be one of 'sandia', 'adr', or 'pvwatts'.
+        p_dc : numeric, or tuple, list or array of numeric
+            DC power on each MPPT input of the inverter. Use tuple, list or
+            array for inverters with multiple MPPT inputs. If type is array,
+            p_dc must be 2d with axis 0 being the MPPT inputs. [W]
+        v_dc : numeric, or tuple, list or array of numeric
+            DC voltage on each MPPT input of the inverter. Required when
+            model='sandia' or model='adr'. Use tuple, list or
+            array for inverters with multiple MPPT inputs. If type is array,
+            v_dc must be 2d with axis 0 being the MPPT inputs. [V]
 
-        Parameter v_dc is required for model='sandia' or model='adr'.
+        Returns
+        -------
+        power_ac : numeric, or tuple of numeric
+            AC power output for the inverter. [W]
 
+        Raises
+        ------
+        ValueError
+            If model is not one of 'sandia', 'adr' or 'pvwatts'.
+
+        See also
+        --------
+        pvlib.inverter.sandia
+        pvlib.inverter.sandia_multi
+        pvlib.inverter.adr
+        pvlib.inverter.pvwatts
+        pvlib.inverter.pvwatts_multi
         """
         model = model.lower()
         if model == 'sandia':

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -872,7 +872,7 @@ class PVSystem:
 
         Returns
         -------
-        power_ac : numeric, or tuple of numeric
+        power_ac : numeric
             AC power output for the inverter. [W]
 
         Raises
@@ -891,9 +891,9 @@ class PVSystem:
         pvlib.inverter.pvwatts_multi
         """
         model = model.lower()
-        mulitple_arrays = self.num_arrays > 1
+        multiple_arrays = self.num_arrays > 1
         if model == 'sandia':
-            if mulitple_arrays:
+            if multiple_arrays:
                 p_dc = self._validate_per_array(p_dc)
                 v_dc = self._validate_per_array(v_dc)
                 inv_fun = inverter.sandia_multi
@@ -903,17 +903,17 @@ class PVSystem:
         elif model == 'pvwatts':
             kwargs = _build_kwargs(['eta_inv_nom', 'eta_inv_ref'],
                                    self.inverter_parameters)
-            if mulitple_arrays:
+            if multiple_arrays:
                 p_dc = self._validate_per_array(p_dc)
                 inv_fun = inverter.pvwatts_multi
             else:
                 inv_fun = inverter.pvwatts
             return inv_fun(p_dc, self.inverter_parameters['pdc0'], **kwargs)
         elif model == 'adr':
-            if mulitple_arrays:
+            if multiple_arrays:
                 raise ValueError(
                     'The adr inverter function cannot be used for an inverter',
-                    'with multiple MPPT inputs')
+                    ' with multiple MPPT inputs')
             else:
                 return inverter.adr(v_dc, p_dc, self.inverter_parameters)
         else:
@@ -921,35 +921,29 @@ class PVSystem:
                 model + ' is not a valid AC power model.',
                 ' model must be one of "sandia", "adr" or "pvwatts"')
 
-    # inverter now specified by self.inverter_parameters
     def snlinverter(self, v_dc, p_dc):
-        """Uses :py:func:`pvlib.inverter.sandia` to calculate AC power based on
-        ``self.inverter_parameters`` and the input voltage and power.
-
-        See :py:func:`pvlib.inverter.sandia` for details
         """
-        return inverter.sandia(v_dc, p_dc, self.inverter_parameters)
+        Deprecated. Use ``PVSystem.get_ac`` instead.
+        """
+        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
+                      ' removed in v0.10. Use PVSystem.get_ac instead')
+        return self.get_ac('sandia', p_dc, v_dc)
 
     def sandia_multi(self, v_dc, p_dc):
-        """Uses :py:func:`pvlib.inverter.sandia_multi` to calculate AC power
-        based on ``self.inverter_parameters`` and the input voltage and power.
-
-        The parameters `v_dc` and `p_dc` must be tuples with length equal to
-        ``self.num_arrays`` if the system has more than one array.
-
-        See :py:func:`pvlib.inverter.sandia_multi` for details.
         """
-        v_dc = self._validate_per_array(v_dc)
-        p_dc = self._validate_per_array(p_dc)
-        return inverter.sandia_multi(v_dc, p_dc, self.inverter_parameters)
+        Deprecated. Use ``PVSystem.get_ac`` instead.
+        """
+        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
+                      ' removed in v0.10. Use PVSystem.get_ac instead')
+        return self.get_ac('sandia', p_dc, v_dc)
 
     def adrinverter(self, v_dc, p_dc):
-        """Uses :py:func:`pvlib.inverter.adr` to calculate AC power based on
-        ``self.inverter_parameters`` and the input voltage and power.
-
-        See :py:func:`pvlib.inverter.adr` for details
         """
-        return inverter.adr(v_dc, p_dc, self.inverter_parameters)
+        Deprecated. Use ``PVSystem.get_ac`` instead.
+        """
+        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
+                      ' removed in v0.10. Use PVSystem.get_ac instead')
+        return self.get_ac('adr', p_dc, v_dc)
 
     @_unwrap_single_value
     def scale_voltage_current_power(self, data):
@@ -1012,32 +1006,19 @@ class PVSystem:
 
     def pvwatts_ac(self, pdc):
         """
-        Calculates AC power according to the PVWatts model using
-        :py:func:`pvlib.inverter.pvwatts`, `self.module_parameters["pdc0"]`,
-        and `eta_inv_nom=self.inverter_parameters["eta_inv_nom"]`.
-
-        See :py:func:`pvlib.inverter.pvwatts` for details.
+        Deprecated. Use ``PVSystem.get_ac`` instead.
         """
-        kwargs = _build_kwargs(['eta_inv_nom', 'eta_inv_ref'],
-                               self.inverter_parameters)
-
-        return inverter.pvwatts(pdc, self.inverter_parameters['pdc0'],
-                                **kwargs)
+        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
+                      ' removed in v0.10. Use PVSystem.get_ac instead')
+        return self.get_ac('pvwatts', pdc)
 
     def pvwatts_multi(self, p_dc):
-        """Uses :py:func:`pvlib.inverter.pvwatts_multi` to calculate AC power
-        based on ``self.inverter_parameters`` and the input voltage and power.
-
-        The parameter `p_dc` must be a tuple with length equal to
-        ``self.num_arrays`` if the system has more than one array.
-
-        See :py:func:`pvlib.inverter.pvwatts_multi` for details.
         """
-        p_dc = self._validate_per_array(p_dc)
-        kwargs = _build_kwargs(['eta_inv_nom', 'eta_inv_ref'],
-                               self.inverter_parameters)
-        return inverter.pvwatts_multi(p_dc, self.inverter_parameters['pdc0'],
-                                      **kwargs)
+        Deprecated. Use ``PVSystem.get_ac`` instead.
+        """
+        warnings.warn('PVsystem.sandia_multi is deprecated and will be',
+                      ' removed in v0.10. Use PVSystem.get_ac instead')
+        return self.get_ac('pvwatts', p_dc)
 
     @property
     @_unwrap_single_value

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1527,7 +1527,7 @@ def test_PVSystem_get_ac_adr(adr_inverter_parameters, mocker):
     assert_series_equal(pacs, pd.Series([np.nan, 1161.5745, 1116.4459,
                                          382.6679, np.nan]))
     inverter.adr.assert_called_once_with(vdcs, pdcs,
-                                         **system.inverter_parameters)
+                                         system.inverter_parameters)
 
 
 def test_PVSystem_get_ac_adr_multi(adr_inverter_parameters):

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1459,16 +1459,16 @@ def test_PVSystem_sandia_multi_single_array(cec_inverter_parameters):
     idcs = pd.Series(np.linspace(0, 11, 3))
     pdcs = idcs * vdcs
 
-    pacs = system.system.sandia_multi(vdcs, pdcs)
+    pacs = system.sandia_multi(vdcs, pdcs)
     assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
-    pacs = system.system.sandia_multi((vdcs,), (pdcs,))
+    pacs = system.sandia_multi((vdcs,), (pdcs,))
     assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.system.sandia_multi((vdcs, vdcs), pdcs)
+        system.sandia_multi((vdcs, vdcs), pdcs)
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.system.sandia_multi((vdcs,), (pdcs, pdcs))
+        system.sandia_multi((vdcs,), (pdcs, pdcs))
 
 
 def test_PVSystem_get_ac_pvwatts(pvwatts_system_defaults, mocker):
@@ -1522,7 +1522,7 @@ def test_PVSystem_get_ac_adr(adr_inverter_parameters, mocker):
     )
     vdcs = pd.Series([135, 154, 390, 420, 551])
     pdcs = pd.Series([135, 1232, 1170, 420, 551])
-    pacs = system.get_ac('adr', vdcs, pdcs)
+    pacs = system.get_ac('adr', pdcs, vdcs)
     assert_series_equal(pacs, pd.Series([np.nan, 1161.5745, 1116.4459,
                                          382.6679, np.nan]))
     inverter.adr.assert_called_once_with(vdcs, pdcs,

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -2077,33 +2077,3 @@ def test_combine_loss_factors():
 def test_no_extra_kwargs():
     with pytest.raises(TypeError, match="arbitrary_kwarg"):
         pvsystem.PVSystem(arbitrary_kwarg='value')
-
-
-def test_deprecated_inverter_methods(cec_inverter_parameters,
-                                     adr_inverter_parameters,
-                                     pvwatts_system_defaults):
-    system = pvsystem.PVSystem(
-        inverter=cec_inverter_parameters['Name'],
-        inverter_parameters=cec_inverter_parameters,
-    )
-    vdcs = pd.Series(np.linspace(0, 50, 3))
-    idcs = pd.Series(np.linspace(0, 11, 3))
-    pdcs = idcs * vdcs
-    matchtxt = "Use PVSystem.get_ac instead"
-    with pytest.warns(match=matchtxt):
-        system.snlinverter(vdcs, pdcs)
-    with pytest.warns(match=matchtxt):
-        system.sandia_multi((vdcs,), (pdcs,))
-    system = pvsystem.PVSystem(
-        inverter_parameters=adr_inverter_parameters,
-    )
-    with pytest.warns(match=matchtxt):
-        system.adrinverter(vdcs, pdcs)
-    with pytest.warns(match=matchtxt):
-        pvwatts_system_defaults.pvwatts_ac(pdcs)
-    system = pvsystem.PVSystem(
-            arrays=[pvsystem.Array(), pvsystem.Array()],
-            inverter_parameters=pvwatts_system_defaults.inverter_parameters,
-        )
-    with pytest.warns(match=matchtxt):
-        system.pvwatts_ac((pdcs, pdcs))

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1449,6 +1449,7 @@ def test_PVSystem_sandia_multi(cec_inverter_parameters):
         system.sandia_multi((vdcs, vdcs), (pdcs, pdcs, pdcs))
 
 
+# remove after deprecation period for PVSystem.sandia_multi
 def test_PVSystem_sandia_multi_single_array(cec_inverter_parameters):
     system = pvsystem.PVSystem(
         arrays=[pvsystem.Array()],
@@ -1527,6 +1528,26 @@ def test_PVSystem_get_ac_adr(adr_inverter_parameters, mocker):
                                          382.6679, np.nan]))
     inverter.adr.assert_called_once_with(vdcs, pdcs,
                                          **system.inverter_parameters)
+
+
+def test_PVSystem_get_ac_adr_multi(adr_inverter_parameters):
+    system = pvsystem.PVSystem(
+        arrays=[pvsystem.Array(), pvsystem.Array()],
+        inverter_parameters=adr_inverter_parameters,
+    )
+    pdcs = pd.Series([135, 1232, 1170, 420, 551])
+    with pytest.raises(ValueError,
+                       match="The adr inverter function cannot be used"):
+        system.get_ac(model='adr', p_dc=pdcs)
+
+
+def test_PVSystem_get_ac_invalid(cec_inverter_parameters):
+    system = pvsystem.PVSystem(
+        inverter_parameters=cec_inverter_parameters,
+    )
+    pdcs = pd.Series(np.linspace(0, 50, 3))
+    with pytest.raises(ValueError, match="is not a valid AC power model"):
+        system.get_ac(model='not_a_model', p_dc=pdcs)
 
 
 def test_PVSystem_creation():

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1449,7 +1449,7 @@ def test_PVSystem_sandia_multi(cec_inverter_parameters):
         system.sandia_multi((vdcs, vdcs), (pdcs, pdcs, pdcs))
 
 
-def test_PVSystem_get_ac_sandia_multi_single_array(cec_inverter_parameters):
+def test_PVSystem_sandia_multi_single_array(cec_inverter_parameters):
     system = pvsystem.PVSystem(
         arrays=[pvsystem.Array()],
         inverter=cec_inverter_parameters['Name'],
@@ -1459,16 +1459,16 @@ def test_PVSystem_get_ac_sandia_multi_single_array(cec_inverter_parameters):
     idcs = pd.Series(np.linspace(0, 11, 3))
     pdcs = idcs * vdcs
 
-    pacs = system.get_ac('sandia', vdcs, pdcs)
+    pacs = system.system.sandia_multi(vdcs, pdcs)
     assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
-    pacs = system.get_ac('sandia', (vdcs,), (pdcs,))
+    pacs = system.system.sandia_multi((vdcs,), (pdcs,))
     assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.get_ac('sandia', (vdcs, vdcs), pdcs)
+        system.system.sandia_multi((vdcs, vdcs), pdcs)
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.get_ac('sandia', (vdcs,), (pdcs, pdcs))
+        system.system.sandia_multi((vdcs,), (pdcs, pdcs))
 
 
 def test_PVSystem_get_ac_pvwatts(pvwatts_system_defaults, mocker):

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -2077,3 +2077,33 @@ def test_combine_loss_factors():
 def test_no_extra_kwargs():
     with pytest.raises(TypeError, match="arbitrary_kwarg"):
         pvsystem.PVSystem(arbitrary_kwarg='value')
+
+
+def test_deprecated_inverter_methods(cec_inverter_parameters,
+                                     adr_inverter_parameters,
+                                     pvwatts_system_defaults):
+    system = pvsystem.PVSystem(
+        inverter=cec_inverter_parameters['Name'],
+        inverter_parameters=cec_inverter_parameters,
+    )
+    vdcs = pd.Series(np.linspace(0, 50, 3))
+    idcs = pd.Series(np.linspace(0, 11, 3))
+    pdcs = idcs * vdcs
+    matchtxt = "Use PVSystem.get_ac instead"
+    with pytest.warns(match=matchtxt):
+        system.snlinverter(vdcs, pdcs)
+    with pytest.warns(match=matchtxt):
+        system.sandia_multi((vdcs,), (pdcs,))
+    system = pvsystem.PVSystem(
+        inverter_parameters=adr_inverter_parameters,
+    )
+    with pytest.warns(match=matchtxt):
+        system.adrinverter(vdcs, pdcs)
+    with pytest.warns(match=matchtxt):
+        pvwatts_system_defaults.pvwatts_ac(pdcs)
+    system = pvsystem.PVSystem(
+            arrays=[pvsystem.Array(), pvsystem.Array()],
+            inverter_parameters=pvwatts_system_defaults.inverter_parameters,
+        )
+    with pytest.warns(match=matchtxt):
+        system.pvwatts_ac((pdcs, pdcs))


### PR DESCRIPTION
 - [x] Closes #998
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Anticipates deprecation of the separate inverter methods PVSystem.snlinverter, .adrinverter, .sandia_multi, .pvwatts, and .pvwatts_multi after `ModelChain.ac_model` is reworked.