### PR TITLE
Address iotools test failures

### DIFF
--- a/pvlib/tests/iotools/test_pvgis.py
+++ b/pvlib/tests/iotools/test_pvgis.py
@@ -159,8 +159,9 @@ def _compare_pvgis_tmy_csv(expected, month_year_expected, inputs_expected,
     for meta_value in meta:
         if not meta_value:
             continue
-        # don't check end year because it changes every year
-        if meta_value[:-4] == 'PVGIS (c) European Communities, 2001-':
+        # this copyright text tends to change (copyright year range increments
+        # annually, e.g.), so just check the beginning of it:
+        if meta_value.startswith('PVGIS (c) European'):
             continue
         assert meta_value in csv_meta
 

--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from pvlib.iotools import srml
-from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR  # , RERUNS, RERUNS_DELAY
 
 srml_testfile = DATA_DIR / 'SRML-day-EUPO1801.txt'
 
@@ -13,7 +13,8 @@ def test_read_srml():
 
 
 @pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+@pytest.mark.xfail(strict=True)
 def test_read_srml_remote():
     srml.read_srml('http://solardat.uoregon.edu/download/Archive/EUPO1801.txt')
 
@@ -41,7 +42,8 @@ def test_read_srml_nans_exist():
      2016, 12),
 ])
 @pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+@pytest.mark.xfail(strict=True)
 def test_read_srml_dt_index(url, year, month):
     data = srml.read_srml(url)
     start = pd.Timestamp(f'{year:04d}{month:02d}01 00:00')
@@ -65,7 +67,8 @@ def test_map_columns(column, expected):
 
 
 @pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+@pytest.mark.xfail(strict=True)
 def test_read_srml_month_from_solardat():
     url = 'http://solardat.uoregon.edu/download/Archive/EUPO1801.txt'
     file_data = srml.read_srml(url)
@@ -74,7 +77,8 @@ def test_read_srml_month_from_solardat():
 
 
 @pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+@pytest.mark.xfail(strict=True)
 def test_15_minute_dt_index():
     data = srml.read_srml_month_from_solardat('TW', 2019, 4, 'RQ')
     start = pd.Timestamp('20190401 00:00')
@@ -87,7 +91,8 @@ def test_15_minute_dt_index():
 
 
 @pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+@pytest.mark.xfail(strict=True)
 def test_hourly_dt_index():
     data = srml.read_srml_month_from_solardat('CD', 1986, 4, 'PH')
     start = pd.Timestamp('19860401 00:00')

--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from pvlib.iotools import srml
-from ..conftest import DATA_DIR  # , RERUNS, RERUNS_DELAY
+from ..conftest import DATA_DIR, RERUNS, RERUNS_DELAY
 
 srml_testfile = DATA_DIR / 'SRML-day-EUPO1801.txt'
 
@@ -13,8 +13,7 @@ def test_read_srml():
 
 
 @pytest.mark.remote_data
-# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-@pytest.mark.xfail(strict=True)
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_remote():
     srml.read_srml('http://solardat.uoregon.edu/download/Archive/EUPO1801.txt')
 
@@ -42,8 +41,7 @@ def test_read_srml_nans_exist():
      2016, 12),
 ])
 @pytest.mark.remote_data
-# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-@pytest.mark.xfail(strict=True)
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_dt_index(url, year, month):
     data = srml.read_srml(url)
     start = pd.Timestamp(f'{year:04d}{month:02d}01 00:00')
@@ -67,8 +65,7 @@ def test_map_columns(column, expected):
 
 
 @pytest.mark.remote_data
-# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-@pytest.mark.xfail(strict=True)
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_month_from_solardat():
     url = 'http://solardat.uoregon.edu/download/Archive/EUPO1801.txt'
     file_data = srml.read_srml(url)
@@ -77,8 +74,7 @@ def test_read_srml_month_from_solardat():
 
 
 @pytest.mark.remote_data
-# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-@pytest.mark.xfail(strict=True)
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_15_minute_dt_index():
     data = srml.read_srml_month_from_solardat('TW', 2019, 4, 'RQ')
     start = pd.Timestamp('20190401 00:00')
@@ -91,8 +87,7 @@ def test_15_minute_dt_index():
 
 
 @pytest.mark.remote_data
-# @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-@pytest.mark.xfail(strict=True)
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_hourly_dt_index():
     data = srml.read_srml_month_from_solardat('CD', 1986, 4, 'PH')
     start = pd.Timestamp('19860401 00:00')


### PR DESCRIPTION
 - [x] Closes #1217
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~Tests added~
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This replaces `flaky` with `xfail(strict=True)` in the hopes that the SRML website issue will get resolved without us having to change any code.  Also addresses the PVGIS issue.