### PR TITLE
Advance numpy from 1.12.0 to 1.16.0

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -115,7 +115,7 @@
         // minimum supported versions
         {
             "python": "3.6",
-            "numpy": "1.12.0",
+            "numpy": "1.16.0",
             "pandas": "0.22.0",
             "scipy": "1.2.0",
             // Note: these don't have a minimum in setup.py

--- a/ci/requirements-py36-min.yml
+++ b/ci/requirements-py36-min.yml
@@ -15,7 +15,7 @@ dependencies:
     - pip:
         - dataclasses
         - h5py==3.1.0
-        - numpy==1.12.0
+        - numpy==1.16.0
         - pandas==0.22.0
         - scipy==1.2.0
         - pytest-rerunfailures # conda version is >3.6

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -10,7 +10,7 @@ dependencies:
     - netcdf4
     - nose
     - numba
-    - numpy >= 1.12.0
+    - numpy >= 1.16.0
     - pandas >= 0.22.0
     - pip
     - pytest

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -10,7 +10,7 @@ dependencies:
     - netcdf4
     - nose
     - numba
-    - numpy >= 1.12.0
+    - numpy >= 1.16.0
     - pandas >= 0.22.0
     - pip
     - pytest

--- a/ci/requirements-py38.yml
+++ b/ci/requirements-py38.yml
@@ -10,7 +10,7 @@ dependencies:
     - netcdf4
     - nose
     - numba
-    - numpy >= 1.12.0
+    - numpy >= 1.16.0
     - pandas >= 0.22.0
     - pip
     - pytest

--- a/ci/requirements-py39.yml
+++ b/ci/requirements-py39.yml
@@ -10,7 +10,7 @@ dependencies:
     # - netcdf4  # pulls in a different version of numpy with ImportError
     - nose
     # - numba  # python 3.9 compat in early 2021
-    - numpy >= 1.12.0
+    - numpy >= 1.16.0
     - pandas >= 0.22.0
     - pip
     - pytest

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -40,7 +40,7 @@ Documentation
 
 Requirements
 ~~~~~~~~~~~~
-* numpy >= 1.16.0 is now required for all python versions.
+* numpy >= 1.16.0 is now required for all python versions. (:pull:`1400`)
 
 
 Contributors

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -40,6 +40,8 @@ Documentation
 
 Requirements
 ~~~~~~~~~~~~
+* numpy >= 1.16.0 is now required for all python versions.
+
 
 Contributors
 ~~~~~~~~~~~~

--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -106,16 +106,16 @@ def test_sandia_multi(cec_inverter_parameters):
     pdcs = idcs * vdcs
     pacs = inverter.sandia_multi((vdcs, vdcs), (pdcs, pdcs),
                                  cec_inverter_parameters)
-    assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
+    assert_series_equal(pacs, pd.Series([-0.020000, 132.004278, 250.000000]))
     # with lists instead of tuples
     pacs = inverter.sandia_multi([vdcs, vdcs], [pdcs, pdcs],
                                  cec_inverter_parameters)
-    assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
+    assert_series_equal(pacs, pd.Series([-0.020000, 132.004278, 250.000000]))
     # with arrays instead of tuples
     pacs = inverter.sandia_multi(np.array([vdcs, vdcs]),
                                  np.array([pdcs, pdcs]),
                                  cec_inverter_parameters)
-    assert_series_equal(pacs, pd.Series([-0.020000, 132.004308, 250.000000]))
+    assert_allclose(pacs, np.array([-0.020000, 132.004278, 250.000000]))
 
 
 def test_sandia_multi_length_error(cec_inverter_parameters):
@@ -184,10 +184,10 @@ def test_pvwatts_multi():
     # with Series
     pdc = pd.Series(pdc)
     out = inverter.pvwatts_multi((pdc, pdc), pdc0, 0.95)
-    assert_series_equal(expected, out)
+    assert_series_equal(pd.Series(expected), out)
     # with list instead of tuple
     out = inverter.pvwatts_multi([pdc, pdc], pdc0, 0.95)
-    assert_series_equal(expected, out)
+    assert_series_equal(pd.Series(expected), out)
 
 
 INVERTER_TEST_MEAS = DATA_DIR / 'inverter_fit_snl_meas.csv'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ AUTHOR = 'pvlib python Developers'
 MAINTAINER_EMAIL = 'holmgren@email.arizona.edu'
 URL = 'https://github.com/pvlib/pvlib-python'
 
-INSTALL_REQUIRES = ['numpy >= 1.12.0',
+INSTALL_REQUIRES = ['numpy >= 1.16.0',
                     'pandas >= 0.22.0',
                     'pytz',
                     'requests',


### PR DESCRIPTION
 - [x] Closes #1399
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Advance numpy to 1.16.0 or later. Repair some poorly formed tests for inverter.py.
