### PR TITLE
Fix broken internal sphinx references

### DIFF
--- a/docs/sphinx/source/timetimezones.rst
+++ b/docs/sphinx/source/timetimezones.rst
@@ -278,7 +278,7 @@ Let's first examine how pvlib handles time when it imports a TMY3 file.
 
 The metadata has a ``'TZ'`` key with a value of ``-9.0``. This is the
 UTC offset in hours in which the data has been recorded. The
-:py:func:`~pvlib.tmy.read_tmy3` function read the data in the file,
+:py:func:`~pvlib.iotools.read_tmy3` function read the data in the file,
 created a :py:class:`~pandas.DataFrame` with that data, and then
 localized the DataFrame's index to have this fixed offset. Here, we
 print just a few of the rows and columns of the large dataframe.
@@ -289,7 +289,7 @@ print just a few of the rows and columns of the large dataframe.
 
     tmy3_data.loc[tmy3_data.index[0:3], ['GHI', 'DNI', 'AOD']]
 
-The :py:func:`~pvlib.tmy.read_tmy2` function also returns a DataFrame
+The :py:func:`~pvlib.iotools.read_tmy2` function also returns a DataFrame
 with a localized DatetimeIndex.
 
 Solar position

--- a/docs/sphinx/source/timetimezones.rst
+++ b/docs/sphinx/source/timetimezones.rst
@@ -278,7 +278,7 @@ Let's first examine how pvlib handles time when it imports a TMY3 file.
 
 The metadata has a ``'TZ'`` key with a value of ``-9.0``. This is the
 UTC offset in hours in which the data has been recorded. The
-:py:func:`~pvlib.tmy.readtmy3` function read the data in the file,
+:py:func:`~pvlib.tmy.read_tmy3` function read the data in the file,
 created a :py:class:`~pandas.DataFrame` with that data, and then
 localized the DataFrame's index to have this fixed offset. Here, we
 print just a few of the rows and columns of the large dataframe.
@@ -289,7 +289,7 @@ print just a few of the rows and columns of the large dataframe.
 
     tmy3_data.loc[tmy3_data.index[0:3], ['GHI', 'DNI', 'AOD']]
 
-The :py:func:`~pvlib.tmy.readtmy2` function also returns a DataFrame
+The :py:func:`~pvlib.tmy.read_tmy2` function also returns a DataFrame
 with a localized DatetimeIndex.
 
 Solar position

--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -90,7 +90,7 @@ def fit_sandia_simple(voltage, current, v_oc=None, i_sc=None, v_mp_i_mp=None,
         I = I_{L} - I_{0} (\exp \frac{V + I R_{s}}{nNsVth} - 1)
         - \frac{V + I R_{s}}{R_{sh}}
 
-    See :py:func:`pvsystem.singlediode` for definition of the parameters.
+    See :py:func:`pvlib.pvsystem.singlediode` for definition of the parameters.
 
     The extraction method [2]_ proceeds in six steps.
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -164,7 +164,7 @@ class Location:
     def get_solarposition(self, times, pressure=None, temperature=12,
                           **kwargs):
         """
-        Uses the :py:func:`solarposition.get_solarposition` function
+        Uses the :py:func:`pvlib.solarposition.get_solarposition` function
         to calculate the solar zenith, azimuth, etc. at this location.
 
         Parameters
@@ -173,11 +173,11 @@ class Location:
             Must be localized or UTC will be assumed.
         pressure : None, float, or array-like, default None
             If None, pressure will be calculated using
-            :py:func:`atmosphere.alt2pres` and ``self.altitude``.
+            :py:func:`pvlib.atmosphere.alt2pres` and ``self.altitude``.
         temperature : None, float, or array-like, default 12
 
         kwargs
-            passed to :py:func:`solarposition.get_solarposition`
+            passed to :py:func:`pvlib.solarposition.get_solarposition`
 
         Returns
         -------

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -627,7 +627,7 @@ class PVSystem:
     @deprecated('0.9', alternative='PVSystem.get_cell_temperature',
                 removal='0.10.0')
     def sapm_celltemp(self, poa_global, temp_air, wind_speed):
-        """Uses :py:func:`temperature.sapm_cell` to calculate cell
+        """Uses :py:func:`pvlib.temperature.sapm_cell` to calculate cell
         temperatures.
 
         Parameters
@@ -720,7 +720,7 @@ class PVSystem:
     @deprecated('0.9', alternative='PVSystem.get_cell_temperature',
                 removal='0.10.0')
     def pvsyst_celltemp(self, poa_global, temp_air, wind_speed=1.0):
-        """Uses :py:func:`temperature.pvsyst_cell` to calculate cell
+        """Uses :py:func:`pvlib.temperature.pvsyst_cell` to calculate cell
         temperature.
 
         Parameters
@@ -756,7 +756,7 @@ class PVSystem:
                 removal='0.10.0')
     def faiman_celltemp(self, poa_global, temp_air, wind_speed=1.0):
         """
-        Use :py:func:`temperature.faiman` to calculate cell temperature.
+        Use :py:func:`pvlib.temperature.faiman` to calculate cell temperature.
 
         Parameters
         ----------
@@ -791,7 +791,7 @@ class PVSystem:
                 removal='0.10.0')
     def fuentes_celltemp(self, poa_global, temp_air, wind_speed):
         """
-        Use :py:func:`temperature.fuentes` to calculate cell temperature.
+        Use :py:func:`pvlib.temperature.fuentes` to calculate cell temperature.
 
         Parameters
         ----------
@@ -834,7 +834,7 @@ class PVSystem:
     def noct_sam_celltemp(self, poa_global, temp_air, wind_speed,
                           effective_irradiance=None):
         """
-        Use :py:func:`temperature.noct_sam` to calculate cell temperature.
+        Use :py:func:`pvlib.temperature.noct_sam` to calculate cell temperature.
 
         Parameters
         ----------
@@ -871,7 +871,7 @@ class PVSystem:
     @_unwrap_single_value
     def first_solar_spectral_loss(self, pw, airmass_absolute):
         """
-        Use the :py:func:`first_solar_spectral_correction` function to
+        Use :py:func:`pvlib.atmosphere.first_solar_spectral_correction` to
         calculate the spectral loss modifier. The model coefficients are
         specific to the module's cell type, and are determined by searching
         for one of the following keys in self.module_parameters (in order):
@@ -884,7 +884,7 @@ class PVSystem:
 
         Parameters
         ----------
-        pw : array-like
+        pw : array-likedef
             atmospheric precipitable water (cm).
 
         airmass_absolute : array-like

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -884,7 +884,7 @@ class PVSystem:
 
         Parameters
         ----------
-        pw : array-likedef
+        pw : array-like
             atmospheric precipitable water (cm).
 
         airmass_absolute : array-like

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -834,7 +834,8 @@ class PVSystem:
     def noct_sam_celltemp(self, poa_global, temp_air, wind_speed,
                           effective_irradiance=None):
         """
-        Use :py:func:`pvlib.temperature.noct_sam` to calculate cell temperature.
+        Use :py:func:`pvlib.temperature.noct_sam` to calculate cell
+        temperature.
 
         Parameters
         ----------


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Sphinx has a `nitpicky` mode to emit warnings for references to things it doesn't know about.  I enabled it for a local build to see what it did and would not recommend it -- the output is several hundreds or thousands of lines of this:

```
pvsystem.py:docstring of pvlib.pvsystem.sapm_spectral_loss:: WARNING: py:class reference target not found: numeric
pvsystem.py:docstring of pvlib.pvsystem.sapm_spectral_loss:: WARNING: py:class reference target not found: dict-like
pvsystem.py:docstring of pvlib.pvsystem.scale_voltage_current_power:: WARNING: py:class reference target not found: DataFrame
pvsystem.py:docstring of pvlib.pvsystem.scale_voltage_current_power:: WARNING: py:class reference target not found: numeric
pvsystem.py:docstring of pvlib.pvsystem.scale_voltage_current_power:: WARNING: py:class reference target not found: default 1
```

But it did flag a few actual broken references that I've fixed here.  Marked for 0.9 in anticipation of these changes not being controversial :)
