### PR TITLE
Correct cloud_cover_to_transmittance_linear documentation

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -29,6 +29,9 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
+* Fix documentation return error in :py:meth:`pvlib.forecast.ForecastModel.cloud_cover_to_transmittance_linear`
+  (:issue:`1367`)
+
 
 Requirements
 ~~~~~~~~~~~~
@@ -41,3 +44,4 @@ Contributors
 * Christian Weickhmann (:ghuser:`cweickhmann`)
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
+* Johann Loux (:ghuser:`JoLo90`)

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -30,7 +30,7 @@ Testing
 Documentation
 ~~~~~~~~~~~~~
 * Fix documentation return error in :py:meth:`pvlib.forecast.ForecastModel.cloud_cover_to_transmittance_linear`
-  (:issue:`1367`)
+  (:issue:`1367`, :pull:`1370`)
 
 
 Requirements

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -512,8 +512,8 @@ class ForecastModel:
     def cloud_cover_to_transmittance_linear(self, cloud_cover, offset=0.75,
                                             **kwargs):
         """
-        Convert cloud cover to atmospheric transmittance using a linear
-        model.
+        Convert cloud cover percentage to atmospheric transmittance ratio using a
+        linear model.
 
         0% cloud cover returns offset.
 
@@ -530,8 +530,8 @@ class ForecastModel:
 
         Returns
         -------
-        ghi : numeric
-            Estimated GHI.
+        transmittance : numeric
+            Estimated transmittance ratio.
         """
         transmittance = ((100.0 - cloud_cover) / 100.0) * offset
 

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -512,10 +512,10 @@ class ForecastModel:
     def cloud_cover_to_transmittance_linear(self, cloud_cover, offset=0.75,
                                             **kwargs):
         """
-        Convert cloud cover (percentage) to atmospheric transmittance (ratio)
+        Convert cloud cover (percentage) to atmospheric transmittance
         using a linear model.
 
-        0% cloud cover returns offset.
+        0% cloud cover returns "offset".
 
         100% cloud cover returns 0.
 
@@ -524,14 +524,15 @@ class ForecastModel:
         cloud_cover : numeric
             Cloud cover in %.
         offset : numeric, default 0.75
-            Determines the maximum transmittance (ratio).
+            Determines the maximum transmittance. [unitless]
         kwargs
             Not used.
 
         Returns
         -------
         transmittance : numeric
-            The fraction of extraterrestrial irradiance that reaches the ground. [unitless]
+            The fraction of extraterrestrial irradiance that reaches
+            the ground. [unitless]
         """
         transmittance = ((100.0 - cloud_cover) / 100.0) * offset
 

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -512,8 +512,8 @@ class ForecastModel:
     def cloud_cover_to_transmittance_linear(self, cloud_cover, offset=0.75,
                                             **kwargs):
         """
-        Convert cloud cover percentage to atmospheric transmittance ratio using a
-        linear model.
+        Convert cloud cover percentage to atmospheric transmittance ratio
+        using a linear model.
 
         0% cloud cover returns offset.
 

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -531,7 +531,7 @@ class ForecastModel:
         Returns
         -------
         transmittance : numeric
-            Estimated transmittance (ratio).
+            The fraction of extraterrestrial irradiance that reaches the ground. [unitless]
         """
         transmittance = ((100.0 - cloud_cover) / 100.0) * offset
 

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -512,7 +512,7 @@ class ForecastModel:
     def cloud_cover_to_transmittance_linear(self, cloud_cover, offset=0.75,
                                             **kwargs):
         """
-        Convert cloud cover percentage to atmospheric transmittance ratio
+        Convert cloud cover (percentage) to atmospheric transmittance (ratio)
         using a linear model.
 
         0% cloud cover returns offset.
@@ -524,14 +524,14 @@ class ForecastModel:
         cloud_cover : numeric
             Cloud cover in %.
         offset : numeric, default 0.75
-            Determines the maximum transmittance.
+            Determines the maximum transmittance (ratio).
         kwargs
             Not used.
 
         Returns
         -------
         transmittance : numeric
-            Estimated transmittance ratio.
+            Estimated transmittance (ratio).
         """
         transmittance = ((100.0 - cloud_cover) / 100.0) * offset
 


### PR DESCRIPTION
Corrects the documentation of the **cloud_cover_to_transmittance_linear** function. The current return is documented as the ghi instead of the transmittance. The information "percentage" has been added to the cloud cover and "ratio" to the transmittance.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes [pvlib#1367](https://github.com/pvlib/pvlib-python/issues/1367)
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Updates entries to [`docs/sphinx/source/api.rst`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
