### PR TITLE
Bug in get_pvgis_hourly related to optimal tilt

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -18,8 +18,8 @@ Bug fixes
   (:issue:`1311`, :pull:`1315`)
 * Fixed a bug in :py:func:`pvlib.spectrum.spectrl2` where negative spectral irradiance
   values were returned when the sun is behind the plane of array (:issue:`1348`, :pull:`1349`)
-* Fixed bug in :py:func:`pvlib.iotools.get_pvgis_hourly` where the `optimal_surface_tilt`
-  argument was not being passed to the `optimaltilt` request parameter (:pull:`1356`)
+* Fixed bug in :py:func:`pvlib.iotools.get_pvgis_hourly` where the ``optimal_surface_tilt``
+  argument was not being passed to the ``optimalinclination`` request parameter (:pull:`1356`)
 
 
 Testing

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -18,6 +18,8 @@ Bug fixes
   (:issue:`1311`, :pull:`1315`)
 * Fixed a bug in :py:func:`pvlib.spectrum.spectrl2` where negative spectral irradiance
   values were returned when the sun is behind the plane of array (:issue:`1348`, :pull:`1349`)
+* Fixed bug in :py:func:`pvlib.iotools.get_pvgis_hourly` where the `optimal_surface_tilt`
+  argument was not being passed to the `optimaltilt` request parameter (:pull:`1356`)
 
 
 Testing
@@ -36,3 +38,4 @@ Contributors
 * :ghuser:`Carlosbogo`
 * Christian Weickhmann (:ghuser:`cweickhmann`)
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
+* Adam R. Jensen (:ghuser:`AdamRJensen`)

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -190,7 +190,7 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
               'trackingtype': trackingtype, 'components': int(components),
               'usehorizon': int(usehorizon),
               'optimalangles': int(optimalangles),
-              'optimalinclination': int(optimalangles), 'loss': loss}
+              'optimalinclination': int(optimal_surface_tilt), 'loss': loss}
     # pvgis only takes 0 for False, and 1 for True, not strings
     if userhorizon is not None:
         params['userhorizon'] = ','.join(str(x) for x in userhorizon)

--- a/pvlib/tests/iotools/test_pvgis.py
+++ b/pvlib/tests/iotools/test_pvgis.py
@@ -273,7 +273,7 @@ def test_get_pvgis_hourly_bad_outputformat(requests_mock):
         get_pvgis_hourly(latitude=45, longitude=8, outputformat='basic')
 
 
-url_additional_inputs = 'https://re.jrc.ec.europa.eu/api/seriescalc?lat=55.6814&lon=12.5758&outputformat=csv&angle=0&aspect=0&pvcalculation=1&pvtechchoice=crystSi&mountingplace=free&trackingtype=0&components=1&usehorizon=1&optimalangles=1&optimalinclination=1&loss=2&userhorizon=10%2C15%2C20%2C10&peakpower=5'  # noqa: E501
+url_additional_inputs = 'https://re.jrc.ec.europa.eu/api/seriescalc?lat=55.6814&lon=12.5758&outputformat=csv&angle=0&aspect=0&pvcalculation=1&pvtechchoice=crystSi&mountingplace=free&trackingtype=0&components=1&usehorizon=1&optimalangles=1&optimalinclination=0&loss=2&userhorizon=10%2C15%2C20%2C10&peakpower=5'  # noqa: E501
 
 
 def test_get_pvgis_hourly_additional_inputs(requests_mock):


### PR DESCRIPTION
Currently, the `optimalangles` boolean input argument is passed correctly to the `optimalangles` parameter but also by mistake to `optimalinclination`. Instead the boolean argument `optimal_surface_tilt` should be passed to the `optimalinclination` parameter.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

~~- [ ] Closes #xxxx~~
- [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
~~- [ ] Tests added~~
~~- [ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
~~- [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
