### PR TITLE
Correct return docstrings 

### DIFF
--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -374,7 +374,8 @@ class PVSystem:
         Returns
         -------
         poa_irradiance : DataFrame or tuple of DataFrame
-            Column names are: ``total, beam, sky, ground``.
+            Column names are: ``'poa_global', 'poa_direct', 'poa_diffuse',
+            'poa_sky_diffuse', 'poa_ground_diffuse'``.
         """
         dni = self._validate_per_array(dni, system_wide=True)
         ghi = self._validate_per_array(ghi, system_wide=True)
@@ -1464,7 +1465,8 @@ class Array:
         Returns
         -------
         poa_irradiance : DataFrame
-            Column names are: ``total, beam, sky, ground``.
+            Column names are: ``'poa_global', 'poa_direct', 'poa_diffuse',
+            'poa_sky_diffuse', 'poa_ground_diffuse'``.
         """
         # not needed for all models, but this is easier
         if dni_extra is None:


### PR DESCRIPTION
 - [x] Closes #1234
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 ~~- [ ] Tests added~~
 ~~- [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~~
 ~~- [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 ~~- [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 ~~- [ ] Pull request is nearly complete and ready for detailed review.~~
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Column names were added as described in the issue.
