### PR TITLE
Fix ASV benchmark configuration issues; don't run benchmarks on non-master fork branches

### DIFF
--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.9.7'
 
       - name: Install asv
-        run: pip install asv==0.4.2
+        run: pip install asv==0.4.2 build
 
       - name: Run asv benchmarks
         run: |

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -4,7 +4,7 @@ name: asv
 on: [pull_request, push]
 
 jobs:
-  quick:
+  quick-benchmarks:
     runs-on: ubuntu-latest
     defaults: 
       run:

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -27,4 +27,4 @@ jobs:
         run: |
           cd benchmarks
           asv machine --yes
-          asv run HEAD^! --quick --dry-run --show-stderr --verbose
+          asv run HEAD^! --quick --dry-run --show-stderr

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -27,4 +27,4 @@ jobs:
         run: |
           cd benchmarks
           asv machine --yes
-          asv run HEAD^! --quick --dry-run --show-stderr
+          asv run HEAD^! --quick --dry-run --show-stderr --verbose

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -27,8 +27,4 @@ jobs:
         run: |
           cd benchmarks
           asv machine --yes
-          asv run HEAD^! --quick --dry-run --show-stderr | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
-          if grep "failed" benchmarks.log > /dev/null ; then
-              exit 1
-          fi
-        
+          asv run HEAD^! --quick --dry-run --show-stderr

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -1,7 +1,12 @@
 name: asv
 
 # CI ASV CHECK is aimed to verify that the benchmarks execute without error.
-on: [pull_request, push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
 
 jobs:
   quick-benchmarks:

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.9.7'
 
       - name: Install asv
-        run: pip install asv==0.4.2 build
+        run: pip install asv==0.4.2
 
       - name: Run asv benchmarks
         run: |

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -115,6 +115,7 @@
         // minimum supported versions
         {
             "python": "3.7",
+			"build": "",
             "numpy": "1.16.0",
             "pandas": "0.25.0",
             "scipy": "1.2.0",
@@ -126,6 +127,7 @@
         // latest versions available
         {
             "python": "3.8",
+			"build": "",
             "numpy": "",
             "pandas": "",
             "scipy": "",

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -24,8 +24,8 @@
     // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
     "build_command": [
-        "python -m build",
-        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+        "python -m build -o {build_cache_dir}",
+        // "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
 
     // List of branches to benchmark. If not provided, defaults to "master"

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -25,7 +25,6 @@
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
     "build_command": [
         "python -m build -o {build_cache_dir}",
-        // "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
 
     // List of branches to benchmark. If not provided, defaults to "master"

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -114,7 +114,7 @@
         // minimum supported versions
         {
             "python": "3.7",
-			"build": "",
+            "build": "",
             "numpy": "1.16.0",
             "pandas": "0.25.0",
             "scipy": "1.2.0",
@@ -126,7 +126,7 @@
         // latest versions available
         {
             "python": "3.8",
-			"build": "",
+            "build": "",
             "numpy": "",
             "pandas": "",
             "scipy": "",

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -23,10 +23,10 @@
     //
     // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
+    "build_command": [
+        "python -m build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR fixes several things:

- First, the ASV jobs have been failing since #1495 because `asv` defaults to calling `setup.py` and wasn't calculating the version string correctly anymore.  This affected both our "quick" CI check and the nightly VM job.
- Second, the "quick" CI check wasn't reporting those failures correctly to the github UI, so it showed up as a green check mark instead of a red X.
- Third, address @wholmgren's comment regarding the CI check for forks: https://github.com/pvlib/pvlib-python/pull/1454#discussion_r884026716