### PR TITLE
unwrap_single_value, validate_per_array in SingleAxisTracker.get_irradiance

### DIFF
--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -726,6 +726,29 @@ def test_run_model_tracker(sapm_dc_snl_ac_system, location, weather, mocker):
                                             'surface_tilt']).all()
     assert mc.results.ac[0] > 0
     assert np.isnan(mc.results.ac[1])
+    assert isinstance(mc.results.dc, pd.DataFrame)
+
+
+def test_run_model_tracker_list(
+        sapm_dc_snl_ac_system, location, weather, mocker):
+    system = SingleAxisTracker(
+        module_parameters=sapm_dc_snl_ac_system.module_parameters,
+        temperature_model_parameters=(
+            sapm_dc_snl_ac_system.temperature_model_parameters
+        ),
+        inverter_parameters=sapm_dc_snl_ac_system.inverter_parameters)
+    mocker.spy(system, 'singleaxis')
+    mc = ModelChain(system, location)
+    mc.run_model([weather])
+    assert system.singleaxis.call_count == 1
+    assert (mc.results.tracking.columns == ['tracker_theta',
+                                            'aoi',
+                                            'surface_azimuth',
+                                            'surface_tilt']).all()
+    assert mc.results.ac[0] > 0
+    assert np.isnan(mc.results.ac[1])
+    assert isinstance(mc.results.dc, tuple)
+    assert len(mc.results.dc) == 1
 
 
 def test__assign_total_irrad(sapm_dc_snl_ac_system, location, weather,

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from pvlib.tools import cosd, sind, tand
-from pvlib.pvsystem import PVSystem
+from pvlib.pvsystem import PVSystem, _unwrap_single_value
 from pvlib import irradiance, atmosphere
 
 
@@ -169,6 +169,7 @@ class SingleAxisTracker(PVSystem):
                              solar_zenith, solar_azimuth)
         return aoi
 
+    @_unwrap_single_value
     def get_irradiance(self, surface_tilt, surface_azimuth,
                        solar_zenith, solar_azimuth, dni, ghi, dhi,
                        dni_extra=None, airmass=None, model='haydavies',
@@ -221,16 +222,26 @@ class SingleAxisTracker(PVSystem):
         if airmass is None:
             airmass = atmosphere.get_relative_airmass(solar_zenith)
 
-        return irradiance.get_total_irradiance(surface_tilt,
-                                               surface_azimuth,
-                                               solar_zenith,
-                                               solar_azimuth,
-                                               dni, ghi, dhi,
-                                               dni_extra=dni_extra,
-                                               airmass=airmass,
-                                               model=model,
-                                               albedo=self.albedo,
-                                               **kwargs)
+        dni = self._validate_per_array(dni, system_wide=True)
+        ghi = self._validate_per_array(ghi, system_wide=True)
+        dhi = self._validate_per_array(dhi, system_wide=True)
+
+        return tuple(
+            irradiance.get_total_irradiance(
+                surface_tilt,
+                surface_azimuth,
+                solar_zenith,
+                solar_azimuth,
+                dni, ghi, dhi,
+                dni_extra=dni_extra,
+                airmass=airmass,
+                model=model,
+                albedo=self.albedo,
+                **kwargs)
+            for array, dni, ghi, dhi in zip(
+                self.arrays, dni, ghi, dhi
+            )
+        )
 
 
 def singleaxis(apparent_zenith, apparent_azimuth,

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -222,6 +222,9 @@ class SingleAxisTracker(PVSystem):
         if airmass is None:
             airmass = atmosphere.get_relative_airmass(solar_zenith)
 
+        # SingleAxisTracker only supports a single Array, but we need the
+        # validate/iterate machinery so that single length tuple input/output
+        # is handled the same as PVSystem.get_irradiance. GH 1159
         dni = self._validate_per_array(dni, system_wide=True)
         ghi = self._validate_per_array(ghi, system_wide=True)
         dhi = self._validate_per_array(dhi, system_wide=True)


### PR DESCRIPTION

 - [x] Closes #1159 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This code would be removed in #1146 but I don't know if/when community will accept that. In the meantime we want this to work. And the test_modelchain additions will be useful for that refactor too.