### PR TITLE
Fix PyPI deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
     - master
+    tags:
+    - "v*"
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.


@wholmgren tagged v0.9.2-alpha.1 yesterday (https://github.com/pvlib/pvlib-python/pull/1483#issuecomment-1216828879) but the deploy workflow [run](https://github.com/pvlib/pvlib-python/runs/7885224844?check_suite_focus=true) for that commit skipped the PyPI upload step.  I think, due to an error I made in #1306, the problem is that the workflow was triggered only by the push, not the tag, so the `github.ref` was `master` and not `v0.9.2-alpha.1` and that step was skipped.  This PR introduces version tags as another trigger for that workflow, so the workflow should be run both on the initial push to master (skipping PyPI upload) and the subsequent version tag (activating the PyPI upload).

Would like to get this merged ASAP to not further delay evaluation of the build/install changes ahead of the final 0.9.2 release.