### PR TITLE
Add bhi, pressure, and wind_ to list of variables

### DIFF
--- a/pvlib/data/variables_style_rules.csv
+++ b/pvlib/data/variables_style_rules.csv
@@ -5,6 +5,7 @@ longitude;longitude
 dni;direct normal irradiance
 dni_extra;direct normal irradiance at top of atmosphere (extraterrestrial)
 dhi;diffuse horizontal irradiance
+bhi;beam/direct horizontal irradiance
 ghi;global horizontal irradiance
 aoi;angle of incidence between :math:`90\deg` and :math:`90\deg`
 aoi_projection;cos(aoi)
@@ -27,6 +28,9 @@ temp_module;temperature of the module
 temp_air;temperature of the air
 temp_dew;dewpoint temperature
 relative_humidity;relative humidity
+wind_speed;wind speed
+wind_direction;wind direction
+pressure;atmospheric pressure
 v_mp, i_mp, p_mp;module voltage, current, power at the maximum power point
 v_oc;open circuit module voltage
 i_sc;short circuit module current


### PR DESCRIPTION
All the terms except bhi are in agreement with pv-terms.

The BHI (Beam Horizontal Irradiance) term was introduced in the variable map for the `get_cams`  and `read_cams` functions in #1175 

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.