### PR TITLE
removed kwargs in calcparams_desoto, calcparams_cec, and sapm

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -121,7 +121,7 @@ Bug fixes
   fix in PVLib for MATLAB. (:issue:`1206`, :pull:`1213`)
 * Removed the **kwargs parameters from :py:meth:`~pvlib.pvsystem.sapm` and
   :py:meth:`~pvlib.pvsystem.calcparams_desoto` and 
-  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`xxxx`)
+  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`1222`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -119,6 +119,9 @@ Bug fixes
 * Update GFS product names for GFS v16. (:issue:`1202`, :pull:`1203`)
 * Corrected methodology error in :py:func:`~pvlib.scaling.wvm`. Tracks with
   fix in PVLib for MATLAB. (:issue:`1206`, :pull:`1213`)
+* Removed the **kwargs parameters from :py:meth:`~pvlib.pvsystem.sapm` and
+  :py:meth:`~pvlib.pvsystem.calcparams_desoto` and 
+  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`xxxx`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -45,9 +45,9 @@ Breaking changes
   ``surface_azimuth`` are now required parameters for
   :py:func:`pvlib.modelchain.basic_chain` (:issue:`1028`, :pull:`1181`)
 
-* Removed the **kwargs parameters from :py:meth:`~pvlib.pvsystem.sapm` and
-  :py:meth:`~pvlib.pvsystem.calcparams_desoto` and 
-  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`1222`)
+* Removed the ``**kwargs`` parameters from :py:meth:`~pvlib.pvsystem.PVSystem.sapm` and
+  :py:meth:`~pvlib.pvsystem.PVSystem.calcparams_desoto` and 
+  :py:meth:`~pvlib.pvsystem.PVSystem.calcparams_cec` (:issue:`1118`, :pull:`1222`)
 
 
 Deprecations

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -45,6 +45,10 @@ Breaking changes
   ``surface_azimuth`` are now required parameters for
   :py:func:`pvlib.modelchain.basic_chain` (:issue:`1028`, :pull:`1181`)
 
+* Removed the **kwargs parameters from :py:meth:`~pvlib.pvsystem.sapm` and
+  :py:meth:`~pvlib.pvsystem.calcparams_desoto` and 
+  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`1222`)
+
 
 Deprecations
 ~~~~~~~~~~~~
@@ -119,9 +123,6 @@ Bug fixes
 * Update GFS product names for GFS v16. (:issue:`1202`, :pull:`1203`)
 * Corrected methodology error in :py:func:`~pvlib.scaling.wvm`. Tracks with
   fix in PVLib for MATLAB. (:issue:`1206`, :pull:`1213`)
-* Removed the **kwargs parameters from :py:meth:`~pvlib.pvsystem.sapm` and
-  :py:meth:`~pvlib.pvsystem.calcparams_desoto` and 
-  :py:meth:`~pvlib.pvsystem.calcparams_cec` (:issue:`1118`, :pull:`1222`)
 
 Testing
 ~~~~~~~

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -379,7 +379,7 @@ class PVSystem:
                      for array, aoi in zip(self.arrays, aoi))
 
     @_unwrap_single_value
-    def calcparams_desoto(self, effective_irradiance, temp_cell, **kwargs):
+    def calcparams_desoto(self, effective_irradiance, temp_cell):
         """
         Use the :py:func:`calcparams_desoto` function, the input
         parameters and ``self.module_parameters`` to calculate the
@@ -392,9 +392,6 @@ class PVSystem:
 
         temp_cell : float or Series or tuple of float or Series
             The average cell temperature of cells within a module in C.
-
-        **kwargs
-            See pvsystem.calcparams_desoto for details
 
         Returns
         -------
@@ -420,7 +417,7 @@ class PVSystem:
         )
 
     @_unwrap_single_value
-    def calcparams_cec(self, effective_irradiance, temp_cell, **kwargs):
+    def calcparams_cec(self, effective_irradiance, temp_cell):
         """
         Use the :py:func:`calcparams_cec` function, the input
         parameters and ``self.module_parameters`` to calculate the
@@ -433,9 +430,6 @@ class PVSystem:
 
         temp_cell : float or Series or tuple of float or Series
             The average cell temperature of cells within a module in C.
-
-        **kwargs
-            See pvsystem.calcparams_cec for details
 
         Returns
         -------
@@ -501,7 +495,7 @@ class PVSystem:
         )
 
     @_unwrap_single_value
-    def sapm(self, effective_irradiance, temp_cell, **kwargs):
+    def sapm(self, effective_irradiance, temp_cell):
         """
         Use the :py:func:`sapm` function, the input parameters,
         and ``self.module_parameters`` to calculate
@@ -514,9 +508,6 @@ class PVSystem:
 
         temp_cell : float or Series or tuple of float or Series
             The average cell temperature of cells within a module in C.
-
-        kwargs
-            See pvsystem.sapm for details
 
         Returns
         -------


### PR DESCRIPTION
Removed the **kwargs parameters from `calcparams_cec`, `calcparams_desoto`, and `sapm`. Python automatically returns a `TypeError` upon user input of unexpected parameters.

 - [x] Closes #1118
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~~Tests added~~
 - [ ] ~~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
