### PR TITLE
Correct singlediode.bishop88_mpp docs

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.4.rst
@@ -65,6 +65,7 @@ Documentation
 ~~~~~~~~~~~~~
 * Added an FAQ page to the docs: :ref:`faq`. (:issue:`1546`, :pull:`1549`)
 * Fixed equation in :py:func:`pvlib.iam.martin_ruiz` docstring (:issue:`1561`, :pull:`1599`)
+* Fixed an error in :py:func:`pvlib.singlediode.bishop88_mpp` docstring (:issue:`1613`, :pull:`1615`)
 
 Benchmarking
 ~~~~~~~~~~~~~

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -422,7 +422,7 @@ def bishop88_mpp(photocurrent, saturation_current, resistance_series,
 
     Returns
     -------
-    OrderedDict or pandas.DataFrame
+    tuple
         max power current ``i_mp`` [A], max power voltage ``v_mp`` [V], and
         max power ``p_mp`` [W]
     """


### PR DESCRIPTION
 - [x] Closes #1613 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

bishop88_mpp calls bishop88 in its return line, thus the returned type is a tuple.
