### PR TITLE
fix run_model_from_effective_irradiance with iterable weather and excluding cell temperature

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1813,6 +1813,7 @@ class ModelChain:
         """
         data = _to_tuple(data)
         self._check_multiple_input(data)
+        self._verify_df(data, required=['effective_irradiance'])
         self._assign_weather(data)
         self._assign_total_irrad(data)
         self.results.effective_irradiance = _tuple_from_dfs(

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1053,7 +1053,7 @@ class ModelChain:
                                   self.results.effective_irradiance)
         # Because this operates on all Arrays simultaneously, poa must be known
         # for all arrays.
-        if any(p is None for p in poa):
+        if poa is None or any(p is None for p in poa):
             # Provide a more informative error message. Because only
             # run_model_from_effective_irradiance() can get to this point
             # without known POA we can suggest a very specific remedy in the

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1051,18 +1051,6 @@ class ModelChain:
 
         poa = _irrad_for_celltemp(self.results.total_irrad,
                                   self.results.effective_irradiance)
-        # Because this operates on all Arrays simultaneously, poa must be known
-        # for all arrays.
-        if poa is None or any(p is None for p in poa):
-            # Provide a more informative error message. Because only
-            # run_model_from_effective_irradiance() can get to this point
-            # without known POA we can suggest a very specific remedy in the
-            # error message.
-            raise ValueError("Incomplete input data. Data must contain "
-                             "'poa_global' for every Array, or must contain "
-                             "'effective_irradiance' for every Array, "
-                             "including Arrays that have a known "
-                             "'cell_temperature' or 'module_temperature'.")
         temp_air = _tuple_from_dfs(self.weather, 'temp_air')
         wind_speed = _tuple_from_dfs(self.weather, 'wind_speed')
         self.results.cell_temperature = model(poa, temp_air, wind_speed)

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1051,6 +1051,18 @@ class ModelChain:
 
         poa = _irrad_for_celltemp(self.results.total_irrad,
                                   self.results.effective_irradiance)
+        # Because this operates on all Arrays simultaneously, poa must be known
+        # for all arrays.
+        if any(p is None for p in poa):
+            # Provide a more informative error message. Because only
+            # run_model_from_effective_irradiance() can get to this point
+            # without known POA we can suggest a very specific remedy in the
+            # error message.
+            raise ValueError("Incomplete input data. Data must contain "
+                             "'poa_global' for every Array, or must contain "
+                             "'effective_irradiance' for every Array, "
+                             "including Arrays that have a known "
+                             "'cell_temperature' or 'module_temperature'.")
         temp_air = _tuple_from_dfs(self.weather, 'temp_air')
         wind_speed = _tuple_from_dfs(self.weather, 'wind_speed')
         self.results.cell_temperature = model(poa, temp_air, wind_speed)
@@ -1572,11 +1584,13 @@ class ModelChain:
         """
         poa = _irrad_for_celltemp(self.results.total_irrad,
                                   self.results.effective_irradiance)
-        if not isinstance(data, tuple) and self.system.num_arrays > 1:
+        # handle simple case first, single array, data not iterable
+        if not isinstance(data, tuple) and self.system.num_arrays == 1:
+            return self._prepare_temperature_single_array(data, poa)
+        if not isinstance(data, tuple):
             # broadcast data to all arrays
             data = (data,) * self.system.num_arrays
-        elif not isinstance(data, tuple):
-            return self._prepare_temperature_single_array(data, poa)
+        # find where cell or module temperature is specified in input data
         given_cell_temperature = tuple(itertools.starmap(
             self._get_cell_temperature,
             zip(data, poa, self.system.temperature_model_parameters)
@@ -1588,22 +1602,7 @@ class ModelChain:
             return self
         # Calculate cell temperature from weather data. If cell_temperature
         # has not been provided for some arrays then it is computed with
-        # ModelChain.temperature_model(). Because this operates on all Arrays
-        # simultaneously, 'poa_global' must be known for all arrays, including
-        # those that have a known cell temperature.
-        try:
-            self._verify_df(self.results.total_irrad, ['poa_global'])
-        except ValueError:
-            # Provide a more informative error message. Because only
-            # run_model_from_effective_irradiance() can get to this point
-            # without known POA we can suggest a very specific remedy in the
-            # error message.
-            raise ValueError("Incomplete input data. Data must contain "
-                             "'poa_global'. For systems with multiple Arrays "
-                             "if you have provided 'cell_temperature' for "
-                             "only a subset of Arrays you must provide "
-                             "'poa_global' for all Arrays, including those "
-                             "that have a known 'cell_temperature'.")
+        # ModelChain.temperature_model().
         self.temperature_model()
         # replace calculated cell temperature with temperature given in `data`
         # where available.

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -1589,8 +1589,7 @@ class ModelChain:
             self.results.cell_temperature = given_cell_temperature
             return self
         # Calculate cell temperature from weather data. If cell_temperature
-        # has not been provided for some arrays then it is computed with
-        # ModelChain.temperature_model().
+        # has not been provided for some arrays then it is computed.
         self.temperature_model()
         # replace calculated cell temperature with temperature given in `data`
         # where available.

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -916,12 +916,12 @@ def test__set_celltemp_missing_poa(
                     aoi_model='no_loss', spectral_model='no_loss')
     data_one = total_irrad
     data_two = total_irrad.copy()
-    data_one['effective_irradiance'] = data_one['poa_global']
     data_two.pop('poa_global')
+    mc._assign_total_irrad((data_one, data_two))
     matchtxt = "Incomplete input data. Data must contain 'poa_global' " \
         "for every Array"
     with pytest.raises(ValueError, match=matchtxt):
-        mc.run_model_from_effective_irradiance((data_one, data_two))
+        mc._set_celltemp('sapm')
 
 
 def test_run_model_solar_position_weather(
@@ -1012,7 +1012,7 @@ def test_run_model_from_effective_irradiance(sapm_dc_snl_ac_system, location,
                          index=data.index)
     assert_series_equal(ac, expected)
     # check with data as an iterable of length 1
-    mc.run_model_from_effective_irradiance(input_type(data))
+    mc.run_model_from_effective_irradiance(input_type((data,)))
 
 
 @pytest.mark.parametrize("input_type", [tuple, list])

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -997,12 +997,10 @@ def test_run_model_from_effective_irradiance(sapm_dc_snl_ac_system, location,
     expected = pd.Series(np.array([149.280238, 96.678385]),
                          index=data.index)
     assert_series_equal(ac, expected)
-    # check with data as an iterable of length 1
-    mc.run_model_from_effective_irradiance(input_type((data,)))
 
 
 @pytest.mark.parametrize("input_type", [tuple, list])
-def test_run_model_from_effective_irradiance_input_type(
+def test_run_model_from_effective_irradiance_multi_array(
         sapm_dc_snl_ac_system_Array, location, weather, total_irrad,
         input_type):
     data = weather.copy()
@@ -1105,7 +1103,6 @@ def test_run_model_from_effective_irradiance_minimal_input(
     mc.run_model_from_effective_irradiance((data, data))
     assert_frame_equal(mc.results.dc[0], mc.results.dc[1])
     assert not mc.results.ac.empty
-
 
 
 def test_run_model_singleton_weather_single_array(cec_dc_snl_ac_system,

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1120,22 +1120,6 @@ def test_run_model_from_effective_irradiance_minimal_input(
     assert not mc.results.ac.empty
 
 
-def test_run_model_from_effective_irradiance_missing_poa(
-        sapm_dc_snl_ac_system_Array, location, total_irrad):
-    data_incomplete = pd.DataFrame(
-        {'effective_irradiance': total_irrad['poa_global'],
-         'poa_global': total_irrad['poa_global']},
-        index=total_irrad.index)
-    data_complete = pd.DataFrame(
-        {'effective_irradiance': total_irrad['poa_global'],
-         'cell_temperature': 30},
-        index=total_irrad.index)
-    mc = ModelChain(sapm_dc_snl_ac_system_Array, location)
-    with pytest.raises(ValueError,
-                       match="you must provide 'poa_global' for all Arrays"):
-        mc.run_model_from_effective_irradiance(
-            (data_complete, data_incomplete))
-
 
 def test_run_model_singleton_weather_single_array(cec_dc_snl_ac_system,
                                                   location, weather):


### PR DESCRIPTION
 - [x] Closes #1163
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Moves check for complete POA for cell temperature calculations to `ModelChain._set_celltemp`.
Adds testing for weather/data input type (tuple, list) to tests for `ModelChain.run_from_effective_irradiance`
