### PR TITLE
Include SolarAnywhere API key in pytest-remote-data.yml

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -97,6 +97,7 @@ jobs:
         env:
           # copy GitHub Secrets into environment variables for the tests to access
           NREL_API_KEY: ${{ secrets.NRELAPIKEY }}
+          SOLARANYWHERE_API_KEY: ${{ secrets.SOLARANYWHERE_API_KEY }}
           BSRN_FTP_USERNAME: ${{ secrets.BSRN_FTP_USERNAME }}
           BSRN_FTP_PASSWORD: ${{ secrets.BSRN_FTP_PASSWORD }}
         run: pytest pvlib/tests/iotools pvlib/tests/test_forecast.py --cov=./ --cov-report=xml --remote-data


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR includes the SolarAnywhere API key in the pytest-remote-data.yml file. The API key is used for testing in #1497, however, it needs to be available to the main branch prior to merging of #1497 as the API key is required for the remote tests to work.

> I think it is just the annoying but secure behavior of `pull-request-target` not respecting `yml` changes in the PR -- your update to include the SA key in the environment isn't taking effect because the action is defined by the `.github/workflows/pytest-remote-data.yml` file on `master`, not this PR branch.  I guess the cleanest workaround is to submit a separate PR to change `pytest-remote-data.yml`, merge that, then merge master into this PR?

_Originally posted by @kanderso-nrel in https://github.com/pvlib/pvlib-python/issues/1497#issuecomment-1217214190_