### PR TITLE
Improve nonuniform timestamps error message for prilliman and detect_clearsky

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -11,6 +11,9 @@ Enhancements
 * Add :py:func:`pvlib.tracking.calc_surface_orientation` for calculating
   single-axis tracker ``surface_tilt`` and ``surface_azimuth`` from
   rotation angles. (:issue:`1471`, :pull:`1480`)
+* Improve error message about uneven time intervals for
+  :py:func:`~pvlib.clearsky.detect_clearsky` and :py:func:`~pvlib.temperature.prilliman`
+  (:issue:`1476`, :pull:`1490`)
 
 Bug fixes
 ~~~~~~~~~
@@ -52,3 +55,4 @@ Contributors
 * Prajwal Borkar (:ghuser:`PrajwalBorkar`) 
 * Kevin Anderson (:ghuser:`kanderso-nrel`)
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Will Hobbs (:ghuser:`williamhobbs`)

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -839,7 +839,8 @@ def prilliman(temp_cell, wind_speed, unit_mass=11.1, coefficients=None):
     .. warning::
         This implementation requires the time series inputs to be regularly
         sampled in time with frequency less than 20 minutes.  Data with
-        irregular time steps should be resampled prior to using this function.
+        irregular time steps (including from data gaps, missing leap days,
+        etc) should be resampled prior to using this function.
 
     Parameters
     ----------

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -406,5 +406,9 @@ def _get_sample_intervals(times, win_length):
         samples_per_window = int(win_length / sample_interval)
         return sample_interval, samples_per_window
     else:
-        raise NotImplementedError('algorithm does not yet support unequal '
-                                  'times. consider resampling your data.')
+        message = (
+            'algorithm does not yet support unequal time intervals. consider '
+            'resampling your data and checking for gaps from missing '
+            'periods, leap days, etc.'
+        )
+        raise NotImplementedError(message)


### PR DESCRIPTION
 - [x] Closes #1476
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

@williamhobbs, does this change adequately address #1476?