### PR TITLE
Remove unnecessary `nose` test dependency

### DIFF
--- a/ci/requirements-py3.10.yml
+++ b/ci/requirements-py3.10.yml
@@ -8,7 +8,6 @@ dependencies:
     - ephem
     - h5py
     # - netcdf4  # pulls in a different version of numpy with ImportError
-    - nose
     # - numba  # python 3.9 compat in early 2021
     - numpy >= 1.16.0
     - pandas >= 0.25.0

--- a/ci/requirements-py3.7-min.yml
+++ b/ci/requirements-py3.7-min.yml
@@ -3,7 +3,6 @@ channels:
     - defaults
 dependencies:
     - coveralls
-    - nose
     - pip
     - pytest
     - pytest-cov

--- a/ci/requirements-py3.7.yml
+++ b/ci/requirements-py3.7.yml
@@ -8,7 +8,6 @@ dependencies:
     - ephem
     - h5py
     - netcdf4
-    - nose
     - numba
     - numpy >= 1.16.0
     - pandas >= 0.25.0

--- a/ci/requirements-py3.8.yml
+++ b/ci/requirements-py3.8.yml
@@ -8,7 +8,6 @@ dependencies:
     - ephem
     - h5py
     - netcdf4
-    - nose
     - numba
     - numpy >= 1.16.0
     - pandas >= 0.25.0

--- a/ci/requirements-py3.9.yml
+++ b/ci/requirements-py3.9.yml
@@ -8,7 +8,6 @@ dependencies:
     - ephem
     - h5py
     # - netcdf4  # pulls in a different version of numpy with ImportError
-    - nose
     # - numba  # python 3.9 compat in early 2021
     - numpy >= 1.16.0
     - pandas >= 0.25.0

--- a/docs/sphinx/source/user_guide/installation.rst
+++ b/docs/sphinx/source/user_guide/installation.rst
@@ -174,7 +174,7 @@ referred to as *conda environments*, but they're the same for our purposes.
    ``conda create --name pvlibdev python pandas scipy``
 #. **Activate** the new conda environment: ``conda activate pvlibdev``
 #. **Install** additional packages into your development environment:
-   ``conda install jupyter ipython matplotlib pytest nose flake8``
+   ``conda install jupyter ipython matplotlib pytest flake8``
 
 The `conda documentation <https://conda.io/docs/index.html>`_ has more
 information on how to use conda virtual environments. You can also add

--- a/docs/sphinx/source/whatsnew/v0.9.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.5.rst
@@ -5,7 +5,7 @@ v0.9.5 (anticipated March 2023)
 -------------------------------
 
 Starting with this version, new releases are no longer distributed through
-the ``pvlib`` `conda channel<https://anaconda.org/pvlib/pvlib>`_.  We recommend
+the ``pvlib`` `conda channel <https://anaconda.org/pvlib/pvlib>`_.  We recommend
 ``conda`` users install from the ``conda-forge`` channel instead (see
 :ref:`installation`).
 
@@ -36,7 +36,7 @@ Benchmarking
 
 Requirements
 ~~~~~~~~~~~~
-
+* Removed unnecessary ``nose`` test requirement (:pull:`1637`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = ['numpy >= 1.16.0',
                     'h5py',
                     'importlib-metadata; python_version < "3.8"']
 
-TESTS_REQUIRE = ['nose', 'pytest', 'pytest-cov', 'pytest-mock',
+TESTS_REQUIRE = ['pytest', 'pytest-cov', 'pytest-mock',
                  'requests-mock', 'pytest-timeout', 'pytest-rerunfailures',
                  'pytest-remotedata']
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

`nose` was our original test framework.  It was replaced with `pytest` in #204, but kept as a dependency due to being some kind of indirect requirement that I don't really understand (https://github.com/pvlib/pvlib-python/pull/232#discussion_r75128631).  In any case it doesn't seem to be necessary today, so this PR gets rid of it.
