### PR TITLE
Update benchmark results links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 <tr>
   <td>Benchmarks</td>
   <td>
-    <a href="https://pvlib-benchmarker.github.io/pvlib-benchmarks/">
+    <a href="https://pvlib.github.io/pvlib-benchmarks/">
     <img src="https://img.shields.io/badge/benchmarks-asv-lightgrey" />
     </a>
   </td>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,7 +80,6 @@ Finally, start a http server to view the test results:
 
 ```
 $ asv preview
-
 ```
 
 
@@ -89,5 +88,5 @@ Nightly benchmarking
 
 The benchmarks are run nightly for new commits to pvlib-python/main.
 
-- Timing results: https://pvlib-benchmarker.github.io/pvlib-benchmarks/
-- Information on the process: https://github.com/pvlib-benchmarker/pvlib-benchmarks
+- Timing results: https://pvlib.github.io/pvlib-benchmarks/
+- Information on the process: https://github.com/pvlib/pvlib-benchmarks


### PR DESCRIPTION
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

We just transferred the repository hosting our benchmark results history from a user-level repo under [pvlib-benchmarker](https://github.com/pvlib-benchmarker) to the pvlib organization (https://github.com/pvlib/pvlib-benchmarks/issues/4).  This PR updates the relevant docs for that location change.