### PR TITLE
Try out jupyterlite-sphinx for running pvlib in the browser

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -54,6 +54,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_gallery.gen_gallery',
     'sphinx_toggleprompt',
+    'jupyterlite_sphinx',
 ]
 
 napoleon_use_rtype = False  # group rtype on same line together with return

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -107,6 +107,7 @@ Contents
    reference/index
    whatsnew
    contributing
+   tryitout
 
 
 Indices and tables

--- a/docs/sphinx/source/tryitout.rst
+++ b/docs/sphinx/source/tryitout.rst
@@ -1,0 +1,46 @@
+
+
+Try it out
+==========
+
+.. replite::
+   :kernel: python
+   :height: 600px
+   :prompt: Try Replite!
+
+   import piplite
+   await piplite.install("pvlib")
+   
+   from pvlib import pvsystem, modelchain, location
+   import pandas as pd
+   import matplotlib.pyplot as plt
+
+   array_kwargs = dict(
+       module_parameters=dict(pdc0=1, gamma_pdc=-0.004),
+       temperature_model_parameters=dict(a=-3.56, b=-0.075, deltaT=3)
+   )
+
+   arrays = [
+       pvsystem.Array(pvsystem.FixedMount(30, 270), name='West-Facing Array',
+                      **array_kwargs),
+       pvsystem.Array(pvsystem.FixedMount(30, 90), name='East-Facing Array',
+                      **array_kwargs),
+   ]
+   loc = location.Location(40, -80)
+   system = pvsystem.PVSystem(arrays=arrays, inverter_parameters=dict(pdc0=3))
+   mc = modelchain.ModelChain(system, loc, aoi_model='physical',
+                              spectral_model='no_loss')
+
+   times = pd.date_range('2019-01-01 06:00', '2019-01-01 18:00', freq='5min',
+                         tz='Etc/GMT+5')
+   weather = loc.get_clearsky(times)
+   mc.run_model(weather)
+
+   fig, ax = plt.subplots()
+   for array, pdc in zip(system.arrays, mc.results.dc):
+       pdc.plot(label=f'{array.name}')
+   mc.results.ac.plot(label='Inverter')
+   plt.ylabel('System Output')
+   plt.legend()
+   plt.show()
+

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ EXTRAS_REQUIRE = {
                  'cftime >= 1.1.1'],
     'doc': ['ipython', 'matplotlib', 'sphinx == 4.5.0',
             'pydata-sphinx-theme == 0.8.1', 'sphinx-gallery',
+            'jupyterlite-sphinx==0.7.2',
             'docutils == 0.15.2', 'pillow', 'netcdf4', 'siphon',
             'sphinx-toggleprompt >= 0.0.5', 'pvfactors'],
     'test': TESTS_REQUIRE


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I've been vaguely aware for some time of projects for running python in the browser.  I had the impression that runtime was painfully slow and there was no possibility of using heavyweight packages like numpy and pandas.  Apparently both of those are no longer the case (depending on what you're willing to call "not painful"), and in fact now it is straightforward to get pvlib running in a browser-based python session.  This PR is a simple example of adding an interactive python console to our sphinx docs.  Note that I don't necessarily mean for this PR to ever be merged; I just wanted to make others aware that this kind of thing is possible...

See here for a pvlib gallery example running in an interactive, in-browser ipython console: https://pvlib-python--1637.org.readthedocs.build/en/1637/tryitout.html