### PR TITLE
Optional requirements installed using pvlib[optional] between quotes

### DIFF
--- a/docs/sphinx/source/installation.rst
+++ b/docs/sphinx/source/installation.rst
@@ -75,7 +75,7 @@ non-editable way, use one of the following commands to install pvlib-python::
 
     # get pvlib and optional dependencies from the Python Package Index
     # another option if you know what you are doing
-    pip install pvlib[optional]
+    pip install "pvlib[optional]"
 
 .. note::
 


### PR DESCRIPTION
<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
 It is only a typo I have discovered after trying to install the optional dependencies :)