### PR TITLE
Clean up how pvlib imports optional dependencies

### DIFF
--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -4,24 +4,14 @@ Read data from ECMWF MACC Reanalysis.
 
 import threading
 import pandas as pd
+from pvlib.tools import _optional_import
 
-try:
-    import netCDF4
-except ImportError:
-    class netCDF4:
-        @staticmethod
-        def Dataset(*a, **kw):
-            raise ImportError(
-                'Reading ECMWF data requires netCDF4 to be installed.')
+netCDF4 = _optional_import('netCDF4', (
+    'Reading ECMWF data requires netCDF4 to be installed.'))
+ecmwfapi = _optional_import('ecmwfapi', (
+    'To download data from ECMWF requires the API client.\nSee https:/'
+    '/confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets'))
 
-try:
-    from ecmwfapi import ECMWFDataServer
-except ImportError:
-    def ECMWFDataServer(*a, **kw):
-        raise ImportError(
-            'To download data from ECMWF requires the API client.\nSee https:/'
-            '/confluence.ecmwf.int/display/WEBAPI/Access+ECMWF+Public+Datasets'
-        )
 
 #: map of ECMWF MACC parameter keynames and codes used in API
 PARAMS = {
@@ -164,7 +154,7 @@ def get_ecmwf_macc(filename, params, start, end, lookup_params=True,
     startdate = start.strftime('%Y-%m-%d')
     enddate = end.strftime('%Y-%m-%d')
     if not server:
-        server = ECMWFDataServer()
+        server = ecmwfapi.ECMWFDataServer()
     t = threading.Thread(target=target, daemon=True,
                          args=(server, startdate, enddate, params, filename))
     t.start()

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -24,7 +24,8 @@ import scipy.optimize as so
 import warnings
 
 from pvlib import atmosphere
-from pvlib.tools import datetime_to_djd, djd_to_datetime
+from pvlib.tools import datetime_to_djd, djd_to_datetime, _optional_import
+ephem = _optional_import('ephem', 'PyEphem must be installed')
 
 
 NS_PER_HR = 1.e9 * 3600.  # nanoseconds per hour
@@ -487,7 +488,6 @@ def _ephem_to_timezone(date, tzinfo):
 
 def _ephem_setup(latitude, longitude, altitude, pressure, temperature,
                  horizon):
-    import ephem
     # initialize a PyEphem observer
     obs = ephem.Observer()
     obs.lat = str(latitude)
@@ -543,11 +543,6 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
     --------
     pyephem
     """
-
-    try:
-        import ephem
-    except ImportError:
-        raise ImportError('PyEphem must be installed')
 
     # times must be localized
     if times.tz:
@@ -630,10 +625,6 @@ def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
     """
 
     # Written by Will Holmgren (@wholmgren), University of Arizona, 2014
-    try:
-        import ephem
-    except ImportError:
-        raise ImportError('PyEphem must be installed')
 
     # if localized, convert to UTC. otherwise, assume UTC.
     try:
@@ -942,8 +933,6 @@ def pyephem_earthsun_distance(time):
     -------
     pd.Series. Earth-sun distance in AU.
     """
-
-    import ephem
 
     sun = ephem.Sun()
     earthsun = []

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -6,6 +6,7 @@ import datetime as dt
 import numpy as np
 import pandas as pd
 import pytz
+import importlib
 
 
 def cosd(angle):
@@ -344,3 +345,39 @@ def _golden_sect_DataFrame(params, VL, VH, func):
             raise Exception("EXCEPTION:iterations exceeded maximum (50)")
 
     return func(df, 'V1'), df['V1']
+
+
+def _optional_import(module_name, message):
+    """
+    Import a module, deferring import errors.
+
+    If the module cannot be imported, don't raise an error, but instead return
+    a dummy object that raises an error when the module actually gets used
+    for something.
+
+    Parameters
+    ----------
+    module_name: str
+        Name of the module to import, e.g. 'pandas'
+    message: str
+        Deferred error message, e.g. 'pandas must be installed for read_csv'
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return _DeferredImportError(message)
+
+
+class _DeferredImportError:
+    """
+    Defer import errors until an imported package actually gets used.
+
+    Useful for importing optional dependencies at the top of a file
+    instead of hiding them inside the functions that use them.
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+    def __getattr__(self, attrname):
+        raise ImportError(self.message)


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

I'd have made an issue for this but I thought a PR would make it easier to see the idea in action.

pvlib has multiple ways of handling optional imports.  One is to hide the imports inside the function that needs them, e.g. how `solarposition.py` handles the `ephem` dependency:
https://github.com/pvlib/pvlib-python/blob/f318c1c1527f69d9bf9aed6167ca1f6ce9e9d764/pvlib/solarposition.py#L633-L636

Another way used in `ecmwf_macc.py` and #1264, is to keep the import at the top of the file for clarity, but defer an import error until the missing module is actually called on to do something, like this:
https://github.com/pvlib/pvlib-python/blob/f318c1c1527f69d9bf9aed6167ca1f6ce9e9d764/pvlib/iotools/ecmwf_macc.py#L8-L15

So only when some bit of code actually tries to create a `netcdf4.Dataset` will the `ImportError` be raised.

Summarizing some of @AdamRJensen's thoughts here: the first is simple but adds a bit of clutter to the functions (`solarposition.py` imports `ephem` four separate times) and doesn't make it easy to see what external packages each pvlib module uses.  The second keeps imports at the top of the file but is a little opaque and gets clunky if more than one function is needed from a single import.

This PR extends the second approach, but with improvements:
- use `__getattr__` so there's no need to explicitly list out the module functions of interest.  For example the ERA5 PR wouldn't have to handle `open_dataset` and `open_mfdataset` separately like [this](https://github.com/AdamRJensen/pvlib-python/blob/792166697e9fa790bda91ea6f1066b0906a7bdec/pvlib/iotools/era5.py#L9-L21)
- less boilerplate in the modules because the machinery is defined in `pvlib.tools`, so each module doesn't need to define a new class for each import

What do people think?  Too "clever"?  Solving a problem that doesn't need solved?  There might be other places to use this too, but I only looked at `ecwmf_macc.py` and `solarposition.py` for now to illustrate its usage.