### PR TITLE
Advance numba from 0.36.1 to 0.40.0

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -121,7 +121,7 @@
             // Note: these don't have a minimum in setup.py
             "h5py": "2.10.0",
             "ephem": "3.7.6.0",
-            "numba": "0.36.1",
+            "numba": "0.40.0",
         },
         // latest versions available
         {

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -14,13 +14,15 @@ Bug fixes
 * :py:func:`pvlib.irradiance.get_total_irradiance` and
   :py:func:`pvlib.solarposition.spa_python` now raise an error instead
   of silently ignoring unknown parameters (:ghpull:`1437`)
-* Updated version of numba in asv.conf from 0.36.1 to 0.40.0 to solve numba/numpy conflict. (:issue:`1439`, :pull:`1440`)
 Testing
 ~~~~~~~
 
 Documentation
 ~~~~~~~~~~~~~
 
+Benchmarking
+~~~~~~~~~~~~~
+* Updated version of numba in asv.conf from 0.36.1 to 0.40.0 to solve numba/numpy conflict. (:issue:`1439`, :pull:`1440`)
 Requirements
 ~~~~~~~~~~~~
 

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -14,7 +14,7 @@ Bug fixes
 * :py:func:`pvlib.irradiance.get_total_irradiance` and
   :py:func:`pvlib.solarposition.spa_python` now raise an error instead
   of silently ignoring unknown parameters (:ghpull:`1437`)
-  
+* Updated version of numba in asv.conf from 0.36.1 to 0.40.0 to solve numba/numpy conflict. (:issue:`1439`, :pull:`1440`)
 Testing
 ~~~~~~~
 


### PR DESCRIPTION
- [x] Closes https://github.com/pvlib/pvlib-python/issues/1439
- [x]  I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
- [x] Adds description and name entries in the appropriate "what's new" file in [docs/sphinx/source/whatsnew](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with :issue:`num` or this Pull Request with :pull:`num`. Includes contributor name and/or GitHub username (link with :ghuser:`user`).
- [x] Pull request is nearly complete and ready for detailed review.

Updated numba version from 0.36.1 to 0.40.0 in asv.conf