### PR TITLE
Update irradiance.aoi to use more reliable formula

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -110,7 +110,7 @@ Bug fixes
 * Reindl model fixed to generate sky_diffuse=0 when GHI=0.
   (:issue:`1153`, :pull:`1154`)
 * Fix floating point round-off issue in
-  :py:func:`~pvlib.irradiance.aoi` (:issue:`1185`, :pull:`1191`)
+  :py:func:`~pvlib.irradiance.aoi_projection` (:issue:`1185`, :pull:`1191`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -109,6 +109,8 @@ Bug fixes
   (:issue:`1065`, :pull:`1140`)
 * Reindl model fixed to generate sky_diffuse=0 when GHI=0.
   (:issue:`1153`, :pull:`1154`)
+* Fix floating point round-off issue in
+  :py:func:`~pvlib.irradiance.aoi_projection` (:issue:`1185`, :pull:`1191`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -110,7 +110,7 @@ Bug fixes
 * Reindl model fixed to generate sky_diffuse=0 when GHI=0.
   (:issue:`1153`, :pull:`1154`)
 * Fix floating point round-off issue in
-  :py:func:`~pvlib.irradiance.aoi_projection` (:issue:`1185`, :pull:`1191`)
+  :py:func:`~pvlib.irradiance.aoi` (:issue:`1185`, :pull:`1191`)
 
 Testing
 ~~~~~~~

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -160,6 +160,12 @@ def aoi_projection(surface_tilt, surface_azimuth, solar_zenith, solar_azimuth):
 
     Input all angles in degrees.
 
+    .. warning::
+
+        For certain inputs, numerical round-off can cause this function
+        to produce values slightly greater than 1.0 when the surface
+        normal and sun position vectors are parallel.
+
     Parameters
     ----------
     surface_tilt : numeric
@@ -181,9 +187,6 @@ def aoi_projection(surface_tilt, surface_azimuth, solar_zenith, solar_azimuth):
         tools.cosd(surface_tilt) * tools.cosd(solar_zenith) +
         tools.sind(surface_tilt) * tools.sind(solar_zenith) *
         tools.cosd(solar_azimuth - surface_azimuth))
-
-    # GH 1185
-    projection = np.clip(projection, -1, 1)
 
     try:
         projection.name = 'aoi_projection'

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -244,7 +244,7 @@ def aoi(surface_tilt, surface_azimuth, solar_zenith, solar_azimuth):
     for arg in [surface_tilt, surface_azimuth, solar_zenith, solar_azimuth]:
         if hasattr(arg, 'index'):
             aoi_value = pd.Series(aoi_value, index=arg.index)
-            aoi_value.name = 'aoi'
+            break
 
     return aoi_value
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -182,6 +182,9 @@ def aoi_projection(surface_tilt, surface_azimuth, solar_zenith, solar_azimuth):
         tools.sind(surface_tilt) * tools.sind(solar_zenith) *
         tools.cosd(solar_azimuth - surface_azimuth))
 
+    # GH 1185
+    projection = np.clip(projection, -1, 1)
+
     try:
         projection.name = 'aoi_projection'
     except AttributeError:

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -792,12 +792,12 @@ def test_aoi_and_aoi_projection(surface_tilt, surface_azimuth, solar_zenith,
     assert_allclose(aoi_projection, aoi_proj_expected, atol=1e-6)
 
 
-def test_aoi_projection_precision():
+def test_aoi_precision():
     # GH 1185
     zenith = 89.26778228223463
     azimuth = 60.932028605997004
-    projection = irradiance.aoi_projection(zenith, azimuth, zenith, azimuth)
-    assert projection == 1
+    aoi = irradiance.aoi(zenith, azimuth, zenith, azimuth)
+    assert aoi == 0
 
 
 @pytest.fixture

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -792,12 +792,12 @@ def test_aoi_and_aoi_projection(surface_tilt, surface_azimuth, solar_zenith,
     assert_allclose(aoi_projection, aoi_proj_expected, atol=1e-6)
 
 
-def test_aoi_precision():
+def test_aoi_projection_precision():
     # GH 1185
     zenith = 89.26778228223463
     azimuth = 60.932028605997004
-    aoi = irradiance.aoi(zenith, azimuth, zenith, azimuth)
-    assert aoi == 0
+    projection = irradiance.aoi_projection(zenith, azimuth, zenith, azimuth)
+    assert projection == 1
 
 
 @pytest.fixture

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -793,11 +793,24 @@ def test_aoi_and_aoi_projection(surface_tilt, surface_azimuth, solar_zenith,
 
 
 def test_aoi_projection_precision():
-    # GH 1185
+    # GH 1185 -- test that aoi_projection does not exceed 1.0, and when
+    # given identical inputs, the returned projection is very close to 1.0
+
+    # scalars
     zenith = 89.26778228223463
     azimuth = 60.932028605997004
     projection = irradiance.aoi_projection(zenith, azimuth, zenith, azimuth)
-    assert projection == 1
+    assert projection <= 1
+    assert np.isclose(projection, 1)
+
+    # arrays
+    zeniths = np.array([zenith])
+    azimuths = np.array([azimuth])
+    projections = irradiance.aoi_projection(zeniths, azimuths,
+                                            zeniths, azimuths)
+    assert all(projections <= 1)
+    assert all(np.isclose(projections, 1))
+    assert projections.dtype == np.dtype('float64')
 
 
 @pytest.fixture

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -792,6 +792,14 @@ def test_aoi_and_aoi_projection(surface_tilt, surface_azimuth, solar_zenith,
     assert_allclose(aoi_projection, aoi_proj_expected, atol=1e-6)
 
 
+def test_aoi_projection_precision():
+    # GH 1185
+    zenith = 89.26778228223463
+    azimuth = 60.932028605997004
+    projection = irradiance.aoi_projection(zenith, azimuth, zenith, azimuth)
+    assert projection == 1
+
+
 @pytest.fixture
 def airmass_kt():
     # disc algorithm stopped at am=12. test am > 12 for out of range behavior


### PR DESCRIPTION
 - [x] Closes #1185
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I decided the proposed option 2 in #1185 made the most sense, but happy to go another way if a better fix exists. 
