### PR TITLE
Fix CI ASV check by allowing any py 3.9.* for ubuntu-latest

### DIFF
--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.9.7'
+          python-version: '3.9'
 
       - name: Install asv
         run: pip install asv==0.4.2


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The "quick ASV check" CI job started failing yesterday: https://github.com/pvlib/pvlib-python/actions/runs/3597286595/jobs/6058885668

The job runs on `ubuntu-latest`, which as of yesterday refers to Ubuntu-22.04 instead of Ubuntu-20.04 ([ref](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/)).  The oldest patch version of python 3.9 available through `setup-python` for Ubuntu 22.04 is 3.9.12 (https://github.com/actions/setup-python/issues/552#issuecomment-1333668378), so specifying 3.9.7 as the job currently does results in an error.  I don't think the patch version really matters here, so I've unpinned the patch version to just require any `3.9` instead of specifically `3.9.7`.