### PR TITLE
Raise ValueError if PVSystem constructed with 0 Arrays

### DIFF
--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -214,8 +214,9 @@ class PVSystem:
         elif len(arrays) == 0:
             raise ValueError("PVSystem must have at least one Array. "
                              "If you want to create a PVSystem instance "
-                             "with a single arbitrary default Array pass "
-                             "`arrays=None`.")
+                             "with a single Array pass `arrays=None` and pass "
+                             "values directly to PVSystem attributes, e.g., "
+                             "`surface_tilt=30`")
         else:
             self.arrays = tuple(arrays)
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -98,7 +98,8 @@ class PVSystem:
     arrays : iterable of Array, optional
         List of arrays that are part of the system. If not specified
         a single array is created from the other parameters (e.g.
-        `surface_tilt`, `surface_azimuth`). If `arrays` is specified
+        `surface_tilt`, `surface_azimuth`). Must contain at least one Array,
+        if empty a ValueError is raised. If `arrays` is specified
         the following parameters are ignored:
 
         - `surface_tilt`
@@ -210,6 +211,11 @@ class PVSystem:
                 racking_model,
                 array_losses_parameters,
             ),)
+        elif len(arrays) == 0:
+            raise ValueError("PVSystem must have at least one Array. "
+                             "If you want to create a PVSystem instance "
+                             "with a single arbitrary default Array pass "
+                             "`arrays=None`.")
         else:
             self.arrays = tuple(arrays)
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -174,6 +174,11 @@ class PVSystem:
         Arbitrary keyword arguments.
         Included for compatibility, but not used.
 
+    Raises
+    ------
+    ValueError
+        If `arrays` is not None and has length 0.
+
     See also
     --------
     pvlib.location.Location

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -99,8 +99,8 @@ class PVSystem:
         List of arrays that are part of the system. If not specified
         a single array is created from the other parameters (e.g.
         `surface_tilt`, `surface_azimuth`). Must contain at least one Array,
-        if empty a ValueError is raised. If `arrays` is specified
-        the following parameters are ignored:
+        if length of arrays is 0 a ValueError is raised. If `arrays` is
+        specified the following parameters are ignored:
 
         - `surface_tilt`
         - `surface_azimuth`

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -2084,6 +2084,12 @@ def test_PVSystem_num_arrays():
     assert system_two.num_arrays == 2
 
 
+def test_PVSystem_at_least_one_array():
+    with pytest.raises(ValueError,
+                       match="PVSystem must have at least one Array"):
+        pvsystem.PVSystem(arrays=[])
+
+
 def test_combine_loss_factors():
     test_index = pd.date_range(start='1990/01/01T12:00', periods=365, freq='D')
     loss_1 = pd.Series(.10, index=test_index)


### PR DESCRIPTION
Provides a useful error message directing users to the solution
they are most likely to want (construct a PVSystem with an
arbitrary default Array).

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1148
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
