### PR TITLE
convert test dirs to packages

### DIFF
--- a/pvlib/tests/iotools/test_bsrn.py
+++ b/pvlib/tests/iotools/test_bsrn.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from pvlib.iotools import bsrn
-from conftest import DATA_DIR, assert_index_equal
+from ..conftest import DATA_DIR, assert_index_equal
 
 
 @pytest.mark.parametrize('testfile,expected_index', [

--- a/pvlib/tests/iotools/test_crn.py
+++ b/pvlib/tests/iotools/test_crn.py
@@ -1,10 +1,9 @@
 import pandas as pd
-from conftest import assert_frame_equal
 import numpy as np
 from numpy import dtype, nan
 import pytest
 from pvlib.iotools import crn
-from conftest import DATA_DIR
+from ..conftest import DATA_DIR, assert_frame_equal
 
 
 @pytest.fixture

--- a/pvlib/tests/iotools/test_ecmwf_macc.py
+++ b/pvlib/tests/iotools/test_ecmwf_macc.py
@@ -6,7 +6,7 @@ import os
 import datetime
 import numpy as np
 import pytest
-from conftest import requires_netCDF4, DATA_DIR
+from ..conftest import requires_netCDF4, DATA_DIR
 from pvlib.iotools import ecmwf_macc
 
 TESTDATA = 'aod550_tcwv_20121101_test.nc'

--- a/pvlib/tests/iotools/test_epw.py
+++ b/pvlib/tests/iotools/test_epw.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pvlib.iotools import epw
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 epw_testfile = DATA_DIR / 'NLD_Amsterdam062400_IWEC.epw'
 

--- a/pvlib/tests/iotools/test_midc.py
+++ b/pvlib/tests/iotools/test_midc.py
@@ -3,7 +3,7 @@ import pytest
 import pytz
 
 from pvlib.iotools import midc
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 
 @pytest.fixture

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -4,7 +4,7 @@ test iotools for PSM3
 
 import os
 from pvlib.iotools import psm3
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 import numpy as np
 import pandas as pd
 import pytest

--- a/pvlib/tests/iotools/test_pvgis.py
+++ b/pvlib/tests/iotools/test_pvgis.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import requests
 from pvlib.iotools import get_pvgis_tmy, read_pvgis_tmy
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 
 @pytest.fixture

--- a/pvlib/tests/iotools/test_solrad.py
+++ b/pvlib/tests/iotools/test_solrad.py
@@ -1,12 +1,11 @@
 import pandas as pd
-from conftest import assert_frame_equal
 import numpy as np
 from numpy import nan
 
 import pytest
 
 from pvlib.iotools import solrad
-from conftest import DATA_DIR
+from ..conftest import DATA_DIR, assert_frame_equal
 
 
 testfile = DATA_DIR / 'abq19056.dat'

--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from pvlib.iotools import srml
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 srml_testfile = DATA_DIR / 'SRML-day-EUPO1801.txt'
 

--- a/pvlib/tests/iotools/test_surfrad.py
+++ b/pvlib/tests/iotools/test_surfrad.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from pvlib.iotools import surfrad
-from conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 testfile = DATA_DIR / 'surfrad-slv16001.dat'
 network_testfile = ('ftp://aftp.cmdl.noaa.gov/data/radiation/surfrad/'

--- a/pvlib/tests/iotools/test_tmy.py
+++ b/pvlib/tests/iotools/test_tmy.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from pvlib.iotools import tmy
-from conftest import DATA_DIR
+from ..conftest import DATA_DIR
 
 # test the API works
 from pvlib.iotools import read_tmy3

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -9,7 +9,7 @@ from pvlib import pvsystem
 
 from pvlib.tests.conftest import requires_pysam, requires_statsmodels
 
-from conftest import DATA_DIR
+from ..conftest import DATA_DIR
 
 
 @pytest.fixture

--- a/pvlib/tests/ivtools/test_utils.py
+++ b/pvlib/tests/ivtools/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 from pvlib.ivtools.utils import _numdiff, rectify_iv_curve
 from pvlib.ivtools.utils import _schumaker_qspline
 
-from conftest import DATA_DIR
+from ..conftest import DATA_DIR
 
 
 @pytest.fixture

--- a/pvlib/tests/test_atmosphere.py
+++ b/pvlib/tests/test_atmosphere.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import nan
 from numpy.testing import assert_allclose
 import pandas as pd
-from conftest import assert_series_equal
+from .conftest import assert_series_equal
 import pytest
 
 from pvlib import atmosphere

--- a/pvlib/tests/test_bifacial.py
+++ b/pvlib/tests/test_bifacial.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from datetime import datetime
 from pvlib.bifacial import pvfactors_timeseries
-from conftest import requires_pvfactors, assert_series_equal
+from .conftest import requires_pvfactors, assert_series_equal
 import pytest
 
 

--- a/pvlib/tests/test_clearsky.py
+++ b/pvlib/tests/test_clearsky.py
@@ -8,7 +8,7 @@ from scipy.linalg import hankel
 
 import pytest
 from numpy.testing import assert_allclose
-from conftest import assert_frame_equal, assert_series_equal
+from .conftest import assert_frame_equal, assert_series_equal
 
 from pvlib.location import Location
 from pvlib import clearsky
@@ -16,7 +16,7 @@ from pvlib import solarposition
 from pvlib import atmosphere
 from pvlib import irradiance
 
-from conftest import requires_tables, DATA_DIR
+from .conftest import requires_tables, DATA_DIR
 
 
 def test_ineichen_series():

--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -1,8 +1,8 @@
 import pytest
 import pandas
 
-import conftest
-from conftest import fail_on_pvlib_version
+from pvlib.tests import conftest
+from pvlib.tests.conftest import fail_on_pvlib_version
 
 from pvlib._deprecation import pvlibDeprecationWarning, deprecated
 

--- a/pvlib/tests/test_forecast.py
+++ b/pvlib/tests/test_forecast.py
@@ -6,13 +6,13 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
 
-from conftest import (
+from .conftest import (
     requires_siphon,
     has_siphon,
     skip_windows,
     requires_recent_cftime
 )
-from conftest import RERUNS, RERUNS_DELAY
+from .conftest import RERUNS, RERUNS_DELAY
 
 pytestmark = pytest.mark.skipif(not has_siphon, reason='requires siphon')
 

--- a/pvlib/tests/test_iam.py
+++ b/pvlib/tests/test_iam.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 import pytest
-from conftest import assert_series_equal
+from .conftest import assert_series_equal
 from numpy.testing import assert_allclose
 
 from pvlib import iam as _iam

--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pandas as pd
 
-from conftest import assert_series_equal
+from .conftest import assert_series_equal
 from numpy.testing import assert_allclose
 
-from conftest import DATA_DIR
+from .conftest import DATA_DIR
 import pytest
 
 from pvlib import inverter

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_almost_equal, assert_allclose
 
 from pvlib import irradiance
 
-from conftest import (
+from .conftest import (
     assert_frame_equal,
     assert_series_equal,
     requires_ephem,

--- a/pvlib/tests/test_location.py
+++ b/pvlib/tests/test_location.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY
 import numpy as np
 from numpy import nan
 import pandas as pd
-from conftest import assert_frame_equal, assert_index_equal
+from .conftest import assert_frame_equal, assert_index_equal
 
 import pytest
 
@@ -15,8 +15,8 @@ import pvlib
 from pvlib.location import Location
 from pvlib.solarposition import declination_spencer71
 from pvlib.solarposition import equation_of_time_spencer71
-from test_solarposition import expected_solpos, golden, golden_mst
-from conftest import requires_ephem, requires_tables, fail_on_pvlib_version
+from pvlib.tests.test_solarposition import expected_solpos, golden, golden_mst
+from .conftest import requires_ephem, requires_tables, fail_on_pvlib_version
 
 
 def test_location_required():
@@ -212,7 +212,7 @@ def test_get_clearsky_valueerror(times):
 
 
 def test_from_tmy_3():
-    from test_tmy import TMY3_TESTFILE
+    from pvlib.tests.iotools.test_tmy import TMY3_TESTFILE
     from pvlib.iotools import read_tmy3
     data, meta = read_tmy3(TMY3_TESTFILE)
     loc = Location.from_tmy(meta, data)
@@ -223,7 +223,7 @@ def test_from_tmy_3():
 
 
 def test_from_tmy_2():
-    from test_tmy import TMY2_TESTFILE
+    from pvlib.tests.iotools.test_tmy import TMY2_TESTFILE
     from pvlib.iotools import read_tmy2
     data, meta = read_tmy2(TMY2_TESTFILE)
     loc = Location.from_tmy(meta, data)
@@ -234,7 +234,7 @@ def test_from_tmy_2():
 
 
 def test_from_epw():
-    from test_epw import epw_testfile
+    from pvlib.tests.iotools.test_epw import epw_testfile
     from pvlib.iotools import read_epw
     data, meta = read_epw(epw_testfile)
     loc = Location.from_epw(meta, data)

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -10,10 +10,10 @@ from pvlib.tracking import SingleAxisTracker
 from pvlib.location import Location
 from pvlib._deprecation import pvlibDeprecationWarning
 
-from conftest import assert_series_equal, assert_frame_equal
+from .conftest import assert_series_equal, assert_frame_equal
 import pytest
 
-from conftest import fail_on_pvlib_version, requires_tables
+from .conftest import fail_on_pvlib_version, requires_tables
 
 
 @pytest.fixture(scope='function')

--- a/pvlib/tests/test_numerical_precision.py
+++ b/pvlib/tests/test_numerical_precision.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 from pvlib import pvsystem
 from pvlib.singlediode import bishop88, estimate_voc
-from conftest import DATA_DIR
+from .conftest import DATA_DIR
 
 logging.basicConfig()
 LOGGER = logging.getLogger(__name__)

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -5,7 +5,7 @@ from numpy import nan, array
 import pandas as pd
 
 import pytest
-from conftest import (
+from .conftest import (
     assert_series_equal, assert_frame_equal, fail_on_pvlib_version)
 from numpy.testing import assert_allclose
 import unittest.mock as mock

--- a/pvlib/tests/test_snow.py
+++ b/pvlib/tests/test_snow.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from conftest import assert_series_equal
+from .conftest import assert_series_equal
 
 from pvlib import snow
 from pvlib.tools import sind

--- a/pvlib/tests/test_soiling.py
+++ b/pvlib/tests/test_soiling.py
@@ -3,10 +3,10 @@
 import datetime
 import numpy as np
 import pandas as pd
-from conftest import assert_series_equal
+from .conftest import assert_series_equal
 from pvlib.soiling import hsu, kimber
 from pvlib.iotools import read_tmy3
-from conftest import DATA_DIR
+from .conftest import DATA_DIR
 import pytest
 
 

--- a/pvlib/tests/test_solarposition.py
+++ b/pvlib/tests/test_solarposition.py
@@ -5,14 +5,14 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from conftest import assert_frame_equal, assert_series_equal
+from .conftest import assert_frame_equal, assert_series_equal
 from numpy.testing import assert_allclose
 import pytest
 
 from pvlib.location import Location
 from pvlib import solarposition, spa
 
-from conftest import requires_ephem, requires_spa_c, requires_numba
+from .conftest import requires_ephem, requires_spa_c, requires_numba
 
 
 # setup times and locations to be tested.

--- a/pvlib/tests/test_spectrum.py
+++ b/pvlib/tests/test_spectrum.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_allclose
 import pandas as pd
 import numpy as np
 from pvlib import spectrum
-from conftest import DATA_DIR
+from .conftest import DATA_DIR
 
 SPECTRL2_TEST_DATA = DATA_DIR / 'spectrl2_example_spectra.csv'
 

--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 
 import pytest
-from conftest import DATA_DIR, assert_series_equal
+from .conftest import DATA_DIR, assert_series_equal
 from numpy.testing import assert_allclose
 
 from pvlib import temperature, tools

--- a/pvlib/tests/test_tracking.py
+++ b/pvlib/tests/test_tracking.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 
 import pvlib
 from pvlib import tracking, pvsystem
-from conftest import DATA_DIR, assert_frame_equal
+from .conftest import DATA_DIR, assert_frame_equal
 
 SINGLEAXIS_COL_ORDER = ['tracker_theta', 'aoi',
                         'surface_azimuth', 'surface_tilt']


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

@mikofski and I have been trying to figure out why vscode doesn't discover pvlib's test suite in https://github.com/microsoft/vscode-python/issues/15398 

This PR:
* adds `__init__.py` files to the test directories
* changes imports of test helpers (e.g. `DATA_DIR`) to use relative imports

Current pytest documentation says that you should not import from `conftest.py` unless you are using packages, so this PR brings us into alignment with that directive. My memory is that pytest used to discourage `__init__.py` in test directories, but maybe I misunderstood or I am misremembering the whole thing. The documentation example for including tests within the package (i.e. `pvlib/tests` rather than `src/pvlib, tests`) shows including an `__init__.py` file within the test directory.

@mikofski does this also fix the problem for you? You might need to `pip uninstall pvlib; pip install -e .` and you might need to reload vscode - I didn't carefully track what was important as I banged away on my keyboard.