### PR TITLE
Check longitude and latitude are numbers (float or integer)

### DIFF
--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -57,6 +57,8 @@ class Location:
 
         if not isinstance(latitude, (float, int)):
             raise TypeError("latitude should be a float")
+        if not isinstance(longitude, (float, int)):
+            raise TypeError("longitude should be a float")
         self.latitude = latitude
         self.longitude = longitude
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -56,9 +56,9 @@ class Location:
     def __init__(self, latitude, longitude, tz='UTC', altitude=0, name=None):
 
         if not isinstance(latitude, (float, int)):
-            raise TypeError("Invalid latitude specification")
+            raise TypeError('Invalid latitude specification')
         if not isinstance(longitude, (float, int)):
-            raise TypeError("Invalid longitude specification")
+            raise TypeError('Invalid longitude specification')
         self.latitude = latitude
         self.longitude = longitude
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -56,9 +56,9 @@ class Location:
     def __init__(self, latitude, longitude, tz='UTC', altitude=0, name=None):
 
         if not isinstance(latitude, (float, int)):
-            raise TypeError("latitude should be a float")
+            raise TypeError("Invalid latitude specification")
         if not isinstance(longitude, (float, int)):
-            raise TypeError("longitude should be a float")
+            raise TypeError("Invalid longitude specification")
         self.latitude = latitude
         self.longitude = longitude
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -55,6 +55,8 @@ class Location:
 
     def __init__(self, latitude, longitude, tz='UTC', altitude=0, name=None):
 
+        if not isinstance(latitude, (float, int)):
+            raise TypeError("latitude should be a float")
         self.latitude = latitude
         self.longitude = longitude
 

--- a/pvlib/tests/test_location.py
+++ b/pvlib/tests/test_location.py
@@ -49,6 +49,11 @@ def test_location_invalid_latitude_type():
         Location('32.2', -111)
 
 
+def test_location_invalid_longitude_type():
+    with pytest.raises(TypeError):
+        Location(32.2, '-111')
+
+
 def test_location_print_all():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
     expected_str = '\n'.join([

--- a/pvlib/tests/test_location.py
+++ b/pvlib/tests/test_location.py
@@ -44,6 +44,11 @@ def test_location_invalid_tz_type():
         Location(32.2, -111, [5])
 
 
+def test_location_invalid_latitude_type():
+    with pytest.raises(TypeError):
+        Location('32.2', -111)
+
+
 def test_location_print_all():
     tus = Location(32.2, -111, 'US/Arizona', 700, 'Tucson')
     expected_str = '\n'.join([


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #xxxx: **I didn't find any issue linked to the modification** 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes. (not relevant for this MR)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``). **I didn't find a file for the unreleased version where I can add my modification**
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

# Context

In [this Stackoverflow question](https://stackoverflow.com/questions/69418240/ufunc-add-did-not-contain-a-loop-with-signature-matching-types-dtypeu32/69419181#69419181), the OP creates a `Location` object with strings without errors and this leads to a Numpy error when using the function `get_solarposition`. Numpy couldn't add a string with two float array.

# Goal
This PR aims at raising an error when something different from a number is given to the `Location` init function.

# Implementation choice
I hesitate between the solution proposed in the PR and something like this:
```python
# for longitude
try:
   self.longitude = float(longitude)
except ValueError:
   raise TypeError('Invalid longitude specification')
```
I prefer the PR version because it doesn't hide the conversion (which is done with the `float` use) but the PR version won't work with a size-1 numpy array whereas the `float` one will (but I don't know if it's a common use case).
