### PR TITLE
Fix tiny typo in docs

### DIFF
--- a/docs/sphinx/source/user_guide/modelchain.rst
+++ b/docs/sphinx/source/user_guide/modelchain.rst
@@ -15,7 +15,7 @@ A :py:class:`~.modelchain.ModelChain` has three components:
 
 * a :py:class:`~.pvsystem.PVSystem` object, representing a collection of modules and inverters
 * a :py:class:`~.location.Location` object, representing a location on the planet
-* values for attributes that specify the model to be used for for each step in the PV modeling
+* values for attributes that specify the model to be used for each step in the PV modeling
   process.
 
 Modeling with a :py:class:`~.ModelChain` typically involves 3 steps:

--- a/docs/sphinx/source/user_guide/pvsystem.rst
+++ b/docs/sphinx/source/user_guide/pvsystem.rst
@@ -117,7 +117,7 @@ PVSystem and Arrays
 The PVSystem class can represent a PV system with a single array of modules,
 or with multiple arrays. For a PV system with a single array, the parameters
 that describe the array can be provided directly to the PVSystem instand.
-For example, the parameters that describe the array's modules are can be
+For example, the parameters that describe the array's modules can be
 passed to `PVSystem.module_parameters`:
 
 .. ipython:: python

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -53,7 +53,7 @@ Documentation
 ~~~~~~~~~~~~~
 * Fix documentation return error in :py:meth:`pvlib.forecast.ForecastModel.cloud_cover_to_transmittance_linear`
   (:issue:`1367`, :pull:`1370`)
-
+* Fix some typos.
 
 Requirements
 ~~~~~~~~~~~~
@@ -69,3 +69,4 @@ Contributors
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
 * Johann Loux (:ghuser:`JoLo90`)
+* Jack Kelly (:ghuser:`JackKelly`)

--- a/docs/sphinx/source/whatsnew/v0.9.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.1.rst
@@ -53,7 +53,7 @@ Documentation
 ~~~~~~~~~~~~~
 * Fix documentation return error in :py:meth:`pvlib.forecast.ForecastModel.cloud_cover_to_transmittance_linear`
   (:issue:`1367`, :pull:`1370`)
-* Fix some typos.
+* Fix some typos (:pull:`1414`)
 
 Requirements
 ~~~~~~~~~~~~

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -305,7 +305,7 @@ def pvsyst_cell(poa_global, temp_air, wind_speed=1.0, u_c=29.0, u_v=0.0,
 
     wind_speed : numeric, default 1.0
         Wind speed in m/s measured at the same height for which the wind loss
-        factor was determined.  The default value 1.0 m/2 is the wind
+        factor was determined.  The default value 1.0 m/s is the wind
         speed at module height used to determine NOCT. [m/s]
 
     u_c : float, default 29.0


### PR DESCRIPTION
A _tiny_ PR! Just fixing a tiny typo in the docs :slightly_smiling_face: 

 - ~~[ ] Closes #xxxx~~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.
