### PR TITLE
Rename `pvwatts` to `pvwattsv5` everywhere

### DIFF
--- a/docs/examples/bifacial/plot_bifi_model_pvwatts.py
+++ b/docs/examples/bifacial/plot_bifi_model_pvwatts.py
@@ -7,7 +7,7 @@ Example of bifacial modeling using pvfactors and procedural method
 
 # %%
 # This example shows how to complete a bifacial modeling example using the
-# :py:func:`pvlib.pvsystem.pvwatts_dc` with the
+# :py:func:`pvlib.pvsystem.pvwattsv5_dc` with the
 # :py:func:`pvlib.bifacial.pvfactors.pvfactors_timeseries` function to
 # transpose GHI data to both front and rear Plane of Array (POA) irradiance.
 
@@ -83,15 +83,15 @@ effective_irrad_bifi = irrad['total_abs_front'] + (irrad['total_abs_back']
 temp_cell = temperature.faiman(effective_irrad_bifi, temp_air=25,
                                wind_speed=1)
 
-# using the pvwatts_dc model and parameters detailed above,
+# using the pvwattsv5_dc model and parameters detailed above,
 # set pdc0 and return DC power for both bifacial and monofacial
 pdc0 = 1
 gamma_pdc = -0.0043
-pdc_bifi = pvsystem.pvwatts_dc(effective_irrad_bifi,
-                               temp_cell,
-                               pdc0,
-                               gamma_pdc=gamma_pdc
-                               ).fillna(0)
+pdc_bifi = pvsystem.pvwattsv5_dc(effective_irrad_bifi,
+                                 temp_cell,
+                                 pdc0,
+                                 gamma_pdc=gamma_pdc
+                                 ).fillna(0)
 pdc_bifi.plot(title='Bifacial Simulation on June Solstice', ylabel='DC Power')
 
 # %%
@@ -99,11 +99,11 @@ pdc_bifi.plot(title='Bifacial Simulation on June Solstice', ylabel='DC Power')
 # irradiance (AOI-corrected), and plot along with bifacial results.
 
 effective_irrad_mono = irrad['total_abs_front']
-pdc_mono = pvsystem.pvwatts_dc(effective_irrad_mono,
-                               temp_cell,
-                               pdc0,
-                               gamma_pdc=gamma_pdc
-                               ).fillna(0)
+pdc_mono = pvsystem.pvwattsv5_dc(effective_irrad_mono,
+                                 temp_cell,
+                                 pdc0,
+                                 gamma_pdc=gamma_pdc
+                                 ).fillna(0)
 
 # plot monofacial results
 plt.figure()

--- a/docs/sphinx/source/reference/modelchain.rst
+++ b/docs/sphinx/source/reference/modelchain.rst
@@ -81,9 +81,11 @@ ModelChain model definitions.
    modelchain.ModelChain.desoto
    modelchain.ModelChain.pvsyst
    modelchain.ModelChain.pvwatts_dc
+   modelchain.ModelChain.pvwattsv5_dc
    modelchain.ModelChain.sandia_inverter
    modelchain.ModelChain.adr_inverter
    modelchain.ModelChain.pvwatts_inverter
+   modelchain.ModelChain.pvwattsv5_inverter
    modelchain.ModelChain.ashrae_aoi_loss
    modelchain.ModelChain.physical_aoi_loss
    modelchain.ModelChain.sapm_aoi_loss
@@ -98,6 +100,7 @@ ModelChain model definitions.
    modelchain.ModelChain.dc_ohmic_model
    modelchain.ModelChain.no_dc_ohmic_loss
    modelchain.ModelChain.pvwatts_losses
+   modelchain.ModelChain.pvwattsv5_losses
    modelchain.ModelChain.no_extra_losses
 
 Inference methods

--- a/docs/sphinx/source/reference/pv_modeling.rst
+++ b/docs/sphinx/source/reference/pv_modeling.rst
@@ -104,7 +104,9 @@ Inverter models (DC to AC conversion)
    inverter.sandia_multi
    inverter.adr
    inverter.pvwatts
+   inverter.pvwattsv5
    inverter.pvwatts_multi
+   inverter.pvwattsv5_multi
 
 Functions for fitting inverter models
 
@@ -149,8 +151,11 @@ PVWatts model
    :toctree: generated/
 
    pvsystem.pvwatts_dc
+   pvsystem.pvwattsv5_dc
    inverter.pvwatts
+   inverter.pvwattsv5
    pvsystem.pvwatts_losses
+   pvsystem.pvwattsv5_losses
 
 Estimating PV model parameters
 ------------------------------

--- a/docs/sphinx/source/user_guide/modelchain.rst
+++ b/docs/sphinx/source/user_guide/modelchain.rst
@@ -327,7 +327,7 @@ below shows a simple example of this.
     mc.results.effective_irradiance = pd.Series(1000, index=[pd.Timestamp('20170401 1200-0700')])
     mc.results.cell_temperature = pd.Series(50, index=[pd.Timestamp('20170401 1200-0700')])
 
-    # run ModelChain.v5_dc and look at the result
+    # run ModelChain.pvwattsv5_dc and look at the result
     mc.pvwattsv5_dc();
     mc.results.dc
 

--- a/docs/sphinx/source/user_guide/modelchain.rst
+++ b/docs/sphinx/source/user_guide/modelchain.rst
@@ -290,7 +290,7 @@ Wrapping methods into a unified API
 Readers may notice that the source code of the :py:meth:`~pvlib.modelchain.ModelChain.run_model`
 method is model-agnostic. :py:meth:`~pvlib.modelchain.ModelChain.run_model` calls generic methods
 such as ``self.dc_model`` rather than a specific model such as
-``pvwatts_dc``. So how does :py:meth:`~pvlib.modelchain.ModelChain.run_model` know what models
+``pvwattsv5_dc``. So how does :py:meth:`~pvlib.modelchain.ModelChain.run_model` know what models
 it’s supposed to run? The answer comes in two parts, and allows us to
 explore more of the ModelChain API along the way.
 
@@ -298,17 +298,17 @@ First, ModelChain has a set of methods that wrap the PVSystem methods
 that perform the calculations (or further wrap the pvsystem.py module’s
 functions). Each of these methods takes the same arguments (``self``)
 and sets the same attributes, thus creating a uniform API. For example,
-the :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` method is shown below. Its only argument is
+the :py:meth:`~pvlib.modelchain.ModelChain.pvwattsv5_dc` method is shown below. Its only argument is
 ``self``, and it sets the ``dc`` attribute.
 
 .. ipython:: python
 
-    mc.pvwatts_dc??
+    mc.pvwattsv5_dc??
 
-The :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` method calls the pvwatts_dc method of the
+The :py:meth:`~pvlib.modelchain.ModelChain.pvwattsv5_dc` method calls the pvwattsv5_dc method of the
 PVSystem object that we supplied when we created the ModelChain instance,
 using data that is stored in the ModelChain ``effective_irradiance`` and
-``cell_temperature`` attributes. The :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` method assigns its
+``cell_temperature`` attributes. The :py:meth:`~pvlib.modelchain.ModelChain.pvwattsv5_dc` method assigns its
 result to the ``dc`` attribute of the ModelChain's ``results`` object. The code
 below shows a simple example of this.
 
@@ -322,21 +322,21 @@ below shows a simple example of this.
     mc = ModelChain(pvwatts_system, location,
                     aoi_model='no_loss', spectral_model='no_loss')
 
-    # manually assign data to the attributes that ModelChain.pvwatts_dc will need.
+    # manually assign data to the attributes that ModelChain.pvwattsv5_dc will need.
     # for standard workflows, run_model would assign these attributes.
     mc.results.effective_irradiance = pd.Series(1000, index=[pd.Timestamp('20170401 1200-0700')])
     mc.results.cell_temperature = pd.Series(50, index=[pd.Timestamp('20170401 1200-0700')])
 
-    # run ModelChain.pvwatts_dc and look at the result
-    mc.pvwatts_dc();
+    # run ModelChain.v5_dc and look at the result
+    mc.pvwattsv5_dc();
     mc.results.dc
 
 The :py:meth:`~pvlib.modelchain.ModelChain.sapm` method works in a manner similar
-to the :py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc`
+to the :py:meth:`~pvlib.modelchain.ModelChain.pvwattsv5_dc`
 method. It calls the :py:meth:`~pvlib.pvsystem.PVSystem.sapm` method using stored data, then
 assigns the result to the ``dc`` attribute of ``ModelChain.results``.
 The :py:meth:`~pvlib.modelchain.ModelChain.sapm` method differs from the
-:py:meth:`~pvlib.modelchain.ModelChain.pvwatts_dc` method in
+:py:meth:`~pvlib.modelchain.ModelChain.pvwattsv5_dc` method in
 a notable way: the PVSystem.sapm method returns a DataFrame with current,
 voltage, and power results, rather than a simple Series
 of power. The ModelChain methods for single diode models (e.g.,
@@ -370,7 +370,7 @@ DC quantities to the output of the full PVSystem.
     mc.sapm();
     mc.results.dc
 
-We’ve established that the ``ModelChain.pvwatts_dc`` and
+We’ve established that the ``ModelChain.pvwattsv5_dc`` and
 ``ModelChain.sapm`` have the same API: they take the same arugments
 (``self``) and they both set the ``dc`` attribute.\* Because the methods
 have the same API, we can call them in the same way. ModelChain includes
@@ -381,7 +381,7 @@ Again, so how does :py:meth:`~pvlib.modelchain.ModelChain.run_model` know which
 models it’s supposed to run?
 
 At object construction, ModelChain assigns the desired model’s method
-(e.g. ``ModelChain.pvwatts_dc``) to the corresponding generic attribute
+(e.g. ``ModelChain.pvwattsv5_dc``) to the corresponding generic attribute
 (e.g. ``ModelChain.dc_model``) either with the value assigned to the ``dc_model``
 parameter at construction, or by inference as described in the next
 section.
@@ -428,7 +428,7 @@ method.
     mc.infer_ac_model??
     pvlib.modelchain._snl_params??
     pvlib.modelchain._adr_params??
-    pvlib.modelchain._pvwatts_params??
+    pvlib.modelchain._pvwattsv5_params??
 
 ModelChain for a PVSystem with multiple Arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -436,7 +436,7 @@ ModelChain for a PVSystem with multiple Arrays
 The PVSystem can represent a PV system with a single array of modules, or
 with multiple arrays (see :ref:`multiarray`). The same models are applied to
 all ``PVSystem.array`` objects, so each ``Array`` must contain the appropriate model
-parameters. For example, if ``ModelChain.dc_model='pvwatts'``, then each 
+parameters. For example, if ``ModelChain.dc_model='pvwattsv5'``, then each 
 ``Array.module_parameters`` must contain ``'pdc0'``.
 
 When the PVSystem contains multiple arrays, ``ModelChain.results`` attributes

--- a/docs/sphinx/source/user_guide/pvsystem.rst
+++ b/docs/sphinx/source/user_guide/pvsystem.rst
@@ -70,28 +70,28 @@ that describe a PV system's modules and inverter are stored in
 
 
 Extrinsic data is passed to the arguments of PVSystem methods. For example,
-the :py:meth:`~pvlib.pvsystem.PVSystem.pvwatts_dc` method accepts extrinsic
+the :py:meth:`~pvlib.pvsystem.PVSystem.pvwattsv5_dc` method accepts extrinsic
 data irradiance and temperature.
 
 .. ipython:: python
 
-    pdc = system.pvwatts_dc(g_poa_effective=1000, temp_cell=30)
+    pdc = system.pvwattsv5_dc(g_poa_effective=1000, temp_cell=30)
     print(pdc)
 
 Methods attached to a PVSystem object wrap the corresponding functions in
 :py:mod:`~pvlib.pvsystem`. The methods simplify the argument list by
 using data stored in the PVSystem attributes. Compare the
-:py:meth:`~pvlib.pvsystem.PVSystem.pvwatts_dc` method signature to the
-:py:func:`~pvlib.pvsystem.pvwatts_dc` function signature:
+:py:meth:`~pvlib.pvsystem.PVSystem.pvwattsv5_dc` method signature to the
+:py:func:`~pvlib.pvsystem.pvwattsv5_dc` function signature:
 
-    * :py:meth:`PVSystem.pvwatts_dc(g_poa_effective, temp_cell) <pvlib.pvsystem.PVSystem.pvwatts_dc>`
-    * :py:func:`pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.) <pvlib.pvsystem.pvwatts_dc>`
+    * :py:meth:`PVSystem.pvwattsv5_dc(g_poa_effective, temp_cell) <pvlib.pvsystem.PVSystem.pvwattsv5_dc>`
+    * :py:func:`pvwattsv5_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.) <pvlib.pvsystem.pvwattsv5_dc>`
 
-How does this work? The :py:meth:`~pvlib.pvsystem.PVSystem.pvwatts_dc`
+How does this work? The :py:meth:`~pvlib.pvsystem.PVSystem.pvwattsv5_dc`
 method looks in `PVSystem.module_parameters` for the `pdc0`, and
-`gamma_pdc` arguments. Then the :py:meth:`PVSystem.pvwatts_dc
-<pvlib.pvsystem.PVSystem.pvwatts_dc>` method calls the
-:py:func:`pvsystem.pvwatts_dc <pvlib.pvsystem.pvwatts_dc>` function with
+`gamma_pdc` arguments. Then the :py:meth:`PVSystem.pvwattsv5_dc
+<pvlib.pvsystem.PVSystem.pvwattsv5_dc>` method calls the
+:py:func:`pvsystem.pvwattsv5_dc <pvlib.pvsystem.pvwattsv5_dc>` function with
 all of the arguments and returns the result to the user. Note that the
 function includes a default value for the parameter `temp_ref`. This
 default value may be overridden by specifying the `temp_ref` key in the
@@ -101,7 +101,7 @@ default value may be overridden by specifying the `temp_ref` key in the
 
     system.arrays[0].module_parameters['temp_ref'] = 0
     # lower temp_ref should lead to lower DC power than calculated above
-    pdc = system.pvwatts_dc(1000, 30)
+    pdc = system.pvwattsv5_dc(1000, 30)
     print(pdc)
 
 Multiple methods may pull data from the same attribute. For example, the
@@ -320,8 +320,8 @@ Losses
 
 The `losses_parameters` attribute contains data that may be used with
 methods that calculate system losses. At present, these methods include
-only :py:meth:`pvlib.pvsystem.PVSystem.pvwatts_losses` and
-:py:func:`pvlib.pvsystem.pvwatts_losses`, but we hope to add more related functions
+only :py:meth:`pvlib.pvsystem.PVSystem.pvwattsv5_losses` and
+:py:func:`pvlib.pvsystem.pvwattsv5_losses`, but we hope to add more related functions
 and methods in the future.
 
 

--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -27,7 +27,7 @@ Deprecations
       instead of ``'pvwatts'``.
 
   The originals should continue to work for now (emitting a deprecation warning),
-  but will be removed in a future release. (:issue:`1350`, :pull:`TODO`)
+  but will be removed in a future release. (:issue:`1350`, :pull:`1558`)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -5,6 +5,29 @@ v0.9.4 (TBD)
 
 Deprecations
 ~~~~~~~~~~~~
+* In anticipation of implementing newer versions of the PVWatts model
+  in the future and to clarify the relevant PVWatts model version for
+  existing functionality, several parts of pvlib have been renamed from
+  `pvwatts` to `pvwattsv5`:
+
+    * ``pvlib.inverter.pvwatts`` is now :py:func:`pvlib.inverter.pvwattsv5`
+    * ``pvlib.inverter.pvwatts_multi`` is now :py:func:`pvlib.inverter.pvwattsv5_multi`
+    * ``pvlib.pvsystem.pvwatts_dc`` is now :py:func:`pvlib.pvsystem.pvwattsv5_dc`
+    * ``pvlib.pvsystem.pvwatts_losses`` is now :py:func:`pvlib.pvsystem.pvwattsv5_losses`
+    * ``pvlib.pvsystem.PVSystem.pvwatts_dc`` is now :py:meth:`pvlib.pvsystem.PVSystem.pvwattsv5_dc`
+    * ``pvlib.pvsystem.PVSystem.pvwatts_losses`` is now :py:meth:`pvlib.pvsystem.PVSystem.pvwattsv5_losses`
+    * ``pvlib.modelchain.ModelChain.pvwatts_dc`` is now :py:meth:`pvlib.modelchain.ModelChain.pvwattsv5_dc`
+    * ``pvlib.modelchain.ModelChain.pvwatts_inverter`` is now :py:meth:`pvlib.modelchain.ModelChain.pvwattsv5_inverter`
+    * ``pvlib.modelchain.ModelChain.pvwatts_losses`` is now :py:meth:`pvlib.modelchain.ModelChain.pvwattsv5_losses`
+    
+    * The ``model`` parameter to :py:meth:`pvlib.pvsystem.PVSystem.get_ac` should
+      now be ``'pvwattsv5'`` instead of ``'pvwatts'``.
+    * The ``dc_model``, ``ac_model``, and ``losses_model`` parameters of
+      :py:class:`pvlib.modelchain.ModelChain` should now be ``'pvwattsv5'``
+      instead of ``'pvwatts'``.
+
+  The originals should continue to work for now (emitting a deprecation warning),
+  but will be removed in a future release. (:issue:`1350`, :pull:`TODO`)
 
 
 Enhancements

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -447,7 +447,7 @@ def pvwattsv5_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
 pvwatts_multi = deprecated(since='0.9.4',
                            name='pvwatts_multi',
                            alternative='pvwattsv5_multi',
-                           removal='0.10')(pvwattsv5_multi)
+                           removal='0.11')(pvwattsv5_multi)
 
 
 def fit_sandia(ac_power, dc_power, dc_voltage, dc_voltage_level, p_ac_0, p_nt):

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from numpy.polynomial.polynomial import polyfit  # different than np.polyfit
 
+from pvlib._deprecation import deprecated
 
 def _sandia_eff(v_dc, p_dc, inverter):
     r'''
@@ -330,9 +331,9 @@ def adr(v_dc, p_dc, inverter, vtol=0.10):
     return power_ac
 
 
-def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
+def pvwattsv5(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     r"""
-    NREL's PVWatts inverter model.
+    NREL's PVWatts v5 inverter model.
 
     The PVWatts inverter model [1]_ calculates inverter efficiency :math:`\eta`
     as a function of input DC power
@@ -370,14 +371,14 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     Notes
     -----
     Note that ``pdc0`` is also used as a symbol in
-    :py:func:`pvlib.pvsystem.pvwatts_dc`. ``pdc0`` in this function refers to
+    :py:func:`pvlib.pvsystem.pvwattsv5_dc`. ``pdc0`` in this function refers to
     the DC power input limit of the inverter. ``pdc0`` in
-    :py:func:`pvlib.pvsystem.pvwatts_dc` refers to the DC power of the modules
+    :py:func:`pvlib.pvsystem.pvwattsv5_dc` refers to the DC power of the modules
     at reference conditions.
 
     See Also
     --------
-    pvlib.inverter.pvwatts_multi
+    pvlib.inverter.pvwattsv5_multi
 
     References
     ----------
@@ -404,13 +405,19 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     return power_ac
 
 
-def pvwatts_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
-    r"""
-    Extend NREL's PVWatts inverter model for multiple MPP inputs.
+pvwatts = deprecated(since='0.9.4',
+                     name='pvwatts',
+                     alternative='pvwattsv5',
+                     removal='0.10')(pvwattsv5)
 
-    DC input power is summed over MPP inputs to obtain the DC power
-    input to the PVWatts inverter model. See :py:func:`pvlib.inverter.pvwatts`
-    for details.
+
+def pvwattsv5_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
+    r"""
+    Extend NREL's PVWatts v5 inverter model for multiple MPPT inputs.
+
+    DC input power is summed over MPPT inputs to obtain the DC power
+    input to the PVWatts v5 inverter model.
+    See :py:func:`pvlib.inverter.pvwattsv5` for details.
 
     Parameters
     ----------
@@ -432,9 +439,15 @@ def pvwatts_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
 
     See Also
     --------
-    pvlib.inverter.pvwatts
+    pvlib.inverter.pvwattsv5
     """
-    return pvwatts(sum(pdc), pdc0, eta_inv_nom, eta_inv_ref)
+    return pvwattsv5(sum(pdc), pdc0, eta_inv_nom, eta_inv_ref)
+
+
+pvwatts_multi = deprecated(since='0.9.4',
+                           name='pvwatts_multi',
+                           alternative='pvwattsv5_multi',
+                           removal='0.10')(pvwattsv5_multi)
 
 
 def fit_sandia(ac_power, dc_power, dc_voltage, dc_voltage_level, p_ac_0, p_nt):

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -408,7 +408,7 @@ def pvwattsv5(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
 pvwatts = deprecated(since='0.9.4',
                      name='pvwatts',
                      alternative='pvwattsv5',
-                     removal='0.10')(pvwattsv5)
+                     removal='0.11')(pvwattsv5)
 
 
 def pvwattsv5_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -373,8 +373,8 @@ def pvwattsv5(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     Note that ``pdc0`` is also used as a symbol in
     :py:func:`pvlib.pvsystem.pvwattsv5_dc`. ``pdc0`` in this function refers to
     the DC power input limit of the inverter. ``pdc0`` in
-    :py:func:`pvlib.pvsystem.pvwattsv5_dc` refers to the DC power of the modules
-    at reference conditions.
+    :py:func:`pvlib.pvsystem.pvwattsv5_dc` refers to the DC power of the
+    modules at reference conditions.
 
     See Also
     --------

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -834,7 +834,7 @@ class ModelChain:
         self.results.dc = _tuple_from_dfs(scaled, "p_mp")
         return self
 
-    @deprecated('0.9.4', alternative='ModelChain.pvwattsv5_dc', removal='0.10')
+    @deprecated('0.9.4', alternative='ModelChain.pvwattsv5_dc', removal='0.11')
     def pvwatts_dc(self):
         return self.pvwattsv5_dc()
 
@@ -906,7 +906,7 @@ class ModelChain:
         return self
 
     @deprecated('0.9.4', alternative='ModelChain.pvwattsv5_inverter',
-                removal='0.10')
+                removal='0.11')
     def pvwatts_inverter(self):
         return self.pvwattsv5_inverter()
 
@@ -1238,7 +1238,7 @@ class ModelChain:
         return self
 
     @deprecated('0.9.4', alternative='ModelChain.pvwattsv5_losses',
-                removal='0.10')
+                removal='0.11')
     def pvwatts_losses(self):
         return self.pvwattsv5_losses()
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -47,6 +47,9 @@ _DC_MODEL_PARAMS = {
     'pvwattsv5': {'pdc0', 'gamma_pdc'}
 }
 
+# temporary alias during the deprecation period
+_DC_MODEL_PARAMS['pvwatts'] = _DC_MODEL_PARAMS['pvwattsv5']
+
 
 def _unwrap_single_value(func):
     """Decorator for functions that return iterables.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1101,7 +1101,8 @@ class PVSystem:
     def pvwatts_dc(self, g_poa_effective, temp_cell):
         """
         Calculates DC power according to the PVWatts v5 model using
-        :py:func:`pvlib.pvsystem.pvwattsv5_dc`, `self.module_parameters['pdc0']`,
+        :py:func:`pvlib.pvsystem.pvwattsv5_dc`,
+        `self.module_parameters['pdc0']`,
         and `self.module_parameters['gamma_pdc']`.
 
         See :py:func:`pvlib.pvsystem.pvwattsv5_dc` for details.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1097,7 +1097,7 @@ class PVSystem:
             in zip(self.arrays, g_poa_effective, temp_cell)
         )
 
-    @deprecated('0.9.4', alternative='PVSystem.pvwattsv5_dc', removal='0.10')
+    @deprecated('0.9.4', alternative='PVSystem.pvwattsv5_dc', removal='0.11')
     def pvwatts_dc(self, g_poa_effective, temp_cell):
         """
         Calculates DC power according to the PVWatts v5 model using
@@ -1124,7 +1124,7 @@ class PVSystem:
         return pvwattsv5_losses(**kwargs)
 
     @deprecated('0.9.4', alternative='PVSystem.pvwattsv5_losses',
-                removal='0.10')
+                removal='0.11')
     def pvwatts_losses(self):
         """
         Calculates DC power losses according the PVwatts v5 model using
@@ -3263,7 +3263,7 @@ def pvwattsv5_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
 pvwatts_dc = deprecated(since='0.9.4',
                         name='pvwatts_dc',
                         alternative='pvwattsv5_dc',
-                        removal='0.10')(pvwattsv5_dc)
+                        removal='0.11')(pvwattsv5_dc)
 
 
 def pvwattsv5_losses(soiling=2, shading=3, snow=0, mismatch=2, wiring=2,
@@ -3323,7 +3323,7 @@ def pvwattsv5_losses(soiling=2, shading=3, snow=0, mismatch=2, wiring=2,
 pvwatts_losses = deprecated(since='0.9.4',
                             name='pvwatts_losses',
                             alternative='pvwattsv5_losses',
-                            removal='0.10')(pvwattsv5_losses)
+                            removal='0.11')(pvwattsv5_losses)
 
 
 def dc_ohms_from_percent(vmp_ref, imp_ref, dc_ohmic_percent,

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1101,7 +1101,7 @@ class PVSystem:
     def pvwatts_dc(self, g_poa_effective, temp_cell):
         """
         Calculates DC power according to the PVWatts v5 model using
-        :py:func:`pvlib.pvsystem.pvwatts_dc`, `self.module_parameters['pdc0']`,
+        :py:func:`pvlib.pvsystem.pvwattsv5_dc`, `self.module_parameters['pdc0']`,
         and `self.module_parameters['gamma_pdc']`.
 
         See :py:func:`pvlib.pvsystem.pvwattsv5_dc` for details.

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -542,7 +542,7 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
     Calculate cell or module temperature using the Fuentes model.
 
     The Fuentes model is a first-principles heat transfer energy balance
-    model [1]_ that is used in PVWatts for cell temperature modeling [2]_.
+    model [1]_ that is used in PVWatts v5 for cell temperature modeling [2]_.
 
     Parameters
     ----------
@@ -557,17 +557,17 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
 
     noct_installed : float
         The "installed" nominal operating cell temperature as defined in [1]_.
-        PVWatts assumes this value to be 45 C for rack-mounted arrays and
+        PVWatts v5 assumes this value to be 45 C for rack-mounted arrays and
         49 C for roof mount systems with restricted air flow around the
         module.  [C]
 
     module_height : float, default 5.0
-        The height above ground of the center of the module. The PVWatts
+        The height above ground of the center of the module. The PVWatts v5
         default is 5.0 [m]
 
     wind_height : float, default 9.144
         The height above ground at which ``wind_speed`` is measured. The
-        PVWatts defauls is 9.144 [m]
+        PVWatts v5 default is 9.144 [m]
 
     emissivity : float, default 0.84
         The effectiveness of the module at radiating thermal energy. [unitless]
@@ -597,7 +597,7 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
 
     Notes
     -----
-    This function returns slightly different values from PVWatts at night
+    This function returns slightly different values from PVWatts v5 at night
     and just after dawn. This is because the SAM SSC assumes that module
     temperature equals ambient temperature when irradiance is zero so it can
     skip the heat balance calculation at night.

--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -134,59 +134,59 @@ def test_sandia_multi_array(cec_inverter_parameters):
     assert_allclose(pacs, np.array([-0.020000, 132.004278, 250.000000]))
 
 
-def test_pvwatts_scalars():
+def test_pvwattsv5_scalars():
     expected = 85.58556604752516
-    out = inverter.pvwatts(90, 100, 0.95)
+    out = inverter.pvwattsv5(90, 100, 0.95)
     assert_allclose(out, expected)
     # GH 675
     expected = 0.
-    out = inverter.pvwatts(0., 100)
+    out = inverter.pvwattsv5(0., 100)
     assert_allclose(out, expected)
 
 
-def test_pvwatts_possible_negative():
-    # pvwatts could return a negative value for (pdc / pdc0) < 0.006
+def test_pvwattsv5_possible_negative():
+    # pvwattsv5 could return a negative value for (pdc / pdc0) < 0.006
     # unless it is clipped. see GH 541 for more
     expected = 0
-    out = inverter.pvwatts(0.001, 1)
+    out = inverter.pvwattsv5(0.001, 1)
     assert_allclose(out, expected)
 
 
-def test_pvwatts_arrays():
+def test_pvwattsv5_arrays():
     pdc = np.array([[np.nan], [0], [50], [100]])
     pdc0 = 100
     expected = np.array([[np.nan],
                          [0.],
                          [47.60843624],
                          [95.]])
-    out = inverter.pvwatts(pdc, pdc0, 0.95)
+    out = inverter.pvwattsv5(pdc, pdc0, 0.95)
     assert_allclose(out, expected, equal_nan=True)
 
 
-def test_pvwatts_series():
+def test_pvwattsv5_series():
     pdc = pd.Series([np.nan, 0, 50, 100])
     pdc0 = 100
     expected = pd.Series(np.array([np.nan, 0., 47.608436, 95.]))
-    out = inverter.pvwatts(pdc, pdc0, 0.95)
+    out = inverter.pvwattsv5(pdc, pdc0, 0.95)
     assert_series_equal(expected, out)
 
 
-def test_pvwatts_multi():
+def test_pvwattsv5_multi():
     pdc = np.array([np.nan, 0, 50, 100]) / 2
     pdc0 = 100
     expected = np.array([np.nan, 0., 47.608436, 95.])
-    out = inverter.pvwatts_multi((pdc, pdc), pdc0, 0.95)
+    out = inverter.pvwattsv5_multi((pdc, pdc), pdc0, 0.95)
     assert_allclose(expected, out)
     # with 2D array
     pdc_2d = np.array([pdc, pdc])
-    out = inverter.pvwatts_multi(pdc_2d, pdc0, 0.95)
+    out = inverter.pvwattsv5_multi(pdc_2d, pdc0, 0.95)
     assert_allclose(expected, out)
     # with Series
     pdc = pd.Series(pdc)
-    out = inverter.pvwatts_multi((pdc, pdc), pdc0, 0.95)
+    out = inverter.pvwattsv5_multi((pdc, pdc), pdc0, 0.95)
     assert_series_equal(pd.Series(expected), out)
     # with list instead of tuple
-    out = inverter.pvwatts_multi([pdc, pdc], pdc0, 0.95)
+    out = inverter.pvwattsv5_multi([pdc, pdc], pdc0, 0.95)
     assert_series_equal(pd.Series(expected), out)
 
 

--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -148,12 +148,8 @@ def test_pvwattsv5_scalars():
 @fail_on_pvlib_version('0.10.0')
 def test_pvwatts_deprecated():
     expected = 85.58556604752516
-    out = inverter.pvwattsv5(90, 100, 0.95)
-    assert_allclose(out, expected)
-    # GH 675
-    expected = 0.
     with pytest.warns(pvlibDeprecationWarning, match='Use pvwattsv5 instead'):
-        out = inverter.pvwatts(0., 100)
+        out = inverter.pvwatts(90, 100, 0.95)
     assert_allclose(out, expected)
 
 

--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -145,7 +145,7 @@ def test_pvwattsv5_scalars():
     assert_allclose(out, expected)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_pvwatts_deprecated():
     expected = 85.58556604752516
     with pytest.warns(pvlibDeprecationWarning, match='Use pvwattsv5 instead'):
@@ -199,7 +199,7 @@ def test_pvwattsv5_multi():
     assert_series_equal(pd.Series(expected), out)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_pvwatts_multi_deprecated():
     pdc = np.array([np.nan, 0, 50, 100]) / 2
     pdc0 = 100

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -351,8 +351,8 @@ def test_with_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather):
 
 def test_with_pvwatts_invalid_version(pvwatts_dc_pvwatts_ac_system, location):
     with pytest.raises(ValueError, match='Invalid PVWatts version'):
-        mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
-                                     version='bad')
+        _ = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
+                                    version='bad')
 
 
 def test_run_model_with_irradiance(sapm_dc_snl_ac_system, location):

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -224,7 +224,7 @@ def pvwatts_dc_pvwatts_ac_fuentes_temp_system():
 
 
 @pytest.fixture(scope="function")
-def pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system():
+def pvwatts_dc_pvwatts_ac_noct_sam_temp_system():
     module_parameters = {'pdc0': 220, 'gamma_pdc': -0.003}
     temp_model_params = {'noct': 45, 'module_efficiency': 0.2}
     inverter_parameters = {'pdc0': 220, 'eta_inv_nom': 0.95}
@@ -1350,14 +1350,13 @@ def test_infer_temp_model(location, sapm_dc_snl_ac_system,
                           pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
                           pvwatts_dc_pvwatts_ac_faiman_temp_system,
                           pvwatts_dc_pvwatts_ac_fuentes_temp_system,
-                          pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system,
+                          pvwatts_dc_pvwatts_ac_noct_sam_temp_system,
                           temp_model):
-    dc_systems = {
-        'sapm_temp': sapm_dc_snl_ac_system,
-        'pvsyst_temp': pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
-        'faiman_temp': pvwatts_dc_pvwatts_ac_faiman_temp_system,
-        'fuentes_temp': pvwatts_dc_pvwatts_ac_fuentes_temp_system,
-        'noct_sam_temp': pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system}
+    dc_systems = {'sapm_temp': sapm_dc_snl_ac_system,
+                  'pvsyst_temp': pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
+                  'faiman_temp': pvwatts_dc_pvwatts_ac_faiman_temp_system,
+                  'fuentes_temp': pvwatts_dc_pvwatts_ac_fuentes_temp_system,
+                  'noct_sam_temp': pvwatts_dc_pvwatts_ac_noct_sam_temp_system}
     system = dc_systems[temp_model]
     mc = ModelChain(system, location, aoi_model='physical',
                     spectral_model='no_loss')

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -2073,7 +2073,7 @@ def test__irrad_for_celltemp():
     assert_series_equal(poa[1], effect_irrad)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_modelchain_pvwatts_methods_deprecated(pvwatts_dc_pvwatts_ac_system,
                                                location, weather):
     mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location)
@@ -2091,7 +2091,7 @@ def test_modelchain_pvwatts_methods_deprecated(pvwatts_dc_pvwatts_ac_system,
         mc.pvwatts_losses()
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_modelchain_pvwatts_modelnames_deprecated(pvwatts_dc_pvwatts_ac_system,
                                                   location):
     with pytest.warns(pvlibDeprecationWarning,

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -349,6 +349,12 @@ def test_with_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather):
     mc.run_model(weather)
 
 
+def test_with_pvwatts_invalid_version(pvwatts_dc_pvwatts_ac_system, location):
+    with pytest.raises(ValueError, match='Invalid pvwatts version'):
+        mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
+                                     version='bad')
+
+
 def test_run_model_with_irradiance(sapm_dc_snl_ac_system, location):
     mc = ModelChain(sapm_dc_snl_ac_system, location)
     times = pd.date_range('20160101 1200-0700', periods=2, freq='6H')
@@ -2066,3 +2072,40 @@ def test__irrad_for_celltemp():
     assert len(poa) == 2
     assert_series_equal(poa[0], effect_irrad)
     assert_series_equal(poa[1], effect_irrad)
+
+
+@fail_on_pvlib_version('0.10.0')
+def test_modelchain_pvwatts_methods_deprecated(pvwatts_dc_pvwatts_ac_system,
+                                               location, weather):
+    mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location)
+    mc.run_model(weather)
+    with pytest.warns(pvlibDeprecationWarning,
+                      match='Use ModelChain.pvwattsv5_dc instead'):
+        mc.pvwatts_dc()
+
+    with pytest.warns(pvlibDeprecationWarning,
+                      match='Use ModelChain.pvwattsv5_inverter instead'):
+        mc.pvwatts_inverter()
+
+    with pytest.warns(pvlibDeprecationWarning,
+                      match='Use ModelChain.pvwattsv5_losses instead'):
+        mc.pvwatts_losses()
+
+
+@fail_on_pvlib_version('0.10.0')
+def test_modelchain_pvwatts_modelnames_deprecated(pvwatts_dc_pvwatts_ac_system,
+                                                  location):
+    with pytest.warns(pvlibDeprecationWarning,
+                      match="model='pvwatts' is now called model='pvwattsv5'"):
+        _ = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
+                                    dc_model='pvwatts')
+
+    with pytest.warns(pvlibDeprecationWarning,
+                      match="model='pvwatts' is now called model='pvwattsv5'"):
+        _ = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
+                                    ac_model='pvwatts')
+
+    with pytest.warns(pvlibDeprecationWarning,
+                      match="model='pvwatts' is now called model='pvwattsv5'"):
+        _ = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
+                                    losses_model='pvwatts')

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -224,7 +224,7 @@ def pvwatts_dc_pvwatts_ac_fuentes_temp_system():
 
 
 @pytest.fixture(scope="function")
-def pvwatts_dc_pvwatts_ac_noct_sam_temp_system():
+def pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system():
     module_parameters = {'pdc0': 220, 'gamma_pdc': -0.003}
     temp_model_params = {'noct': 45, 'module_efficiency': 0.2}
     inverter_parameters = {'pdc0': 220, 'eta_inv_nom': 0.95}
@@ -344,7 +344,7 @@ def test_with_sapm(sapm_dc_snl_ac_system, location, weather):
 
 def test_with_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather):
     mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location)
-    assert mc.dc_model == mc.pvwatts_dc
+    assert mc.dc_model == mc.pvwattsv5_dc
     assert mc.temperature_model == mc.sapm_temp
     mc.run_model(weather)
 
@@ -609,13 +609,13 @@ def test_prepare_inputs_missing_irrad_component(
         mc.prepare_inputs(weather)
 
 
-@pytest.mark.parametrize('ac_model', ['sandia', 'pvwatts'])
+@pytest.mark.parametrize('ac_model', ['sandia', 'pvwattsv5'])
 @pytest.mark.parametrize("input_type", [tuple, list])
 def test_run_model_arrays_weather(sapm_dc_snl_ac_system_same_arrays,
                                   pvwatts_dc_pvwatts_ac_system_arrays,
                                   location, ac_model, input_type):
     system = {'sandia': sapm_dc_snl_ac_system_same_arrays,
-              'pvwatts': pvwatts_dc_pvwatts_ac_system_arrays}
+              'pvwattsv5': pvwatts_dc_pvwatts_ac_system_arrays}
     mc = ModelChain(system[ac_model], location, aoi_model='no_loss',
                     spectral_model='no_loss')
     times = pd.date_range('20200101 1200-0700', periods=2, freq='2H')
@@ -1245,7 +1245,7 @@ def poadc(mc):
 
 
 @pytest.mark.parametrize('dc_model', [
-    'sapm', 'cec', 'desoto', 'pvsyst', 'singlediode', 'pvwatts_dc'])
+    'sapm', 'cec', 'desoto', 'pvsyst', 'singlediode', 'pvwattsv5_dc'])
 def test_infer_dc_model(sapm_dc_snl_ac_system, cec_dc_snl_ac_system,
                         pvsyst_dc_snl_ac_system, pvwatts_dc_pvwatts_ac_system,
                         location, dc_model, weather, mocker):
@@ -1254,19 +1254,19 @@ def test_infer_dc_model(sapm_dc_snl_ac_system, cec_dc_snl_ac_system,
                   'desoto': cec_dc_snl_ac_system,
                   'pvsyst': pvsyst_dc_snl_ac_system,
                   'singlediode': cec_dc_snl_ac_system,
-                  'pvwatts_dc': pvwatts_dc_pvwatts_ac_system}
+                  'pvwattsv5_dc': pvwatts_dc_pvwatts_ac_system}
     dc_model_function = {'sapm': 'sapm',
                          'cec': 'calcparams_cec',
                          'desoto': 'calcparams_desoto',
                          'pvsyst': 'calcparams_pvsyst',
                          'singlediode': 'calcparams_desoto',
-                         'pvwatts_dc': 'pvwatts_dc'}
+                         'pvwattsv5_dc': 'pvwattsv5_dc'}
     temp_model_function = {'sapm': 'sapm',
                            'cec': 'sapm',
                            'desoto': 'sapm',
                            'pvsyst': 'pvsyst',
                            'singlediode': 'sapm',
-                           'pvwatts_dc': 'sapm'}
+                           'pvwattsv5_dc': 'sapm'}
     temp_model_params = {'sapm': {'a': -3.40641, 'b': -0.0842075, 'deltaT': 3},
                          'pvsyst': {'u_c': 29.0, 'u_v': 0}}
     system = dc_systems[dc_model]
@@ -1344,13 +1344,14 @@ def test_infer_temp_model(location, sapm_dc_snl_ac_system,
                           pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
                           pvwatts_dc_pvwatts_ac_faiman_temp_system,
                           pvwatts_dc_pvwatts_ac_fuentes_temp_system,
-                          pvwatts_dc_pvwatts_ac_noct_sam_temp_system,
+                          pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system,
                           temp_model):
-    dc_systems = {'sapm_temp': sapm_dc_snl_ac_system,
-                  'pvsyst_temp': pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
-                  'faiman_temp': pvwatts_dc_pvwatts_ac_faiman_temp_system,
-                  'fuentes_temp': pvwatts_dc_pvwatts_ac_fuentes_temp_system,
-                  'noct_sam_temp': pvwatts_dc_pvwatts_ac_noct_sam_temp_system}
+    dc_systems = {
+        'sapm_temp': sapm_dc_snl_ac_system,
+        'pvsyst_temp': pvwatts_dc_pvwatts_ac_pvsyst_temp_system,
+        'faiman_temp': pvwatts_dc_pvwatts_ac_faiman_temp_system,
+        'fuentes_temp': pvwatts_dc_pvwatts_ac_fuentes_temp_system,
+        'noct_sam_temp': pvwattsv5_dc_pvwattsv5_ac_noct_sam_temp_system}
     system = dc_systems[temp_model]
     mc = ModelChain(system, location, aoi_model='physical',
                     spectral_model='no_loss')
@@ -1382,8 +1383,8 @@ def test_dc_model_user_func(pvwatts_dc_pvwatts_ac_system, location, weather,
     assert not mc.results.ac.empty
 
 
-def test_pvwatts_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
-                                     weather, mocker):
+def test_pvwattsv5_dc_multiple_strings(pvwatts_dc_pvwatts_ac_system, location,
+                                       weather, mocker):
     system = pvwatts_dc_pvwatts_ac_system
     m = mocker.spy(system, 'scale_voltage_current_power')
     mc1 = ModelChain(system, location,
@@ -1406,8 +1407,8 @@ def acdc(mc):
 
 
 @pytest.mark.parametrize('inverter_model', ['sandia', 'adr',
-                                            'pvwatts', 'sandia_multi',
-                                            'pvwatts_multi'])
+                                            'pvwattsv5', 'sandia_multi',
+                                            'pvwattsv5_multi'])
 def test_ac_models(sapm_dc_snl_ac_system, cec_dc_adr_ac_system,
                    pvwatts_dc_pvwatts_ac_system, cec_dc_snl_ac_arrays,
                    pvwatts_dc_pvwatts_ac_system_arrays,
@@ -1415,14 +1416,14 @@ def test_ac_models(sapm_dc_snl_ac_system, cec_dc_adr_ac_system,
     ac_systems = {'sandia': sapm_dc_snl_ac_system,
                   'sandia_multi': cec_dc_snl_ac_arrays,
                   'adr': cec_dc_adr_ac_system,
-                  'pvwatts': pvwatts_dc_pvwatts_ac_system,
-                  'pvwatts_multi': pvwatts_dc_pvwatts_ac_system_arrays}
+                  'pvwattsv5': pvwatts_dc_pvwatts_ac_system,
+                  'pvwattsv5_multi': pvwatts_dc_pvwatts_ac_system_arrays}
     inverter_to_ac_model = {
         'sandia': 'sandia',
         'sandia_multi': 'sandia',
         'adr': 'adr',
-        'pvwatts': 'pvwatts',
-        'pvwatts_multi': 'pvwatts'}
+        'pvwattsv5': 'pvwattsv5',
+        'pvwattsv5_multi': 'pvwattsv5'}
     ac_model = inverter_to_ac_model[inverter_model]
     system = ac_systems[inverter_model]
 
@@ -1671,14 +1672,14 @@ def test_dc_ohmic_not_a_model(cec_dc_snl_ac_system, location,
                    dc_ohmic_model='not_a_dc_model')
 
 
-def test_losses_models_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather,
-                               mocker):
+def test_losses_models_pvwattsv5(pvwatts_dc_pvwatts_ac_system, location,
+                                 weather, mocker):
     age = 1
     pvwatts_dc_pvwatts_ac_system.losses_parameters = dict(age=age)
-    m = mocker.spy(pvsystem, 'pvwatts_losses')
-    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
-                    aoi_model='no_loss', spectral_model='no_loss',
-                    losses_model='pvwatts')
+    m = mocker.spy(pvsystem, 'pvwattsv5_losses')
+    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                    dc_model='pvwattsv5', aoi_model='no_loss',
+                    spectral_model='no_loss', losses_model='pvwattsv5')
     mc.run_model(weather)
     assert m.call_count == 1
     m.assert_called_with(age=age)
@@ -1687,21 +1688,21 @@ def test_losses_models_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather,
     # check that we're applying correction to dc
     # GH 696
     dc_with_loss = mc.results.dc
-    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
-                    aoi_model='no_loss', spectral_model='no_loss',
-                    losses_model='no_loss')
+    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                    dc_model='pvwattsv5', aoi_model='no_loss',
+                    spectral_model='no_loss', losses_model='no_loss')
     mc.run_model(weather)
     assert not np.allclose(mc.results.dc, dc_with_loss, equal_nan=True)
 
 
-def test_losses_models_pvwatts_arrays(multi_array_sapm_dc_snl_ac_system,
-                                      location, weather):
+def test_losses_models_pvwattsv5_arrays(multi_array_sapm_dc_snl_ac_system,
+                                        location, weather):
     age = 1
     system_both = multi_array_sapm_dc_snl_ac_system['two_array_system']
     system_both.losses_parameters = dict(age=age)
     mc = ModelChain(system_both, location,
                     aoi_model='no_loss', spectral_model='no_loss',
-                    losses_model='pvwatts')
+                    losses_model='pvwattsv5')
     mc.run_model(weather)
     dc_with_loss = mc.results.dc
     mc = ModelChain(system_both, location,
@@ -1716,7 +1717,8 @@ def test_losses_models_pvwatts_arrays(multi_array_sapm_dc_snl_ac_system,
 def test_losses_models_ext_def(pvwatts_dc_pvwatts_ac_system, location, weather,
                                mocker):
     m = mocker.spy(sys.modules[__name__], 'constant_losses')
-    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
+    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                    dc_model='pvwattsv5',
                     aoi_model='no_loss', spectral_model='no_loss',
                     losses_model=constant_losses)
     mc.run_model(weather)
@@ -1728,8 +1730,9 @@ def test_losses_models_ext_def(pvwatts_dc_pvwatts_ac_system, location, weather,
 
 def test_losses_models_no_loss(pvwatts_dc_pvwatts_ac_system, location, weather,
                                mocker):
-    m = mocker.spy(pvsystem, 'pvwatts_losses')
-    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location, dc_model='pvwatts',
+    m = mocker.spy(pvsystem, 'pvwattsv5_losses')
+    mc = ModelChain(pvwatts_dc_pvwatts_ac_system, location,
+                    dc_model='pvwattsv5',
                     aoi_model='no_loss', spectral_model='no_loss',
                     losses_model='no_loss')
     assert mc.losses_model == mc.no_extra_losses
@@ -1754,8 +1757,8 @@ def test_invalid_dc_model_params(sapm_dc_snl_ac_system, cec_dc_snl_ac_system,
     with pytest.raises(ValueError):
         ModelChain(cec_dc_snl_ac_system, location, **kwargs)
 
-    kwargs['dc_model'] = 'pvwatts'
-    kwargs['ac_model'] = 'pvwatts'
+    kwargs['dc_model'] = 'pvwattsv5'
+    kwargs['ac_model'] = 'pvwattsv5'
     for array in pvwatts_dc_pvwatts_ac_system.arrays:
         array.module_parameters.pop('pdc0')
 
@@ -1769,7 +1772,7 @@ def test_invalid_dc_model_params(sapm_dc_snl_ac_system, cec_dc_snl_ac_system,
     'temperature_model', 'losses_model'
 ])
 def test_invalid_models(model, sapm_dc_snl_ac_system, location):
-    kwargs = {'dc_model': 'pvwatts', 'ac_model': 'pvwatts',
+    kwargs = {'dc_model': 'pvwattsv5', 'ac_model': 'pvwattsv5',
               'aoi_model': 'no_loss', 'spectral_model': 'no_loss',
               'temperature_model': 'sapm', 'losses_model': 'no_loss'}
     kwargs[model] = 'invalid'

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -350,7 +350,7 @@ def test_with_pvwatts(pvwatts_dc_pvwatts_ac_system, location, weather):
 
 
 def test_with_pvwatts_invalid_version(pvwatts_dc_pvwatts_ac_system, location):
-    with pytest.raises(ValueError, match='Invalid pvwatts version'):
+    with pytest.raises(ValueError, match='Invalid PVWatts version'):
         mc = ModelChain.with_pvwatts(pvwatts_dc_pvwatts_ac_system, location,
                                      version='bad')
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1538,7 +1538,7 @@ def test_PVSystem_get_ac_pvwatts_kwargs(pvwatts_system_kwargs, mocker):
     assert out < pdc
 
 
-@fail_on_pvlib_version('0.10')
+@fail_on_pvlib_version('0.11')
 def test_PVSystem_get_ac_pvwatts_deprecated(pvwatts_system_defaults, mocker):
     mocker.spy(inverter, 'pvwattsv5')
     pdc = 50
@@ -1577,7 +1577,7 @@ def test_PVSystem_get_ac_pvwatts_multi(
         system.get_ac('pvwattsv5', (pdcs, pdcs, pdcs))
 
 
-@fail_on_pvlib_version('0.10')
+@fail_on_pvlib_version('0.11')
 def test_PVSystem_get_ac_pvwatts_multi_deprecated(
         pvwatts_system_defaults, pvwatts_system_kwargs, mocker):
     mocker.spy(inverter, 'pvwatts_multi')
@@ -2039,7 +2039,7 @@ def test_pvwattsv5_dc_series():
     assert_series_equal(expected, out)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_pvwatts_dc_deprecated():
     irrad_trans = pd.Series([np.nan, 900, 900])
     temp_cell = pd.Series([30, np.nan, 30])
@@ -2070,7 +2070,7 @@ def test_pvwattsv5_losses_series():
     assert_series_equal(expected, out)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_pvwatts_losses_deprecated():
     expected = 14.075660688264469
     with pytest.warns(pvlibDeprecationWarning,
@@ -2109,7 +2109,7 @@ def test_PVSystem_pvwatts_dcv5(pvwatts_system_defaults, mocker):
     assert_allclose(expected, out, atol=10)
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_PVSystem_pvwatts_dc_deprecated(pvwatts_system_defaults, mocker):
     mocker.spy(pvsystem, 'pvwatts_dc')
     irrad = 900
@@ -2201,7 +2201,7 @@ def test_PVSystem_pvwattsv5_losses(pvwatts_system_defaults, mocker):
     assert out < expected
 
 
-@fail_on_pvlib_version('0.10.0')
+@fail_on_pvlib_version('0.11.0')
 def test_PVSystem_pvwatts_losses_deprecated(pvwatts_system_defaults, mocker):
     mocker.spy(pvsystem, 'pvwatts_losses')
     age = 1

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -2118,9 +2118,6 @@ def test_PVSystem_pvwatts_dc_deprecated(pvwatts_system_defaults, mocker):
     match = "Use PVSystem.pvwattsv5_dc instead"
     with pytest.warns(pvlibDeprecationWarning, match=match):
         out = pvwatts_system_defaults.pvwatts_dc(irrad, temp_cell)
-    pvsystem.pvwattsv5_dc.assert_called_once_with(
-        irrad, temp_cell,
-        **pvwatts_system_defaults.arrays[0].module_parameters)
     assert_allclose(expected, out, atol=10)
     assert pvsystem.pvwatts_dc.call_count == 0
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1521,26 +1521,26 @@ def test_PVSystem_get_ac_sandia_multi(cec_inverter_parameters, mocker):
 
 
 def test_PVSystem_get_ac_pvwatts(pvwatts_system_defaults, mocker):
-    mocker.spy(inverter, 'pvwatts')
+    mocker.spy(inverter, 'pvwattsv5')
     pdc = 50
-    out = pvwatts_system_defaults.get_ac('pvwatts', pdc)
-    inverter.pvwatts.assert_called_once_with(
+    out = pvwatts_system_defaults.get_ac('pvwattsv5', pdc)
+    inverter.pvwattsv5.assert_called_once_with(
         pdc, **pvwatts_system_defaults.inverter_parameters)
     assert out < pdc
 
 
 def test_PVSystem_get_ac_pvwatts_kwargs(pvwatts_system_kwargs, mocker):
-    mocker.spy(inverter, 'pvwatts')
+    mocker.spy(inverter, 'pvwattsv5')
     pdc = 50
-    out = pvwatts_system_kwargs.get_ac('pvwatts', pdc)
-    inverter.pvwatts.assert_called_once_with(
+    out = pvwatts_system_kwargs.get_ac('pvwattsv5', pdc)
+    inverter.pvwattsv5.assert_called_once_with(
         pdc, **pvwatts_system_kwargs.inverter_parameters)
     assert out < pdc
 
 
 def test_PVSystem_get_ac_pvwatts_multi(
         pvwatts_system_defaults, pvwatts_system_kwargs, mocker):
-    mocker.spy(inverter, 'pvwatts_multi')
+    mocker.spy(inverter, 'pvwattsv5_multi')
     expected = [pd.Series([0.0, 48.123524, 86.400000]),
                 pd.Series([0.0, 45.893550, 85.500000])]
     systems = [pvwatts_system_defaults, pvwatts_system_kwargs]
@@ -1551,21 +1551,21 @@ def test_PVSystem_get_ac_pvwatts_multi(
             inverter_parameters=base_sys.inverter_parameters,
         )
         pdcs = pd.Series([0., 25., 50.])
-        pacs = system.get_ac('pvwatts', (pdcs, pdcs))
+        pacs = system.get_ac('pvwattsv5', (pdcs, pdcs))
         assert_series_equal(pacs, exp)
-    assert inverter.pvwatts_multi.call_count == 2
+    assert inverter.pvwattsv5_multi.call_count == 2
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.get_ac('pvwatts', (pdcs,))
+        system.get_ac('pvwattsv5', (pdcs,))
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.get_ac('pvwatts', pdcs)
+        system.get_ac('pvwattsv5', pdcs)
     with pytest.raises(ValueError,
                        match="Length mismatch for per-array parameter"):
-        system.get_ac('pvwatts', (pdcs, pdcs, pdcs))
+        system.get_ac('pvwattsv5', (pdcs, pdcs, pdcs))
 
 
-@pytest.mark.parametrize('model', ['sandia', 'adr', 'pvwatts'])
+@pytest.mark.parametrize('model', ['sandia', 'adr', 'pvwattsv5'])
 def test_PVSystem_get_ac_single_array_tuple_input(
         model,
         pvwatts_system_defaults,
@@ -1573,16 +1573,16 @@ def test_PVSystem_get_ac_single_array_tuple_input(
         adr_inverter_parameters):
     vdcs = {
         'sandia': pd.Series(np.linspace(0, 50, 3)),
-        'pvwatts': None,
+        'pvwattsv5': None,
         'adr': pd.Series([135, 154, 390, 420, 551])
     }
     pdcs = {'adr': pd.Series([135, 1232, 1170, 420, 551]),
             'sandia': pd.Series(np.linspace(0, 11, 3)) * vdcs['sandia'],
-            'pvwatts': 50}
+            'pvwattsv5': 50}
     inverter_parameters = {
         'sandia': cec_inverter_parameters,
         'adr': adr_inverter_parameters,
-        'pvwatts': pvwatts_system_defaults.inverter_parameters
+        'pvwattsv5': pvwatts_system_defaults.inverter_parameters
     }
     expected = {
         'adr': pd.Series([np.nan, 1161.5745, 1116.4459, 382.6679, np.nan]),
@@ -1593,8 +1593,8 @@ def test_PVSystem_get_ac_single_array_tuple_input(
         inverter_parameters=inverter_parameters[model]
     )
     ac = system.get_ac(p_dc=(pdcs[model],), v_dc=(vdcs[model],), model=model)
-    if model == 'pvwatts':
-        assert ac < pdcs['pvwatts']
+    if model == 'pvwattsv5':
+        assert ac < pdcs['pvwattsv5']
     else:
         assert_series_equal(ac, expected[model])
 
@@ -1981,48 +1981,48 @@ def test_Array___repr__():
     assert array.__repr__() == expected
 
 
-def test_pvwatts_dc_scalars():
+def test_pvwattsv5_dc_scalars():
     expected = 88.65
-    out = pvsystem.pvwatts_dc(900, 30, 100, -0.003)
+    out = pvsystem.pvwattsv5_dc(900, 30, 100, -0.003)
     assert_allclose(out, expected)
 
 
-def test_pvwatts_dc_arrays():
+def test_pvwattsv5_dc_arrays():
     irrad_trans = np.array([np.nan, 900, 900])
     temp_cell = np.array([30, np.nan, 30])
     irrad_trans, temp_cell = np.meshgrid(irrad_trans, temp_cell)
     expected = np.array([[nan,  88.65,  88.65],
                          [nan,    nan,    nan],
                          [nan,  88.65,  88.65]])
-    out = pvsystem.pvwatts_dc(irrad_trans, temp_cell, 100, -0.003)
+    out = pvsystem.pvwattsv5_dc(irrad_trans, temp_cell, 100, -0.003)
     assert_allclose(out, expected, equal_nan=True)
 
 
-def test_pvwatts_dc_series():
+def test_pvwattsv5_dc_series():
     irrad_trans = pd.Series([np.nan, 900, 900])
     temp_cell = pd.Series([30, np.nan, 30])
     expected = pd.Series(np.array([   nan,    nan,  88.65]))
-    out = pvsystem.pvwatts_dc(irrad_trans, temp_cell, 100, -0.003)
+    out = pvsystem.pvwattsv5_dc(irrad_trans, temp_cell, 100, -0.003)
     assert_series_equal(expected, out)
 
 
-def test_pvwatts_losses_default():
+def test_pvwattsv5_losses_default():
     expected = 14.075660688264469
-    out = pvsystem.pvwatts_losses()
+    out = pvsystem.pvwattsv5_losses()
     assert_allclose(out, expected)
 
 
-def test_pvwatts_losses_arrays():
+def test_pvwattsv5_losses_arrays():
     expected = np.array([nan, 14.934904])
     age = np.array([nan, 1])
-    out = pvsystem.pvwatts_losses(age=age)
+    out = pvsystem.pvwattsv5_losses(age=age)
     assert_allclose(out, expected)
 
 
-def test_pvwatts_losses_series():
+def test_pvwattsv5_losses_series():
     expected = pd.Series([nan, 14.934904])
     age = pd.Series([nan, 1])
-    out = pvsystem.pvwatts_losses(age=age)
+    out = pvsystem.pvwattsv5_losses(age=age)
     assert_series_equal(expected, out)
 
 
@@ -2044,30 +2044,30 @@ def pvwatts_system_kwargs():
     return system
 
 
-def test_PVSystem_pvwatts_dc(pvwatts_system_defaults, mocker):
-    mocker.spy(pvsystem, 'pvwatts_dc')
+def test_PVSystem_pvwatts_dcv5(pvwatts_system_defaults, mocker):
+    mocker.spy(pvsystem, 'pvwattsv5_dc')
     irrad = 900
     temp_cell = 30
     expected = 90
-    out = pvwatts_system_defaults.pvwatts_dc(irrad, temp_cell)
-    pvsystem.pvwatts_dc.assert_called_once_with(
+    out = pvwatts_system_defaults.pvwattsv5_dc(irrad, temp_cell)
+    pvsystem.pvwattsv5_dc.assert_called_once_with(
         irrad, temp_cell,
         **pvwatts_system_defaults.arrays[0].module_parameters)
     assert_allclose(expected, out, atol=10)
 
 
-def test_PVSystem_pvwatts_dc_kwargs(pvwatts_system_kwargs, mocker):
-    mocker.spy(pvsystem, 'pvwatts_dc')
+def test_PVSystem_pvwattsv5_dc_kwargs(pvwatts_system_kwargs, mocker):
+    mocker.spy(pvsystem, 'pvwattsv5_dc')
     irrad = 900
     temp_cell = 30
     expected = 90
-    out = pvwatts_system_kwargs.pvwatts_dc(irrad, temp_cell)
-    pvsystem.pvwatts_dc.assert_called_once_with(
+    out = pvwatts_system_kwargs.pvwattsv5_dc(irrad, temp_cell)
+    pvsystem.pvwattsv5_dc.assert_called_once_with(
         irrad, temp_cell, **pvwatts_system_kwargs.arrays[0].module_parameters)
     assert_allclose(expected, out, atol=10)
 
 
-def test_PVSystem_multiple_array_pvwatts_dc():
+def test_PVSystem_multiple_array_pvwattsv5_dc():
     array_one_module_parameters = {
         'pdc0': 100, 'gamma_pdc': -0.003, 'temp_ref': 20
     }
@@ -2087,17 +2087,17 @@ def test_PVSystem_multiple_array_pvwatts_dc():
     irrad_two = 500
     temp_cell_one = 30
     temp_cell_two = 20
-    expected_one = pvsystem.pvwatts_dc(irrad_one, temp_cell_one,
-                                       **array_one_module_parameters)
-    expected_two = pvsystem.pvwatts_dc(irrad_two, temp_cell_two,
-                                       **array_two_module_parameters)
-    dc_one, dc_two = system.pvwatts_dc((irrad_one, irrad_two),
-                                       (temp_cell_one, temp_cell_two))
+    expected_one = pvsystem.pvwattsv5_dc(irrad_one, temp_cell_one,
+                                         **array_one_module_parameters)
+    expected_two = pvsystem.pvwattsv5_dc(irrad_two, temp_cell_two,
+                                         **array_two_module_parameters)
+    dc_one, dc_two = system.pvwattsv5_dc((irrad_one, irrad_two),
+                                         (temp_cell_one, temp_cell_two))
     assert dc_one == expected_one
     assert dc_two == expected_two
 
 
-def test_PVSystem_multiple_array_pvwatts_dc_value_error():
+def test_PVSystem_multiple_array_pvwattsv5_dc_value_error():
     system = pvsystem.PVSystem(
         arrays=[pvsystem.Array(pvsystem.FixedMount(0, 180)),
                 pvsystem.Array(pvsystem.FixedMount(0, 180)),
@@ -2105,54 +2105,54 @@ def test_PVSystem_multiple_array_pvwatts_dc_value_error():
     )
     error_message = 'Length mismatch for per-array parameter'
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc(10, (1, 1, 1))
+        system.pvwattsv5_dc(10, (1, 1, 1))
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((10, 10), (1, 1, 1))
+        system.pvwattsv5_dc((10, 10), (1, 1, 1))
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((10, 10, 10, 10), (1, 1, 1))
+        system.pvwattsv5_dc((10, 10, 10, 10), (1, 1, 1))
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((1, 1, 1), 1)
+        system.pvwattsv5_dc((1, 1, 1), 1)
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((1, 1, 1), (1,))
+        system.pvwattsv5_dc((1, 1, 1), (1,))
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((1,), 1)
+        system.pvwattsv5_dc((1,), 1)
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc((1, 1, 1, 1), (1, 1))
+        system.pvwattsv5_dc((1, 1, 1, 1), (1, 1))
     with pytest.raises(ValueError, match=error_message):
-        system.pvwatts_dc(2, 3)
+        system.pvwattsv5_dc(2, 3)
     with pytest.raises(ValueError, match=error_message):
         # ValueError is raised for non-tuple iterable with correct length
-        system.pvwatts_dc((1, 1, 1), pd.Series([1, 2, 3]))
+        system.pvwattsv5_dc((1, 1, 1), pd.Series([1, 2, 3]))
 
 
-def test_PVSystem_pvwatts_losses(pvwatts_system_defaults, mocker):
-    mocker.spy(pvsystem, 'pvwatts_losses')
+def test_PVSystem_pvwattsv5_losses(pvwatts_system_defaults, mocker):
+    mocker.spy(pvsystem, 'pvwattsv5_losses')
     age = 1
     pvwatts_system_defaults.losses_parameters = dict(age=age)
     expected = 15
-    out = pvwatts_system_defaults.pvwatts_losses()
-    pvsystem.pvwatts_losses.assert_called_once_with(age=age)
+    out = pvwatts_system_defaults.pvwattsv5_losses()
+    pvsystem.pvwattsv5_losses.assert_called_once_with(age=age)
     assert out < expected
 
 
 @fail_on_pvlib_version('0.10')
 def test_PVSystem_pvwatts_ac(pvwatts_system_defaults, mocker):
-    mocker.spy(inverter, 'pvwatts')
+    mocker.spy(inverter, 'pvwattsv5')
     pdc = 50
     with pytest.warns(pvlibDeprecationWarning):
         out = pvwatts_system_defaults.pvwatts_ac(pdc)
-    inverter.pvwatts.assert_called_once_with(
+    inverter.pvwattsv5.assert_called_once_with(
         pdc, **pvwatts_system_defaults.inverter_parameters)
     assert out < pdc
 
 
 @fail_on_pvlib_version('0.10')
 def test_PVSystem_pvwatts_ac_kwargs(pvwatts_system_kwargs, mocker):
-    mocker.spy(inverter, 'pvwatts')
+    mocker.spy(inverter, 'pvwattsv5')
     pdc = 50
     with pytest.warns(pvlibDeprecationWarning):
         out = pvwatts_system_kwargs.pvwatts_ac(pdc)
-    inverter.pvwatts.assert_called_once_with(
+    inverter.pvwattsv5.assert_called_once_with(
         pdc, **pvwatts_system_kwargs.inverter_parameters)
     assert out < pdc
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1595,6 +1595,7 @@ def test_PVSystem_get_ac_pvwatts_multi_deprecated(
         with pytest.warns(pvlibDeprecationWarning, match=match):
             pacs = system.get_ac('pvwatts', (pdcs, pdcs))
         assert_series_equal(pacs, exp)
+    assert inverter.pvwatts_multi.call_count == 0
 
 
 @pytest.mark.parametrize('model', ['sandia', 'adr', 'pvwattsv5'])
@@ -2110,7 +2111,7 @@ def test_PVSystem_pvwatts_dcv5(pvwatts_system_defaults, mocker):
 
 @fail_on_pvlib_version('0.10.0')
 def test_PVSystem_pvwatts_dc_deprecated(pvwatts_system_defaults, mocker):
-    mocker.spy(pvsystem, 'pvwattsv5_dc')
+    mocker.spy(pvsystem, 'pvwatts_dc')
     irrad = 900
     temp_cell = 30
     expected = 90
@@ -2121,6 +2122,7 @@ def test_PVSystem_pvwatts_dc_deprecated(pvwatts_system_defaults, mocker):
         irrad, temp_cell,
         **pvwatts_system_defaults.arrays[0].module_parameters)
     assert_allclose(expected, out, atol=10)
+    assert pvsystem.pvwatts_dc.call_count == 0
 
 
 def test_PVSystem_pvwattsv5_dc_kwargs(pvwatts_system_kwargs, mocker):
@@ -2204,14 +2206,14 @@ def test_PVSystem_pvwattsv5_losses(pvwatts_system_defaults, mocker):
 
 @fail_on_pvlib_version('0.10.0')
 def test_PVSystem_pvwatts_losses_deprecated(pvwatts_system_defaults, mocker):
-    mocker.spy(pvsystem, 'pvwattsv5_losses')
+    mocker.spy(pvsystem, 'pvwatts_losses')
     age = 1
     pvwatts_system_defaults.losses_parameters = dict(age=age)
     expected = 15
     with pytest.warns(pvlibDeprecationWarning,
                       match='Use PVSystem.pvwattsv5_losses instead'):
         out = pvwatts_system_defaults.pvwatts_losses()
-    pvsystem.pvwattsv5_losses.assert_called_once_with(age=age)
+    pvsystem.pvwatts_losses.call_count == 0
     assert out < expected
 
 


### PR DESCRIPTION
 - [x] Closes #1350
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

A rather tedious PR, both to prepare and (I imagine) to review.  `$ git grep -n -e 'pvwatts[^v]'` is invaluable for finding stragglers.  

For reference, SAM's implementation of PVWatts v8 is out (https://github.com/NREL/ssc/pull/630), but I don't think there's a publication about it yet, so let's implement v8 later and just focus on making room for it now.  This PR is big enough already anyway.