### PR TITLE
Make leap_day=True default for PSM3 (deprecation)

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -24,6 +24,10 @@ Bug fixes
   where passing localized timezones with large UTC offsets could return
   rise/set/transit times for the wrong day in recent versions of ``ephem``
   (:issue:`1449`, :pull:`1448`)
+* :py:func:`pvlib.iotools.get_psm3` now raises a deprecation warning if
+  the `leap_day` parameter is not specified. Starting in pvlib 0.11.0
+  `leap_day` will be default to True instead of False.
+  (:issue:`1481`, :pull:`1511`)
 
 
 Testing

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -24,9 +24,9 @@ Bug fixes
   where passing localized timezones with large UTC offsets could return
   rise/set/transit times for the wrong day in recent versions of ``ephem``
   (:issue:`1449`, :pull:`1448`)
-* :py:func:`pvlib.iotools.get_psm3` now raises a deprecation warning if
-  the `leap_day` parameter is not specified. Starting in pvlib 0.11.0
-  `leap_day` will be default to True instead of False.
+* :py:func:`pvlib.iotools.get_psm3` now raises a deprecation warning for
+  single-year requests where the `leap_day` parameter is not specified.
+  Starting in pvlib 0.11.0 `leap_day` will default to True instead of False.
   (:issue:`1481`, :pull:`1511`)
 
 

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -24,8 +24,8 @@ Bug fixes
   where passing localized timezones with large UTC offsets could return
   rise/set/transit times for the wrong day in recent versions of ``ephem``
   (:issue:`1449`, :pull:`1448`)
-* :py:func:`pvlib.iotools.get_psm3` now raises a deprecation warning for
-  single-year requests where the `leap_day` parameter is not specified.
+* :py:func:`pvlib.iotools.get_psm3` now raises a deprecation warning if
+  the `leap_day` parameter is not specified in a single-year request.
   Starting in pvlib 0.11.0 `leap_day` will default to True instead of False.
   (:issue:`1481`, :pull:`1511`)
 

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -165,7 +165,7 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
     attributes = [amap.get(a, a) for a in attributes]
     attributes = list(set(attributes))  # remove duplicate values
 
-    if (leap_day is None) & (not names.startswith('t')):
+    if (leap_day is None) and (not names.startswith('t')):
         warnings.warn(
             'The ``get_psm3`` function will default to leap_day=True '
             'starting in pvlib 0.11.0. Specify leap_day=True '

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -42,7 +42,7 @@ VARIABLE_MAP = {
 
 
 def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
-             attributes=ATTRIBUTES, leap_day=False, full_name=PVLIB_PYTHON,
+             attributes=ATTRIBUTES, leap_day=None, full_name=PVLIB_PYTHON,
              affiliation=PVLIB_PYTHON, map_variables=None, timeout=30):
     """
     Retrieve NSRDB PSM3 timeseries weather data from the PSM3 API. The NSRDB
@@ -164,6 +164,14 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
             VARIABLE_MAP.items()}
     attributes = [amap.get(a, a) for a in attributes]
     attributes = list(set(attributes))  # remove duplicate values
+
+    if leap_day is None:
+        warnings.warn(
+            'The ``get_psm3`` function will default to leap_day=True '
+            'starting in pvlib 0.11.0. Specify leap_day=True '
+            'to enable this behavior now, or specify leap_day=False '
+            'to hide this warning.', pvlibDeprecationWarning)
+        leap_day = False
 
     # required query-string parameters for request to PSM3 API
     params = {

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -165,7 +165,7 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
     attributes = [amap.get(a, a) for a in attributes]
     attributes = list(set(attributes))  # remove duplicate values
 
-    if leap_day is None:
+    if (leap_day is None) & (not names.startswith('t')):
         warnings.warn(
             'The ``get_psm3`` function will default to leap_day=True '
             'starting in pvlib 0.11.0. Specify leap_day=True '


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1481 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~~
 - ~~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
It has been decided to change the default value for the `leap_day` argument in the `get_psm3` function from False to True (see #1481). This PR adds a deprecation warning stating that the default will be changed to `leap_day=True` in pvlib 0.11.