### PR TITLE
Get test_aoi_and_aoi_projection passing on numpy 1.22.0

### DIFF
--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -25,6 +25,7 @@ jobs:
   - script: |
       pip install pytest pytest-cov pytest-mock requests-mock pytest-timeout pytest-azurepipelines pytest-rerunfailures pytest-remotedata
       pip install -e .
+      export NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
       pytest pvlib --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
     displayName: 'Test with pytest'
 

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -25,7 +25,6 @@ jobs:
   - script: |
       pip install pytest pytest-cov pytest-mock requests-mock pytest-timeout pytest-azurepipelines pytest-rerunfailures pytest-remotedata
       pip install -e .
-      export NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"
       pytest pvlib --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
     displayName: 'Test with pytest'
 

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -878,7 +878,7 @@ def test_aoi_and_aoi_projection(surface_tilt, surface_azimuth, solar_zenith,
                                 aoi_proj_expected):
     aoi = irradiance.aoi(surface_tilt, surface_azimuth, solar_zenith,
                          solar_azimuth)
-    assert_allclose(aoi, aoi_expected, atol=1e-6)
+    assert_allclose(aoi, aoi_expected, atol=1e-5)
 
     aoi_projection = irradiance.aoi_projection(
         surface_tilt, surface_azimuth, solar_zenith, solar_azimuth)


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

A test recently started failing because a returned value was very slightly different from the expected value ([example](https://dev.azure.com/solararbiter/pvlib%20python/_build/results?buildId=5734&view=logs&j=88437082-9fce-53b3-ffed-ea022e86ea67&t=6b9e297c-f567-5c08-dab9-9c9bfc583be2&l=157)):

```
>       assert_allclose(aoi, aoi_expected, atol=1e-6)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=1e-06
E       
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference: 1.20741827e-06
E       Max relative difference: inf
E        x: array(1.207418e-06)
E        y: array(0)
```

In here https://github.com/pvlib/pvlib-python/pull/717#issuecomment-1004215937 I speculated that this was because of a change in numpy 1.22.0 enabling a set of SIMD extensions (AVX512), which can improve calculation speed but can also result in very slightly different calculation results.  Here are the reasons I think it's the source of this test failure:

- Numpy currently [only enabled AVX512 on linux](https://numpy.org/doc/stable/release/1.22.0-notes.html#vectorize-umath-module-using-avx-512), and only in 1.22.0.  This is consistent with our test failure, as only the bare linux python 3.8 and 3.9 tests failed.  There are no numpy 1.22.0 wheels for python 3.7 and below so they used an older numpy that doesn't have AVX512 enabled.  Additionally, the conda linux tests are still using an older numpy, so the extension was not enabled for them either.  
- I couldn't reproduce the test failure locally on a CPU that doesn't support AVX512, and I could reproduce it on a CPU that does support AVX512.
- Setting this magic environment variable resolved the test failure on the CPU with AVX512 enabled: `NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512CD,AVX512VL,AVX512BW,AVX512DQ,AVX512_SKX"`

So I'm trying that same environment variable in our CI configuration to see if that resolves the CI failure as well.  If so I think we can be pretty confident that this numpy change is responsible.  

As a permanent fix, I think we should just loosen the tolerance on the failing test a bit.