### PR TITLE
Update azure ubuntu image from 16.04 to 20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
 - template: ci/azure/posix.yml
   parameters:
     name: Test_bare_Linux
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
 
 - template: ci/azure/posix.yml
@@ -21,7 +21,7 @@ jobs:
 - template: ci/azure/conda_linux.yml
   parameters:
     name: Test_conda_linux
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
 
 
 - template: ci/azure/conda_windows.yml


### PR DESCRIPTION
As @wholmgren mentioned would happen (https://github.com/pvlib/pvlib-python/pull/1287#issuecomment-902921273), the ubuntu-16.04 image we use for the two sets of linux tests has been removed and those test jobs are now failing ([example](https://dev.azure.com/solararbiter/pvlib%20python/_build/results?buildId=5584&view=logs&jobId=88437082-9fce-53b3-ffed-ea022e86ea67&j=88437082-9fce-53b3-ffed-ea022e86ea67)):

> ##[warning]An image label with the label ubuntu-16.04 does not exist.
> ,##[error]The remote provider was unable to process the request.

The [currently available options](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software) are `ubuntu-18.04` and `ubuntu-20.04`, along with `ubuntu-latest`.  I arbitrarily chose `20.04` for this PR as I don't think it should matter much.

Note that #1306 still needs some work and I think it makes sense to just get azure working again in the meantime.