### PR TITLE
docstring updated to indicate limits of axis_tilt

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -52,3 +52,4 @@ Contributors
 * Prajwal Borkar (:ghuser:`PrajwalBorkar`) 
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Kurt Rhee (:ghuser:`kurt-rhee`)

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -21,6 +21,7 @@ class SingleAxisTracker(PVSystem):
     axis_tilt : float, default 0
         The tilt of the axis of rotation (i.e, the y-axis defined by
         axis_azimuth) with respect to horizontal, in decimal degrees.
+        axis_azimuth must be >= 0 and <= 90.
 
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -527,10 +527,9 @@ def calc_surface_orientation(tracker_theta, axis_tilt=0, axis_azimuth=0):
 def calc_axis_tilt(slope_azimuth, slope_tilt, axis_azimuth):
     """
     Calculate tracker axis tilt in the global reference frame when on a sloped
-    plane. Tracker axis tilt is a limited positive angle equaling a minimum of
-    0 when the normal vector of the module's surface points straight skyward,
-    parallel to the z-axis and a maximum of 90 when the normal vector of the
-    modules surface is parallel with the y-axis.
+    plane. Axis tilt is the inclination of the tracker rotation axis with
+    respect to horizontal, ranging from 0 degrees (horizontal axis) to 90
+    degrees (vertical axis).
 
     Parameters
     ----------

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -295,8 +295,8 @@ def singleaxis(apparent_zenith, apparent_azimuth,
 
     axis_tilt : float, default 0
         The tilt of the axis of rotation (i.e, the y-axis defined by
-        axis_azimuth) with respect to horizontal, in decimal degrees.
-        axis_tilt must be >= 0 and <= 90.
+        ``axis_azimuth``) with respect to horizontal.
+        ``axis_tilt`` must be >= 0 and <= 90. [degree]
 
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -20,8 +20,8 @@ class SingleAxisTracker(PVSystem):
     ----------
     axis_tilt : float, default 0
         The tilt of the axis of rotation (i.e, the y-axis defined by
-        axis_azimuth) with respect to horizontal, in decimal degrees.
-        axis_tilt must be >= 0 and <= 90.
+        ``axis_azimuth``) with respect to horizontal.
+        ``axis_tilt`` must be >= 0 and <= 90. [degree]
 
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -644,8 +644,8 @@ def calc_cross_axis_tilt(
     axis_azimuth : float
         direction of tracker axes projected on the horizontal [degrees]
     axis_tilt : float
-        tilt of trackers relative to horizontal.  axis_tilt must be >= 0
-        and <= 90.[degrees]
+        tilt of trackers relative to horizontal.  ``axis_tilt`` must be >= 0
+        and <= 90. [degree]
 
     Returns
     -------

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -21,7 +21,7 @@ class SingleAxisTracker(PVSystem):
     axis_tilt : float, default 0
         The tilt of the axis of rotation (i.e, the y-axis defined by
         axis_azimuth) with respect to horizontal, in decimal degrees.
-        axis_azimuth must be >= 0 and <= 90.
+        axis_tilt must be >= 0 and <= 90.
 
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of
@@ -296,6 +296,7 @@ def singleaxis(apparent_zenith, apparent_azimuth,
     axis_tilt : float, default 0
         The tilt of the axis of rotation (i.e, the y-axis defined by
         axis_azimuth) with respect to horizontal, in decimal degrees.
+        axis_tilt must be >= 0 and <= 90.
 
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of
@@ -482,6 +483,7 @@ def calc_surface_orientation(tracker_theta, axis_tilt=0, axis_azimuth=0):
         results in ``surface_azimuth`` to the East. [degree]
     axis_tilt : float, default 0
         The tilt of the axis of rotation with respect to horizontal. [degree]
+        axis_tilt must be >= 0 and <= 90.
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of
         rotation lies. Measured east of north. [degree]
@@ -525,7 +527,10 @@ def calc_surface_orientation(tracker_theta, axis_tilt=0, axis_azimuth=0):
 def calc_axis_tilt(slope_azimuth, slope_tilt, axis_azimuth):
     """
     Calculate tracker axis tilt in the global reference frame when on a sloped
-    plane.
+    plane. Tracker axis tilt is a limited positive angle equaling a minimum of
+    0 when the normal vector of the module's surface points straight skyward,
+    parallel to the z-axis and a maximum of 90 when the normal vector of the
+    modules surface is parallel with the y-axis.
 
     Parameters
     ----------
@@ -640,7 +645,8 @@ def calc_cross_axis_tilt(
     axis_azimuth : float
         direction of tracker axes projected on the horizontal [degrees]
     axis_tilt : float
-        tilt of trackers relative to horizontal [degrees]
+        tilt of trackers relative to horizontal.  axis_tilt must be >= 0
+        and <= 90.[degrees]
 
     Returns
     -------

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -482,8 +482,8 @@ def calc_surface_orientation(tracker_theta, axis_tilt=0, axis_azimuth=0):
         results in ``surface_azimuth`` to the West while ``tracker_theta < 0``
         results in ``surface_azimuth`` to the East. [degree]
     axis_tilt : float, default 0
-        The tilt of the axis of rotation with respect to horizontal. [degree]
-        axis_tilt must be >= 0 and <= 90.
+        The tilt of the axis of rotation with respect to horizontal.
+        ``axis_tilt`` must be >= 0 and <= 90.  [degree]
     axis_azimuth : float, default 0
         A value denoting the compass direction along which the axis of
         rotation lies. Measured east of north. [degree]


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [Y] Adds docstring information from discussion in #1471 
 - [Y] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [N] Tests added
 - [N] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [N] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [Y] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [Y] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
