### PR TITLE
Added Benchmarking functions for scaling.py module

### DIFF
--- a/benchmarks/benchmarks/scaling.py
+++ b/benchmarks/benchmarks/scaling.py
@@ -1,0 +1,33 @@
+"""
+ASV benchmarks for scaling.py
+"""
+
+import pandas as pd
+from pvlib import scaling
+import numpy as np
+
+
+class Scaling:
+
+    def setup(self):
+        self.n = 1000
+        lat = np.array((9.99, 10, 10.01))
+        lon = np.array((4.99, 5, 5.01))
+        self.coordinates = np.array([(lati, loni) for (lati, loni) in zip(lat, lon)])
+        self.times = pd.date_range('2019-01-01', freq='1T', periods=self.n)
+        self.positions = np.array([[0, 0], [100, 0], [100, 100], [0, 100]])
+        self.clearsky_index = pd.Series(np.random.rand(self.n), index=self.times)
+        self.cloud_speed = 5
+        self.tmscales = np.array((1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096))
+
+    def time_latlon_to_xy(self):
+        scaling.latlon_to_xy(self.coordinates)
+
+    def time__compute_wavelet(self):
+        scaling._compute_wavelet(self.clearsky_index, dt=1)
+
+    def time__compute_vr(self):
+        scaling._compute_vr(self.positions, self.cloud_speed, self.tmscales)
+
+    def time_wvm(self):
+        scaling.wvm(self.clearsky_index, self.positions, self.cloud_speed, dt=1)

--- a/benchmarks/benchmarks/scaling.py
+++ b/benchmarks/benchmarks/scaling.py
@@ -13,12 +13,14 @@ class Scaling:
         self.n = 1000
         lat = np.array((9.99, 10, 10.01))
         lon = np.array((4.99, 5, 5.01))
-        self.coordinates = np.array([(lati, loni) for (lati, loni) in zip(lat, lon)])
+        self.coordinates = np.array([(lati, loni) for 
+                                     (lati, loni) in zip(lat, lon)])
         self.times = pd.date_range('2019-01-01', freq='1T', periods=self.n)
         self.positions = np.array([[0, 0], [100, 0], [100, 100], [0, 100]])
         self.clearsky_index = pd.Series(np.random.rand(self.n), index=self.times)
         self.cloud_speed = 5
-        self.tmscales = np.array((1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096))
+        self.tmscales = np.array((1, 2, 4, 8, 16, 32, 64, 
+                                 128, 256, 512, 1024, 2048, 4096))
 
     def time_latlon_to_xy(self):
         scaling.latlon_to_xy(self.coordinates)
@@ -30,4 +32,5 @@ class Scaling:
         scaling._compute_vr(self.positions, self.cloud_speed, self.tmscales)
 
     def time_wvm(self):
-        scaling.wvm(self.clearsky_index, self.positions, self.cloud_speed, dt=1)
+        scaling.wvm(self.clearsky_index, self.positions,
+                    self.cloud_speed, dt=1)

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -23,6 +23,7 @@ Documentation
 Benchmarking
 ~~~~~~~~~~~~~
 * Updated version of numba in asv.conf from 0.36.1 to 0.40.0 to solve numba/numpy conflict. (:issue:`1439`, :pull:`1440`)
+* Added Benchmarking for :py:func:`pvlib.scaling.latlon_to_xy`, :py:func:`pvlib.scaling._compute_wavelet`, :py:func:`pvlib.scaling._compute_vr`, and :py:func:`pvlib.scaling.wvm` functions for the module `scaling`
 Requirements
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Created and Added Benchmarking for `pvlib.scaling.latlon_to_xy`, `pvlib.scaling._compute_wavelet`, `pvlib.scaling._compute_vr`, and `pvlib.scaling.wvm` functions for the module `scaling`

 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.