### PR TITLE
Update benchmark for tracking.py

### DIFF
--- a/benchmarks/benchmarks/tracking.py
+++ b/benchmarks/benchmarks/tracking.py
@@ -28,8 +28,4 @@ class SingleAxis:
                                 max_angle=60,
                                 backtrack=True,
                                 gcr=0.45)
-
-    def time_tracker_singleaxis(self):
-        with np.errstate(invalid='ignore'):
-            self.tracker.singleaxis(self.solar_position.apparent_zenith,
-                                    self.solar_position.azimuth)
+            

--- a/benchmarks/benchmarks/tracking.py
+++ b/benchmarks/benchmarks/tracking.py
@@ -28,4 +28,3 @@ class SingleAxis:
                                 max_angle=60,
                                 backtrack=True,
                                 gcr=0.45)
-            

--- a/docs/sphinx/source/whatsnew/v0.9.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.2.rst
@@ -48,6 +48,7 @@ Benchmarking
 * Updated version of numba in asv.conf from 0.36.1 to 0.40.0 to solve numba/numpy conflict. (:issue:`1439`, :pull:`1440`)
 * Added benchmarks for the `pvlib.scaling` module (:pull:`1445`)
 * Added a basic CI asv check (:issue:`1446`, :pull:`1454`)
+* Removed ``time_tracker_singleaxis`` function from tracking.py (:issue:`1508`, :pull:`1525`)
 
 Requirements
 ~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1508 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 ~~- [ ] Tests added~~
 ~~- [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 ~~- [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Removed `time_tracker_singleaxis` function from the benchmark file as `SingleAxisTracker` has been deprecated.