### PR TITLE
Deprecate modelchain.basic_chain

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -8,6 +8,11 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
+* :py:func:`pvlib.modelchain.basic_chain` is deprecated.
+  See :py:meth:`pvlib.modelchain.ModelChain.with_pvwatts` for a simplified
+  :py:class:`~pvlib.modelchain.ModelChain` interface, although note that the
+  model parameters for :py:func:`~pvlib.modelchain.basic_chain` do not directly
+  translate. (:pull:`1401`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -9,10 +9,10 @@ Breaking changes
 Deprecations
 ~~~~~~~~~~~~
 * :py:func:`pvlib.modelchain.basic_chain` is deprecated.
-  See :py:meth:`pvlib.modelchain.ModelChain.with_pvwatts` for a simplified
-  :py:class:`~pvlib.modelchain.ModelChain` interface, although note that the
-  model parameters for :py:func:`~pvlib.modelchain.basic_chain` do not directly
-  translate. (:pull:`1401`)
+  See :py:meth:`pvlib.modelchain.ModelChain.with_pvwatts` and
+  :py:meth:`pvlib.modelchain.ModelChain.with_sapm` for alternative simplified
+  :py:class:`~pvlib.modelchain.ModelChain` interfaces, although note that the
+  inputs do not directly translate. (:pull:`1401`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -67,8 +67,9 @@ SAPM_CONFIG = dict(
 @deprecated(
     since='0.9.1',
     name='pvlib.modelchain.basic_chain',
-    alternative='pvlib.modelchain.ModelChain.with_pvwatts',
-    addendum='Note that with_pvwatts takes different model parameters.'
+    alternative=('pvlib.modelchain.ModelChain.with_pvwatts'
+                 ' or pvlib.modelchain.ModelChain.with_sapm'),
+    addendum='Note that the with_xyz methods take different model parameters.'
 )
 def basic_chain(times, latitude, longitude,
                 surface_tilt, surface_azimuth,

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -64,7 +64,9 @@ SAPM_CONFIG = dict(
 )
 
 
-@deprecated(since='0.9.1', name='pvlib.modelchain.basic_chain',
+@deprecated(
+    since='0.9.1',
+    name='pvlib.modelchain.basic_chain',
     alternative='pvlib.modelchain.ModelChain.with_pvwatts',
     addendum='Note that with_pvwatts takes different model parameters.'
 )

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -21,6 +21,8 @@ from pvlib.pvsystem import _DC_MODEL_PARAMS
 from pvlib._deprecation import pvlibDeprecationWarning
 from pvlib.tools import _build_kwargs
 
+from pvlib._deprecation import deprecated
+
 # keys that are used to detect input data and assign data to appropriate
 # ModelChain attribute
 # for ModelChain.weather
@@ -62,6 +64,10 @@ SAPM_CONFIG = dict(
 )
 
 
+@deprecated(since='0.9.1', name='pvlib.modelchain.basic_chain',
+    alternative='pvlib.modelchain.ModelChain.with_pvwatts',
+    addendum='Note that with_pvwatts takes different model parameters.'
+)
 def basic_chain(times, latitude, longitude,
                 surface_tilt, surface_azimuth,
                 module_parameters, temperature_model_parameters,

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1799,10 +1799,11 @@ def test_basic_chain_alt_az(sam_data, cec_inverter_parameters,
     modules = sam_data['sandiamod']
     module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
     temp_model_params = sapm_temperature_cs5p_220m.copy()
-    dc, ac = modelchain.basic_chain(times, latitude, longitude,
-                                    surface_tilt, surface_azimuth,
-                                    module_parameters, temp_model_params,
-                                    cec_inverter_parameters)
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+        dc, ac = modelchain.basic_chain(times, latitude, longitude,
+                                        surface_tilt, surface_azimuth,
+                                        module_parameters, temp_model_params,
+                                        cec_inverter_parameters)
 
     expected = pd.Series(np.array([111.621405, -2.00000000e-02]),
                          index=times)
@@ -1821,21 +1822,23 @@ def test_basic_chain_altitude_pressure(sam_data, cec_inverter_parameters,
     modules = sam_data['sandiamod']
     module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
     temp_model_params = sapm_temperature_cs5p_220m.copy()
-    dc, ac = modelchain.basic_chain(times, latitude, longitude,
-                                    surface_tilt, surface_azimuth,
-                                    module_parameters, temp_model_params,
-                                    cec_inverter_parameters,
-                                    pressure=93194)
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+        dc, ac = modelchain.basic_chain(times, latitude, longitude,
+                                        surface_tilt, surface_azimuth,
+                                        module_parameters, temp_model_params,
+                                        cec_inverter_parameters,
+                                        pressure=93194)
 
     expected = pd.Series(np.array([113.190045, -2.00000000e-02]),
                          index=times)
     assert_series_equal(ac, expected)
 
-    dc, ac = modelchain.basic_chain(times, latitude, longitude,
-                                    surface_tilt, surface_azimuth,
-                                    module_parameters, temp_model_params,
-                                    cec_inverter_parameters,
-                                    altitude=altitude)
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+        dc, ac = modelchain.basic_chain(times, latitude, longitude,
+                                        surface_tilt, surface_azimuth,
+                                        module_parameters, temp_model_params,
+                                        cec_inverter_parameters,
+                                        altitude=altitude)
 
     expected = pd.Series(np.array([113.189814, -2.00000000e-02]),
                          index=times)

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1799,7 +1799,7 @@ def test_basic_chain_alt_az(sam_data, cec_inverter_parameters,
     modules = sam_data['sandiamod']
     module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
     temp_model_params = sapm_temperature_cs5p_220m.copy()
-    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts'):
         dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                         surface_tilt, surface_azimuth,
                                         module_parameters, temp_model_params,
@@ -1822,7 +1822,7 @@ def test_basic_chain_altitude_pressure(sam_data, cec_inverter_parameters,
     modules = sam_data['sandiamod']
     module_parameters = modules['Canadian_Solar_CS5P_220M___2009_']
     temp_model_params = sapm_temperature_cs5p_220m.copy()
-    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts'):
         dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                         surface_tilt, surface_azimuth,
                                         module_parameters, temp_model_params,
@@ -1833,7 +1833,7 @@ def test_basic_chain_altitude_pressure(sam_data, cec_inverter_parameters,
                          index=times)
     assert_series_equal(ac, expected)
 
-    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts instead'):
+    with pytest.warns(pvlibDeprecationWarning, match='with_pvwatts'):
         dc, ac = modelchain.basic_chain(times, latitude, longitude,
                                         surface_tilt, surface_azimuth,
                                         module_parameters, temp_model_params,


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~ 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

See https://github.com/pvlib/pvlib-python/discussions/1385#discussioncomment-2035493

Do we remove functions from the API listing at deprecation or at removal?  SingleAxisTracker and some other deprecated things are currently listed, so I've not removed `basic_chain` here. 