### PR TITLE
Make sure times are assigned with ModelChain.run_from_poa

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1324,6 +1324,7 @@ class ModelChain:
                 _build_weather(weather) for weather in data
             )
         self._configure_results()
+        self._assign_times()
         return self
 
     def _assign_total_irrad(self, data):
@@ -1392,7 +1393,6 @@ class ModelChain:
         self._check_multiple_input(weather, strict=False)
         self._verify_df(weather, required=['ghi', 'dni', 'dhi'])
         self._assign_weather(weather)
-        self._assign_times()
 
         self._prep_inputs_solar_pos(weather)
         self._prep_inputs_airmass()
@@ -1488,7 +1488,7 @@ class ModelChain:
         data = _to_tuple(data)
         self._check_multiple_input(data)
         self._assign_weather(data)
-        self._assign_times()
+
         self._verify_df(data, required=['poa_global', 'poa_direct',
                                         'poa_diffuse'])
         self._assign_total_irrad(data)

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1488,7 +1488,7 @@ class ModelChain:
         data = _to_tuple(data)
         self._check_multiple_input(data)
         self._assign_weather(data)
-
+        self._assign_times()
         self._verify_df(data, required=['poa_global', 'poa_direct',
                                         'poa_diffuse'])
         self._assign_total_irrad(data)

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -774,6 +774,7 @@ def test_prepare_inputs_from_poa(sapm_dc_snl_ac_system, location,
     assert_frame_equal(mc.weather, weather_expected)
     # total_irrad attribute
     assert_frame_equal(mc.results.total_irrad, total_irrad)
+    assert not pd.isnull(mc.results.solar_position.index[0])
 
 
 @pytest.mark.parametrize("input_type", [tuple, list])


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

When running `ModelChain.run_from_poa`, `ModelChain.times` is not assigned so that the solar position results are incorrect and have a `NaT` index.

The issue was introduced in #1076 here https://github.com/pvlib/pvlib-python/blob/b0d29f550ea14d49499a97d60fa80c32a2a883d6/pvlib/modelchain.py#L1196-L1203, so I'm not sure if any what's new update is needed.