### PR TITLE
fix ForecastModel.get_data handling of timezones

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -207,7 +207,7 @@ Bug fixes
 * Fix :py:func:`~pvlib.tracking.singleaxis` AOI wrong when sun behind module.
   (:pull:`1273`, :issue:`1221`)
 * Fix :py:meth:`~pvlib.forecast.ForecastModel.get_data` failure to correct for
-  non-UTC timezones. (:issue:`1237`, :pull:``)
+  non-UTC timezones. (:issue:`1237`, :pull:`1285`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.0.rst
@@ -127,7 +127,7 @@ Enhancements
   for retrieving and reading BSRN solar radiation data files.
   (:pull:`1254`, :pull:`1145`, :issue:`1015`)
 * Add :func:`~pvlib.iotools.get_cams`,
-  :func:`~pvlib.iotools.parse_cams`, and 
+  :func:`~pvlib.iotools.parse_cams`, and
   :func:`~pvlib.iotools.read_cams`
   for retrieving, parsing, and reading CAMS Radiation and McClear time-series
   files. (:pull:`1175`)
@@ -179,9 +179,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 * Corrected an error in :py:func:`~pvlib.irradiance.perez` where the horizon
-  irradiance component was prevented from taking negative values. Negative 
-  values are intentional according to the original publication. Changes in 
-  output are expected to be small and primarily occur at low irradiance 
+  irradiance component was prevented from taking negative values. Negative
+  values are intentional according to the original publication. Changes in
+  output are expected to be small and primarily occur at low irradiance
   conditions.
   (:issue:`1238`, :pull:`1239`)
 * Pass weather data to solar position calculations in
@@ -205,7 +205,9 @@ Bug fixes
 * Changed deprecated use of ``.astype()`` to ``.view()`` in :py:mod:`~pvlib.solarposition`.
   (:pull:`1256`, :issue:`1261`, :pull:`1262`)
 * Fix :py:func:`~pvlib.tracking.singleaxis` AOI wrong when sun behind module.
-  (:pull:`1273`, :issue:`1221`) 
+  (:pull:`1273`, :issue:`1221`)
+* Fix :py:meth:`~pvlib.forecast.ForecastModel.get_data` failure to correct for
+  non-UTC timezones. (:issue:`1237`, :pull:``)
 
 Testing
 ~~~~~~~

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -183,7 +183,12 @@ class ForecastModel:
         self.end = pd.Timestamp(end)
         if self.start.tz is None or self.end.tz is None:
             raise TypeError('start and end must be tz-localized')
-        self.query.time_range(self.start, self.end)
+        # don't assume that siphon or the server can handle anything other
+        # than UTC
+        self.query.time_range(
+            self.start.tz_convert('UTC'),
+            self.end.tz_convert('UTC')
+        )
 
     def set_query_latlon(self):
         '''
@@ -412,10 +417,14 @@ class ForecastModel:
         -------
         pandas.DatetimeIndex
         '''
+        # np.masked_array with elements like real_datetime(2021, 8, 17, 16, 0)
+        # and dtype=object
         times = num2date(time[:].squeeze(), time.units,
                          only_use_cftime_datetimes=False,
                          only_use_python_datetimes=True)
-        self.time = pd.DatetimeIndex(pd.Series(times), tz=self.location.tz)
+        # convert to pandas, localize to UTC, convert to desired timezone
+        self.time = pd.DatetimeIndex(
+            times, tz='UTC').tz_convert(self.location.tz)
 
     def cloud_cover_to_ghi_linear(self, cloud_cover, ghi_clear, offset=35,
                                   **kwargs):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1237
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~Tests added~ I haven't used this code in years and don't care to add tests for it. "highly experimental" indeed
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

I hope this is the last time I ever open Pandora's box. 