### PR TITLE
removing the parameter *closed* from the pandas dataframes in the exa…

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -4,7 +4,7 @@ v0.9.3 (TBD)
 ------------------------
 
 Deprecations
-~~~~~~~~~~~~
+- removing the parameter *closed* from the pandas dataframes in the examples because it is deprecated for pandas >= 1.4.0.
 
 
 Enhancements
@@ -32,5 +32,5 @@ Requirements
 
 
 Contributors
-~~~~~~~~~~~~
+- Joao Guilherme
 


### PR DESCRIPTION
…mples because it is deprecated for pandas >= 1.4.0.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
