### PR TITLE
Use scipy.constants

### DIFF
--- a/ci/requirements-py3.10.yml
+++ b/ci/requirements-py3.10.yml
@@ -23,7 +23,7 @@ dependencies:
     - python=3.10
     - pytz
     - requests
-    - scipy >= 1.2.0
+    - scipy >= 1.4.0
     - shapely  # pvfactors dependency
     # - siphon  # conda-forge
     - statsmodels

--- a/ci/requirements-py3.7-min.yml
+++ b/ci/requirements-py3.7-min.yml
@@ -17,7 +17,7 @@ dependencies:
         - h5py==3.1.0
         - numpy==1.16.0
         - pandas==0.25.0
-        - scipy==1.2.0
+        - scipy==1.4.0
         - pytest-rerunfailures # conda version is >3.6
         - pytest-remotedata # conda package is 0.3.0, needs > 0.3.1
         - requests-mock

--- a/ci/requirements-py3.7.yml
+++ b/ci/requirements-py3.7.yml
@@ -23,7 +23,7 @@ dependencies:
     - python=3.7
     - pytz
     - requests
-    - scipy >= 1.2.0
+    - scipy >= 1.4.0
     - shapely  # pvfactors dependency
     - siphon  # conda-forge
     - statsmodels

--- a/ci/requirements-py3.8.yml
+++ b/ci/requirements-py3.8.yml
@@ -23,7 +23,7 @@ dependencies:
     - python=3.8
     - pytz
     - requests
-    - scipy >= 1.2.0
+    - scipy >= 1.4.0
     - shapely  # pvfactors dependency
     - siphon  # conda-forge
     - statsmodels

--- a/ci/requirements-py3.9.yml
+++ b/ci/requirements-py3.9.yml
@@ -23,7 +23,7 @@ dependencies:
     - python=3.9
     - pytz
     - requests
-    - scipy >= 1.2.0
+    - scipy >= 1.4.0
     - shapely  # pvfactors dependency
     # - siphon  # conda-forge
     - statsmodels

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -8,7 +8,7 @@ Function names should follow the pattern "fit_" + name of model + "_" +
 
 import numpy as np
 
-import scipy.constants
+from scipy import constants
 from scipy import optimize
 from scipy.special import lambertw
 from scipy.misc import derivative
@@ -18,6 +18,9 @@ from pvlib.singlediode import bishop88_mpp
 
 from pvlib.ivtools.utils import rectify_iv_curve, _numdiff
 from pvlib.ivtools.sde import _fit_sandia_cocontent
+
+
+CONSTANTS = {'E0': 1000.0, 'T0': 25.0, 'k': constants.k, 'q': constants.e}
 
 
 def fit_cec_sam(celltype, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc,
@@ -204,7 +207,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
     """
 
     # Constants
-    k = scipy.constants.value('Boltzmann constant in eV/K')
+    k = constants.value('Boltzmann constant in eV/K')  # in eV/K
     Tref = temp_ref + 273.15  # [K]
 
     # initial guesses of variables for computing convergence:
@@ -340,9 +343,9 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
         T0 : float
             cell temperature at STC, default 25 [C]
         k : float
-            1.38066E-23 J/K (Boltzmann's constant)
+            Boltzmann's constant [J/K]
         q : float
-            1.60218E-19 Coulomb (elementary charge)
+            elementary charge [Coulomb]
 
     maxiter : int, default 5
         input that sets the maximum number of iterations for the parameter
@@ -417,7 +420,7 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     """
 
     if const is None:
-        const = {'E0': 1000.0, 'T0': 25.0, 'k': 1.38066e-23, 'q': 1.60218e-19}
+        const = CONSTANTS
 
     ee = ivcurves['ee']
     tc = ivcurves['tc']
@@ -520,9 +523,9 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
         T0 : float
             cell temperature at STC, default 25 [C]
         k : float
-            1.38066E-23 J/K (Boltzmann's constant)
+            Boltzmann's constant [J/K]
         q : float
-            1.60218E-19 Coulomb (elementary charge)
+            elementary charge [Coulomb]
 
     maxiter : int, default 5
         input that sets the maximum number of iterations for the parameter
@@ -579,7 +582,7 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     """
 
     if const is None:
-        const = {'E0': 1000.0, 'T0': 25.0, 'k': 1.38066e-23, 'q': 1.60218e-19}
+        const = CONSTANTS
 
     ee = ivcurves['ee']
     tc = ivcurves['tc']

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -10,6 +10,7 @@ import itertools
 import os
 from urllib.request import urlopen
 import numpy as np
+from scipy import constants
 import pandas as pd
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
@@ -2043,8 +2044,8 @@ def calcparams_desoto(effective_irradiance, temp_cell,
          Source: [4]
     '''
 
-    # Boltzmann constant in eV/K
-    k = 8.617332478e-05
+    # Boltzmann constant in eV/K, 8.617332478e-05
+    k = constants.value('Boltzmann constant in eV/K')
 
     # reference temperature
     Tref_K = temp_ref + 273.15
@@ -2301,10 +2302,10 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
     '''
 
     # Boltzmann constant in J/K
-    k = 1.38064852e-23
+    k = constants.k
 
     # elementary charge in coulomb
-    q = 1.6021766e-19
+    q = constants.e
 
     # reference temperature
     Tref_K = temp_ref + 273.15
@@ -2576,8 +2577,8 @@ def sapm(effective_irradiance, temp_cell, module):
     temp_ref = 25
     irrad_ref = 1000
 
-    q = 1.60218e-19  # Elementary charge in units of coulombs
-    kb = 1.38066e-23  # Boltzmann's constant in units of J/K
+    q = constants.e  # Elementary charge in units of coulombs
+    kb = constants.k  # Boltzmann's constant in units of J/K
 
     # avoid problem with integer input
     Ee = np.array(effective_irradiance, dtype='float64') / irrad_ref


### PR DESCRIPTION
 - [x] Closes #483 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

In review of #1573 @markcampanelli pointed out that the precisely calculated solutions to the single diode equation should use the latest values of physical constants (Boltzmann and elementary charge). In 2019, the various committees agreed that the [published values](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.330-2019.pdf) of these two constants were _exact_, without uncertainty. (I link to the U.S. agency NIST, other agencies also published the same values).

With this agreement I see no reason for pvlib to use approximate values anywhere. Scipy 1.4.0 published the agree exact values in `scipy.constants`. Advancing to scipy 1.4.0 does not require pvlib to also advance the numpy version.