### PR TITLE
Add optional `return_components` parameter to irradiance.haydavies

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -10,6 +10,7 @@ Deprecations
 Enhancements
 ~~~~~~~~~~~~
 * Multiple code style issues fixed that were reported by LGTM analysis. (:issue:`1275`, :pull:`1559`)
+* Option to return individual components of Hay Davies sky transposition model (:issue:`1553`, :pull:`1568`)
 
 Bug fixes
 ~~~~~~~~~
@@ -35,3 +36,4 @@ Requirements
 Contributors
 ~~~~~~~~~~~~
 * Christian Orner (:ghuser:`chrisorner`)
+* Saurabh Aneja (:ghuser:`spaneja`)

--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -10,7 +10,7 @@ Deprecations
 Enhancements
 ~~~~~~~~~~~~
 * Multiple code style issues fixed that were reported by LGTM analysis. (:issue:`1275`, :pull:`1559`)
-* Option to return individual components of Hay Davies sky transposition model (:issue:`1553`, :pull:`1568`)
+* Add optional ``return_components`` parameter to :py:func:`pvlib.irradiance.haydavies` to return individual diffuse irradiance components (:issue:`1553`, :pull:`1568`)
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -791,6 +791,10 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         projection. Must supply ``solar_zenith`` and ``solar_azimuth``
         or supply ``projection_ratio``.
 
+    return_components: bool (optional, default=False)
+        Flag used to decide whether to return the calculated diffuse components
+        or not.
+
     Returns
     --------
     sky_diffuse : numeric

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -847,8 +847,8 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         # Calculate the individual components
         diffuse_components['isotropic'] = np.maximum(dhi * term1 * term2, 0)
         diffuse_components['circumsolar'] = np.maximum(dhi * (AI * Rb), 0)
-        diffuse_components['horizon'] = np.where(np.isnan(diffuse_components['isotropic']),
-                                                 np.nan, 0.)
+        diffuse_components['horizon'] = np.where(
+            np.isnan(diffuse_components['isotropic']), np.nan, 0.)
 
         # Set values of components to 0 when sky_diffuse is 0
         mask = sky_diffuse == 0

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -834,6 +834,12 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     sky_diffuse = dhi * (AI * Rb + term1 * term2)
     sky_diffuse = np.maximum(sky_diffuse, 0)
 
+    # we've preserved the input type until now, so don't ruin it!
+    # if isinstance(sky_diffuse, pd.Series):
+    #     sky_diffuse[np.isnan(surface_tilt)] = 0
+    # else:
+    #     sky_diffuse = np.where(np.isnan(surface_tilt), 0, sky_diffuse)
+
     if return_components:
         diffuse_components = OrderedDict()
         diffuse_components['sky_diffuse'] = sky_diffuse
@@ -841,6 +847,8 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         # Calculate the individual components
         diffuse_components['isotropic'] = np.maximum(dhi * term1 * term2, 0)
         diffuse_components['circumsolar'] = np.maximum(dhi * (AI * Rb), 0)
+        diffuse_components['horizon'] = np.where(np.isnan(diffuse_components['isotropic']),
+                                                 np.nan, 0.)
 
         # Set values of components to 0 when sky_diffuse is 0
         mask = sky_diffuse == 0

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -206,6 +206,7 @@ def test_haydavies(irrad_data, ephem_data, dni_et):
     # values from matlab 1.4 code
     assert_allclose(result, [0, 27.1775, 102.9949, 33.1909], atol=1e-4)
 
+
 def test_haydavies_components(irrad_data, ephem_data, dni_et):
     result = irradiance.haydavies(
         40, 180, irrad_data['dhi'], irrad_data['dni'], dni_et,
@@ -214,16 +215,21 @@ def test_haydavies_components(irrad_data, ephem_data, dni_et):
     expected = pd.DataFrame(np.array(
         [[0, 27.1775, 102.9949, 33.1909],
          [0, 27.1775, 30.1818, 27.9837],
-         [0, 0, 72.8130, 5.2071],]).T,
-        columns=['sky_diffuse', 'isotropic', 'circumsolar'],
+         [0, 0, 72.8130, 5.2071],
+         [0, 0, 0, 0]]).T,
+        columns=['sky_diffuse', 'isotropic', 'circumsolar', 'horizon'],
         index=irrad_data.index
     )
     # values
-    assert_allclose(result.sky_diffuse, [0, 27.1775, 102.9949, 33.1909], atol=1e-4)
-    assert_allclose(result.isotropic, [0, 27.1775, 30.1818, 27.9837], atol=1e-4)
+    assert_allclose(result.sky_diffuse, [0, 27.1775, 102.9949, 33.1909],
+                    atol=1e-4)
+    assert_allclose(result.isotropic, [0, 27.1775, 30.1818, 27.9837],
+                    atol=1e-4)
     assert_allclose(result.circumsolar, [0, 0, 72.8130, 5.2071], atol=1e-4)
+    assert_allclose(result.horizon, [0, 0, 0, 0], atol=1e-4)
     assert_frame_equal(result, expected, check_less_precise=4)
     assert isinstance(result, pd.DataFrame)
+
 
 def test_reindl(irrad_data, ephem_data, dni_et):
     result = irradiance.reindl(

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -206,6 +206,24 @@ def test_haydavies(irrad_data, ephem_data, dni_et):
     # values from matlab 1.4 code
     assert_allclose(result, [0, 27.1775, 102.9949, 33.1909], atol=1e-4)
 
+def test_haydavies_components(irrad_data, ephem_data, dni_et):
+    result = irradiance.haydavies(
+        40, 180, irrad_data['dhi'], irrad_data['dni'], dni_et,
+        ephem_data['apparent_zenith'], ephem_data['azimuth'],
+        return_components=True)
+    expected = pd.DataFrame(np.array(
+        [[0, 27.1775, 102.9949, 33.1909],
+         [0, 27.1775, 30.1818, 27.9837],
+         [0, 0, 72.8130, 5.2071],]).T,
+        columns=['sky_diffuse', 'isotropic', 'circumsolar'],
+        index=irrad_data.index
+    )
+    # values
+    assert_allclose(result.sky_diffuse, [0, 27.1775, 102.9949, 33.1909], atol=1e-4)
+    assert_allclose(result.isotropic, [0, 27.1775, 30.1818, 27.9837], atol=1e-4)
+    assert_allclose(result.circumsolar, [0, 0, 72.8130, 5.2071], atol=1e-4)
+    assert_frame_equal(result, expected, check_less_precise=4)
+    assert isinstance(result, pd.DataFrame)
 
 def test_reindl(irrad_data, ephem_data, dni_et):
     result = irradiance.reindl(

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -212,6 +212,10 @@ def test_haydavies_components(irrad_data, ephem_data, dni_et):
         40, 180, irrad_data['dhi'], irrad_data['dni'], dni_et,
         ephem_data['apparent_zenith'], ephem_data['azimuth'],
         return_components=True)
+    result_val = irradiance.haydavies(
+        40, 180, irrad_data['dhi'].values, irrad_data['dni'].values, dni_et,
+        ephem_data['apparent_zenith'].values, ephem_data['azimuth'].values,
+        return_components=True)
     expected = pd.DataFrame(np.array(
         [[0, 27.1775, 102.9949, 33.1909],
          [0, 27.1775, 30.1818, 27.9837],
@@ -229,6 +233,8 @@ def test_haydavies_components(irrad_data, ephem_data, dni_et):
     assert_allclose(result.horizon, [0, 0, 0, 0], atol=1e-4)
     assert_frame_equal(result, expected, check_less_precise=4)
     assert isinstance(result, pd.DataFrame)
+    assert_allclose(result_val['sky_diffuse'], [0, 27.1775, 102.9949, 33.1909],
+                    atol=1e-4)
 
 
 def test_reindl(irrad_data, ephem_data, dni_et):

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -225,14 +225,7 @@ def test_haydavies_components(irrad_data, ephem_data, dni_et):
         index=irrad_data.index
     )
     # values
-    assert_allclose(result.sky_diffuse, [0, 27.1775, 102.9949, 33.1909],
-                    atol=1e-4)
-    assert_allclose(result.isotropic, [0, 27.1775, 30.1818, 27.9837],
-                    atol=1e-4)
-    assert_allclose(result.circumsolar, [0, 0, 72.8130, 5.2071], atol=1e-4)
-    assert_allclose(result.horizon, [0, 0, 0, 0], atol=1e-4)
     assert_frame_equal(result, expected, check_less_precise=4)
-    assert isinstance(result, pd.DataFrame)
     assert_allclose(result_val['sky_diffuse'], [0, 27.1775, 102.9949, 33.1909],
                     atol=1e-4)
 

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -208,14 +208,6 @@ def test_haydavies(irrad_data, ephem_data, dni_et):
 
 
 def test_haydavies_components(irrad_data, ephem_data, dni_et):
-    result = irradiance.haydavies(
-        40, 180, irrad_data['dhi'], irrad_data['dni'], dni_et,
-        ephem_data['apparent_zenith'], ephem_data['azimuth'],
-        return_components=True)
-    result_val = irradiance.haydavies(
-        40, 180, irrad_data['dhi'].values, irrad_data['dni'].values, dni_et,
-        ephem_data['apparent_zenith'].values, ephem_data['azimuth'].values,
-        return_components=True)
     expected = pd.DataFrame(np.array(
         [[0, 27.1775, 102.9949, 33.1909],
          [0, 27.1775, 30.1818, 27.9837],
@@ -224,11 +216,35 @@ def test_haydavies_components(irrad_data, ephem_data, dni_et):
         columns=['sky_diffuse', 'isotropic', 'circumsolar', 'horizon'],
         index=irrad_data.index
     )
-    # values
+    # pandas
+    result = irradiance.haydavies(
+        40, 180, irrad_data['dhi'], irrad_data['dni'], dni_et,
+        ephem_data['apparent_zenith'], ephem_data['azimuth'],
+        return_components=True)
     assert_frame_equal(result, expected, check_less_precise=4)
-    assert_allclose(result_val['sky_diffuse'], [0, 27.1775, 102.9949, 33.1909],
+    # numpy
+    result = irradiance.haydavies(
+        40, 180, irrad_data['dhi'].values, irrad_data['dni'].values, dni_et,
+        ephem_data['apparent_zenith'].values, ephem_data['azimuth'].values,
+        return_components=True)
+    assert_allclose(result['sky_diffuse'], expected['sky_diffuse'], atol=1e-4)
+    assert_allclose(result['isotropic'], expected['isotropic'], atol=1e-4)
+    assert_allclose(result['circumsolar'], expected['circumsolar'], atol=1e-4)
+    assert_allclose(result['horizon'], expected['horizon'], atol=1e-4)
+    assert isinstance(result, dict)
+    # scalar
+    result = irradiance.haydavies(
+        40, 180, irrad_data['dhi'].values[-1], irrad_data['dni'].values[-1],
+        dni_et[-1], ephem_data['apparent_zenith'].values[-1],
+        ephem_data['azimuth'].values[-1], return_components=True)
+    assert_allclose(result['sky_diffuse'], expected['sky_diffuse'][-1],
                     atol=1e-4)
-
+    assert_allclose(result['isotropic'], expected['isotropic'][-1],
+                    atol=1e-4)
+    assert_allclose(result['circumsolar'], expected['circumsolar'][-1],
+                    atol=1e-4)
+    assert_allclose(result['horizon'], expected['horizon'][-1], atol=1e-4)
+    assert isinstance(result, dict)
 
 def test_reindl(irrad_data, ephem_data, dni_et):
     result = irradiance.reindl(


### PR DESCRIPTION
Update the Hay Davies sky transposition model to return individual components by user request.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
