### PR TITLE
Fix the things that broke when we renamed master -> main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
  - [ ] Closes #xxxx
  - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
  - [ ] Tests added
- - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
- - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
+ - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
+ - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
  - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
  - [ ] Pull request is nearly complete and ready for detailed review.
  - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -4,7 +4,7 @@ name: asv
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
     tags:
     - "v*"
 

--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -1,5 +1,5 @@
 # A secondary test job that only runs the iotools tests if explicitly requested
-# (for pull requests) or on a push to the master branch.
+# (for pull requests) or on a push to the main branch.
 # Because the iotools tests require GitHub secrets, we need to be careful about 
 # malicious PRs accessing the secrets and exposing them externally.
 #
@@ -48,7 +48,7 @@ on:
     types: [labeled]
   push:
     branches:
-    - master
+    - main
 
 jobs:
   test:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         if: github.event_name == 'pull_request_target'
-        # pull_request_target runs in the context of the target branch (pvlib/master),
+        # pull_request_target runs in the context of the target branch (pvlib/main),
         # but what we need is the hypothetical merge commit from the PR:
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/pvlib/pvlib-python/blob/master/LICENSE">
+    <a href="https://github.com/pvlib/pvlib-python/blob/main/LICENSE">
     <img src="https://img.shields.io/pypi/l/pvlib.svg" alt="license" />
     </a>
 </td>
@@ -28,11 +28,11 @@
     <a href="http://pvlib-python.readthedocs.org/en/stable/">
     <img src="https://readthedocs.org/projects/pvlib-python/badge/?version=stable" alt="documentation build status" />
     </a>
-    <a href="https://github.com/pvlib/pvlib-python/actions/workflows/pytest.yml?query=branch%3Amaster">
-      <img src="https://github.com/pvlib/pvlib-python/actions/workflows/pytest.yml/badge.svg?branch=master" alt="GitHub Actions Testing Status" />
+    <a href="https://github.com/pvlib/pvlib-python/actions/workflows/pytest.yml?query=branch%3Amain">
+      <img src="https://github.com/pvlib/pvlib-python/actions/workflows/pytest.yml/badge.svg?branch=main" alt="GitHub Actions Testing Status" />
     </a>
     <a href="https://codecov.io/gh/pvlib/pvlib-python">
-    <img src="https://codecov.io/gh/pvlib/pvlib-python/branch/master/graph/badge.svg" alt="codecov coverage" />
+    <img src="https://codecov.io/gh/pvlib/pvlib-python/branch/main/graph/badge.svg" alt="codecov coverage" />
     </a>
   </td>
 </tr>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ tests are run using
 
 The basic structure of the tests and how to run them is described below.
 We refer readers to the ASV documentation for more details. The AstroPy
-[documentation](https://github.com/astropy/astropy-benchmarks/tree/master)
+[documentation](https://github.com/astropy/astropy-benchmarks/tree/main)
 may also be helpful.
 
 The test configuration is described in [asv.conf.json](asv.conf.json).
@@ -23,7 +23,7 @@ For example, if your feature branch is named ``feature``, a useful asv
 run may be (from the same directory as `asv.conf.json`):
 
 ```
-$ asv run master..feature
+$ asv run main..feature
 ```
 
 This will generate timings for every commit between the two specified
@@ -87,7 +87,7 @@ $ asv preview
 Nightly benchmarking
 --------------------
 
-The benchmarks are run nightly for new commits to pvlib-python/master.
+The benchmarks are run nightly for new commits to pvlib-python/main.
 
 - Timing results: https://pvlib-benchmarker.github.io/pvlib-benchmarks/
 - Information on the process: https://github.com/pvlib-benchmarker/pvlib-benchmarks

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -29,7 +29,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -431,7 +431,7 @@ def make_github_url(file_name):
     "/docs/sphinx/source/api.rst" or "generated/pvlib.atmosphere.alt2pres.rst"
     """
 
-    URL_BASE = "https://github.com/pvlib/pvlib-python/blob/master/"
+    URL_BASE = "https://github.com/pvlib/pvlib-python/blob/main/"
 
     # is it a gallery page?
     if any(d in file_name for d in sphinx_gallery_conf['gallery_dirs']):

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -102,7 +102,7 @@ A pull request can also quickly become unmanageable if it proposes
 changes to the API in order to implement another feature. Consider
 clearly and concisely documenting all proposed API changes before
 implementing any code. Modifying
-`api.rst <https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/api.rst>`_
+`api.rst <https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/reference>`_
 and/or the latest `whatsnew file <https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew>`_
 can help formalize this process.
 
@@ -230,7 +230,7 @@ Documentation
 Documentation must be written in
 `numpydoc format <https://numpydoc.readthedocs.io/>`_ format which is rendered
 using the `Sphinx Napoleon extension
-<https://www.sphinx-doc.org/en/main/usage/extensions/napoleon.html>`_.
+<https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_.
 
 The numpydoc format includes a specification for the allowable input
 types. Python's `duck typing <https://en.wikipedia.org/wiki/Duck_typing>`_

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -102,8 +102,8 @@ A pull request can also quickly become unmanageable if it proposes
 changes to the API in order to implement another feature. Consider
 clearly and concisely documenting all proposed API changes before
 implementing any code. Modifying
-`api.rst <https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/api.rst>`_
-and/or the latest `whatsnew file <https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew>`_
+`api.rst <https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/api.rst>`_
+and/or the latest `whatsnew file <https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew>`_
 can help formalize this process.
 
 Questions about related issues frequently come up in the process of
@@ -154,7 +154,7 @@ a timely manner is to:
    the issue with the appropriate milestone.
 #. Make a limited-scope pull request. It can be a lot of work to check all of
    the boxes in `pull request guidelines
-   <https://github.com/pvlib/pvlib-python/blob/master/.github/PULL_REQUEST_TEMPLATE.md>`_,
+   <https://github.com/pvlib/pvlib-python/blob/main/.github/PULL_REQUEST_TEMPLATE.md>`_,
    especially for pull requests with a lot of new primary code.
    See :ref:`pull-request-scope`.
 #. Tag pvlib community members or ``@pvlib`` when the pull
@@ -217,7 +217,7 @@ We typically use GitHub's
 "`squash and merge <https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits>`_"
 feature to merge your pull request into pvlib. GitHub will condense the
 commit history of your branch into a single commit when merging into
-pvlib-python/master (the commit history on your branch remains
+pvlib-python/main (the commit history on your branch remains
 unchanged). Therefore, you are free to make commits that are as big or
 small as you'd like while developing your pull request.
 
@@ -230,7 +230,7 @@ Documentation
 Documentation must be written in
 `numpydoc format <https://numpydoc.readthedocs.io/>`_ format which is rendered
 using the `Sphinx Napoleon extension
-<https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_.
+<https://www.sphinx-doc.org/en/main/usage/extensions/napoleon.html>`_.
 
 The numpydoc format includes a specification for the allowable input
 types. Python's `duck typing <https://en.wikipedia.org/wiki/Duck_typing>`_
@@ -258,7 +258,7 @@ Read the Docs build it for you.  Building the docs locally requires installing
 pvlib python as an editable library (see :ref:`installation` for instructions).
 First, install the ``doc`` dependencies specified in the
 ``EXTRAS_REQUIRE`` section of
-`setup.py <https://github.com/pvlib/pvlib-python/blob/master/setup.py>`_.
+`setup.py <https://github.com/pvlib/pvlib-python/blob/main/setup.py>`_.
 An easy way to do this is with::
 
     pip install pvlib[doc]
@@ -288,7 +288,7 @@ Example Gallery
 
 The example gallery uses `sphinx-gallery <https://sphinx-gallery.github.io/>`_
 and is generated from script files in the
-`docs/examples <https://github.com/pvlib/pvlib-python/tree/master/docs/examples>`_
+`docs/examples <https://github.com/pvlib/pvlib-python/tree/main/docs/examples>`_
 directory.  sphinx-gallery will execute example files that start with
 ``plot_`` and capture the output.
 
@@ -325,7 +325,7 @@ Testing
 Developers **must** include comprehensive tests for any additions or
 modifications to pvlib. New unit test code should be placed in the
 corresponding test module in the
-`pvlib/tests <https://github.com/pvlib/pvlib-python/tree/master/pvlib/tests>`_
+`pvlib/tests <https://github.com/pvlib/pvlib-python/tree/main/pvlib/tests>`_
 directory.
 
 A pull request will automatically run the tests for you on a variety of
@@ -334,7 +334,7 @@ typically more efficient to run and debug the tests in your own local
 environment.
 
 To run the tests locally, install the ``test`` dependencies specified in the
-`setup.py <https://github.com/pvlib/pvlib-python/blob/master/setup.py>`_
+`setup.py <https://github.com/pvlib/pvlib-python/blob/main/setup.py>`_
 file. See :ref:`installation` instructions for more information.
 
 pvlib's unit tests can easily be run by executing ``pytest`` on the
@@ -492,7 +492,7 @@ tests are run using the `airspeed velocity
 performance tests for most contributions at this time. Pull request
 reviewers will provide further information if a performance test is
 necessary. See our `README
-<https://github.com/pvlib/pvlib-python/tree/master/benchmarks/README.md>`_
+<https://github.com/pvlib/pvlib-python/tree/main/benchmarks/README.md>`_
 for instructions on running the benchmarks.
 
 
@@ -507,4 +507,4 @@ contributing.html>`_ for inspiration.
 Code of Conduct
 ~~~~~~~~~~~~~~~
 All contributors are expected to adhere to the `Contributor Code of Conduct
-<https://github.com/pvlib/pvlib-python/blob/master/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct>`_.
+<https://github.com/pvlib/pvlib-python/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct>`_.

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -19,7 +19,7 @@ Please see the :ref:`installation` page for installation help.
 
 For examples of how to use pvlib python, please see
 :ref:`package_overview` and our `Jupyter Notebook tutorials
-<http://nbviewer.ipython.org/github/pvlib/pvlib-python/tree/master/docs/
+<http://nbviewer.ipython.org/github/pvlib/pvlib-python/tree/main/docs/
 tutorials/>`_. The documentation assumes general familiarity with
 Python, NumPy, and Pandas. Google searches will yield many
 excellent tutorials for these packages.
@@ -72,9 +72,9 @@ Additional pvlib python publications include:
 * W.F. Holmgren, R.W. Andrews, A.T. Lorenzo, and J.S. Stein,
   “PVLIB Python 2015,” in 42nd Photovoltaic Specialists Conference, 2015.
   (`paper
-  <https://github.com/pvlib/pvsc2015/blob/master/pvlib_pvsc_42.pdf>`__ and
+  <https://github.com/pvlib/pvsc2015/blob/main/pvlib_pvsc_42.pdf>`__ and
   the `notebook to reproduce the figures
-  <http://nbviewer.ipython.org/github/pvlib/pvsc2015/blob/master/paper.ipynb>`_)
+  <http://nbviewer.ipython.org/github/pvlib/pvsc2015/blob/main/paper.ipynb>`_)
 * J.S. Stein, W.F. Holmgren, J. Forbess, and C.W. Hansen,
   "PVLIB: Open Source Photovoltaic Performance Modeling Functions
   for Matlab and Python," in 43rd Photovoltaic Specialists Conference, 2016.
@@ -85,7 +85,7 @@ Additional pvlib python publications include:
 License
 =======
 
-`BSD 3-clause <https://github.com/pvlib/pvlib-python/blob/master/LICENSE>`_.
+`BSD 3-clause <https://github.com/pvlib/pvlib-python/blob/main/LICENSE>`_.
 
 NumFOCUS
 ========

--- a/docs/sphinx/source/user_guide/forecasts.rst
+++ b/docs/sphinx/source/user_guide/forecasts.rst
@@ -46,9 +46,9 @@ We do not know of a similarly easy way to access archives of forecast data.
 This document demonstrates how to use pvlib python to create a PV power
 forecast using these tools. The `forecast
 <http://nbviewer.jupyter.org/github/pvlib/pvlib-python/blob/
-master/docs/tutorials/forecast.ipynb>`_ and `forecast_to_power
+main/docs/tutorials/forecast.ipynb>`_ and `forecast_to_power
 <http://nbviewer.jupyter.org/github/pvlib/pvlib-python/blob/
-master/docs/tutorials/forecast_to_power.ipynb>`_ Jupyter notebooks
+main/docs/tutorials/forecast_to_power.ipynb>`_ Jupyter notebooks
 provide additional example code.
 
 .. warning::

--- a/docs/sphinx/source/user_guide/installation.rst
+++ b/docs/sphinx/source/user_guide/installation.rst
@@ -98,7 +98,7 @@ repository <https://github.com/pvlib/pvlib-python>`_ or go to the
 download the zip file of the most recent release. You can also use the
 nbviewer website to choose a tutorial to experiment with. Go to our
 `nbviewer tutorial page
-<http://nbviewer.jupyter.org/github/pvlib/pvlib-python/tree/master/docs/
+<http://nbviewer.jupyter.org/github/pvlib/pvlib-python/tree/main/docs/
 tutorials/>`_.
 
 
@@ -228,7 +228,7 @@ pvlib-python is compatible with Python 3.
 
 pvlib-python requires Pandas, Numpy, and SciPy. The minimum version requirements
 are specified in
-`setup.py <https://github.com/pvlib/pvlib-python/blob/master/setup.py>`_.
+`setup.py <https://github.com/pvlib/pvlib-python/blob/main/setup.py>`_.
 They are typically releases from several years ago.
 
 A handful of pvlib-python features require additional packages that must


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/master/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/master/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I just noticed that the CI hasn't been running on `main` for the last several commits, likely because of renaming our primary branch but not updating the CI configs.  We also have a ton of broken links scattered through the docs.  This PR goes through and updates all those things.