### PR TITLE
Update MacOS and Windows Azure images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
 - template: ci/azure/posix.yml
   parameters:
     name: Test_bare_macOS
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
 
 
 - template: ci/azure/conda_linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
 - template: ci/azure/conda_windows.yml
   parameters:
     name: Test_conda_windows
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
 
 
 - job: 'Publish'


### PR DESCRIPTION
 - ~Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~Tests added~
 - ~Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Similar to #1335, but for the MacOS and Windows jobs.  MacOS is already failing:

> ##[warning]An image label with the label macOS-10.14 does not exist.
> ,##[error]The remote provider was unable to process the request.

And Windows is currently working but will also break before too long:

> ##[warning]A brownout will take place on December, 15 3:00 PM - 4:30 PM UTC to raise awareness of the upcoming windows-2016 environment removal. For more details, see https://github.com/actions/virtual-environments/issues/4312