### PR TITLE
Update sphinx to 4.5.0

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -20,6 +20,9 @@ import warnings
 # for generating GH links with linenumbers
 import inspect
 
+# import distutils before calling pd.show_versions()
+# https://github.com/pypa/setuptools/issues/3044
+import distutils  # noqa: F401
 import pandas as pd
 pd.show_versions()
 

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -244,7 +244,7 @@ def setup(app):
     # In-line links to references as numbers in brackets.
     app.add_css_file("reference_format.css")
     # Add a warning banner at the top of the page if viewing the "latest" docs
-    app.add_javascript("version-alert.js")
+    app.add_js_file("version-alert.js")
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -342,8 +342,6 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
 }
-
-nbsphinx_allow_errors = True
 
 ipython_warning_is_error = False
 

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,11 @@ EXTRAS_REQUIRE = {
     'optional': ['cython', 'ephem', 'netcdf4', 'nrel-pysam', 'numba',
                  'pvfactors', 'siphon', 'statsmodels',
                  'cftime >= 1.1.1'],
-    'doc': ['ipython', 'matplotlib', 'sphinx == 3.1.2',
-            'pydata-sphinx-theme == 0.8.0', 'sphinx-gallery',
+    # sphinx 4.4.0 has an annoying, difficult-to-disable, warning about
+    # extlinks: https://github.com/sphinx-doc/sphinx/issues/10112
+    # So stick with <4.4.0 for now.
+    'doc': ['ipython', 'matplotlib', 'sphinx == 4.3.2',
+            'pydata-sphinx-theme == 0.8.1', 'sphinx-gallery',
             'docutils == 0.15.2', 'pillow', 'netcdf4', 'siphon',
             'sphinx-toggleprompt >= 0.0.5', 'pvfactors'],
     'test': TESTS_REQUIRE

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,7 @@ EXTRAS_REQUIRE = {
     'optional': ['cython', 'ephem', 'netcdf4', 'nrel-pysam', 'numba',
                  'pvfactors', 'siphon', 'statsmodels',
                  'cftime >= 1.1.1'],
-    # sphinx 4.4.0 has an annoying, difficult-to-disable, warning about
-    # extlinks: https://github.com/sphinx-doc/sphinx/issues/10112
-    # So stick with <4.4.0 for now.
-    'doc': ['ipython', 'matplotlib', 'sphinx == 4.3.2',
+    'doc': ['ipython', 'matplotlib', 'sphinx == 4.5.0',
             'pydata-sphinx-theme == 0.8.1', 'sphinx-gallery',
             'docutils == 0.15.2', 'pillow', 'netcdf4', 'siphon',
             'sphinx-toggleprompt >= 0.0.5', 'pvfactors'],


### PR DESCRIPTION
 - [x] Closes #1284
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

This should fix the docs build issue (e.g. #1434) of incompatibility between the latest jinja2 version and our older sphinx.  I didn't see any build issues when I ran it locally, but I'll check again on the CI build. 