### PR TITLE
Removing the 'closed' kwarg from pd.date_range in gallery examples 

### DIFF
--- a/docs/examples/solar-position/plot_sunpath_diagrams.py
+++ b/docs/examples/solar-position/plot_sunpath_diagrams.py
@@ -24,8 +24,7 @@ import matplotlib.pyplot as plt
 tz = 'Asia/Calcutta'
 lat, lon = 28.6, 77.2
 
-times = pd.date_range('2019-01-01 00:00:00', '2020-01-01', closed='left',
-                      freq='H', tz=tz)
+times = pd.date_range('2019-01-01 00:00:00', '2020-01-01', freq='H', tz=tz)
 solpos = solarposition.get_solarposition(times, lat, lon)
 # remove nighttime
 solpos = solpos.loc[solpos['apparent_elevation'] > 0, :]

--- a/docs/examples/solar-tracking/plot_single_axis_tracking.py
+++ b/docs/examples/solar-tracking/plot_single_axis_tracking.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 tz = 'US/Eastern'
 lat, lon = 40, -80
 
-times = pd.date_range('2019-01-01', '2019-01-02', closed='left', freq='5min',
+times = pd.date_range('2019-01-01', '2019-01-02', freq='5min',
                       tz=tz)
 solpos = solarposition.get_solarposition(times, lat, lon)
 

--- a/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
+++ b/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
@@ -91,8 +91,7 @@ lat, lon = 40, -80
 gcr = 0.4
 
 # calculate the solar position
-times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', closed='left',
-                      freq='1min', tz=tz)
+times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', freq='1min',tz=tz)
 solpos = solarposition.get_solarposition(times, lat, lon)
 
 # compare the backtracking angle at various terrain slopes

--- a/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
+++ b/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
@@ -92,7 +92,7 @@ gcr = 0.4
 
 # calculate the solar position
 times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', freq='1min',
-                       tz=tz)
+                      tz=tz)
 solpos = solarposition.get_solarposition(times, lat, lon)
 
 # compare the backtracking angle at various terrain slopes

--- a/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
+++ b/docs/examples/solar-tracking/plot_single_axis_tracking_on_sloped_terrain.py
@@ -91,7 +91,8 @@ lat, lon = 40, -80
 gcr = 0.4
 
 # calculate the solar position
-times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', freq='1min',tz=tz)
+times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', freq='1min',
+                       tz=tz)
 solpos = solarposition.get_solarposition(times, lat, lon)
 
 # compare the backtracking angle at various terrain slopes

--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -5,7 +5,7 @@ v0.9.3 (TBD)
 
 Deprecations
 ~~~~~~~~~~~~
-
+it was removed the tag *close* in the examples files, since it was unsual and it is deprecated for pandas >= 1.4.0.
 
 Enhancements
 ~~~~~~~~~~~~
@@ -33,4 +33,4 @@ Requirements
 
 Contributors
 ~~~~~~~~~~~~
-
+João Guilherme

--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -5,7 +5,7 @@ v0.9.3 (TBD)
 
 Deprecations
 ~~~~~~~~~~~~
-it was removed the tag *close* in the examples files, since it was unsual and it is deprecated for pandas >= 1.4.0.
+  * Removed the kwarg `close` from `pd.date_range` in the examples since it is deprecated for pandas >= 1.4.0. (:pull:`1540`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -5,7 +5,7 @@ v0.9.3 (TBD)
 
 Deprecations
 ~~~~~~~~~~~~
-  * Removed the kwarg `close` from `pd.date_range` in the examples since it is deprecated for pandas >= 1.4.0. (:pull:`1540`)
+  * Removed the kwarg ``closed`` from ``pd.date_range`` in the examples since it is deprecated for pandas >= 1.4.0. (:pull:`1540`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -33,4 +33,4 @@ Requirements
 
 Contributors
 ~~~~~~~~~~~~
-João Guilherme
+João Guilherme (:ghuser:`joaoguilhermeS`)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - ~~[ ] Closes #xxxx~~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
