### PR TITLE
add support for zero gcr in bifacial.infinite_sheds and shading.masking_angle

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -20,6 +20,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+* Fixed bug in :py:func:`pvlib.shading.masking_angle` and :py:func:`pvlib.bifacial.infinite_sheds._ground_angle`
+  where zero ``gcr`` input caused a ZeroDivisionError (:issue:`1576`, :pull:`1589`)
 
 Testing
 ~~~~~~~
@@ -43,3 +45,4 @@ Contributors
 * Christian Orner (:ghuser:`chrisorner`)
 * Saurabh Aneja (:ghuser:`spaneja`)
 * Marcus Boumans (:ghuser:`bowie2211`)
+* Karel De Brabandere (:ghuser:`kdebrab`)

--- a/pvlib/bifacial/infinite_sheds.py
+++ b/pvlib/bifacial/infinite_sheds.py
@@ -216,8 +216,8 @@ def _ground_angle(x, surface_tilt, gcr):
     #  :         \  v      *-.\
     #  :          \<-----P---->\
 
-    x1 = x * sind(surface_tilt)
-    x2 = (x * cosd(surface_tilt) + 1 / gcr)
+    x1 = gcr * x * sind(surface_tilt)
+    x2 = gcr * x * cosd(surface_tilt) + 1
     psi = np.arctan2(x1, x2)  # do this first because it handles 0 / 0
     return np.rad2deg(psi)
 

--- a/pvlib/shading.py
+++ b/pvlib/shading.py
@@ -52,8 +52,8 @@ def masking_angle(surface_tilt, gcr, slant_height):
     # The original equation (8 in [1]) requires pitch and collector width,
     # but it's easy to non-dimensionalize it to make it a function of GCR
     # by factoring out B from the argument to arctan.
-    numerator = (1 - slant_height) * sind(surface_tilt)
-    denominator = 1/gcr - (1 - slant_height) * cosd(surface_tilt)
+    numerator = gcr * (1 - slant_height) * sind(surface_tilt)
+    denominator = 1 - gcr * (1 - slant_height) * cosd(surface_tilt)
     phi = np.arctan(numerator / denominator)
     return np.degrees(phi)
 

--- a/pvlib/tests/bifacial/test_infinite_sheds.py
+++ b/pvlib/tests/bifacial/test_infinite_sheds.py
@@ -106,6 +106,14 @@ def test__ground_angle(test_system):
     assert np.allclose(angles, expected_angles)
 
 
+def test__ground_angle_zero_gcr():
+    surface_tilt = 30.0
+    x = np.array([0.0, 0.5, 1.0])
+    angles = infinite_sheds._ground_angle(x, surface_tilt, 0)
+    expected_angles = np.array([0, 0, 0])
+    assert np.allclose(angles, expected_angles)
+
+
 def test__vf_row_ground(test_system):
     ts, _, _ = test_system
     x = np.array([0., 0.5, 1.0])

--- a/pvlib/tests/test_shading.py
+++ b/pvlib/tests/test_shading.py
@@ -45,6 +45,13 @@ def test_masking_angle_scalar(surface_tilt, masking_angle):
         assert np.isclose(masking_angle_actual, angle)
 
 
+def test_masking_angle_zero_gcr(surface_tilt):
+    # scalar inputs and outputs, including zero
+    for tilt in surface_tilt:
+        masking_angle_actual = shading.masking_angle(tilt, 0, 0.25)
+        assert np.isclose(masking_angle_actual, 0)
+
+
 def test_masking_angle_passias_series(surface_tilt, average_masking_angle):
     # pandas series inputs and outputs
     masking_angle_actual = shading.masking_angle_passias(surface_tilt, 0.5)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1576
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
