### PR TITLE
Appease a few test warnings

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.7 && matrix.suffix == ''
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.7 && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           verbose: true

--- a/pvlib/tests/test_atmosphere.py
+++ b/pvlib/tests/test_atmosphere.py
@@ -169,7 +169,6 @@ def test_kasten96_lt():
     )
     lt = atmosphere.kasten96_lt(*np.meshgrid(amp, pwat, aod_bb))
     assert np.allclose(lt, lt_expected, 1e-3)
-    return lt
 
 
 def test_angstrom_aod():

--- a/pvlib/tests/test_clearsky.py
+++ b/pvlib/tests/test_clearsky.py
@@ -808,4 +808,3 @@ def test_bird():
         [Eb3, Ebh3, Gh3, Dh3],
         testdata2[['Direct Beam', 'Direct Hz', 'Global Hz', 'Dif Hz']].iloc[11],
         rtol=1e-3)
-    return pd.DataFrame({'Eb': Eb, 'Ebh': Ebh, 'Gh': Gh, 'Dh': Dh}, index=times)

--- a/pvlib/tests/test_solarposition.py
+++ b/pvlib/tests/test_solarposition.py
@@ -191,7 +191,7 @@ def test_sun_rise_set_transit_ephem(expected_rise_set_ephem, golden):
         temperature=11, horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('min').tz_convert('MST')
     assert_frame_equal(expected_rise_set_ephem, result_rounded)
 
@@ -227,7 +227,7 @@ def test_sun_rise_set_transit_ephem(expected_rise_set_ephem, golden):
                                                       horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('min').tz_convert('MST')
     assert_frame_equal(expected, result_rounded)
 
@@ -259,14 +259,14 @@ def test_sun_rise_set_transit_ephem(expected_rise_set_ephem, golden):
         altitude=golden.altitude, pressure=0, temperature=11, horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('min').tz_convert('MST')
     assert_frame_equal(expected, result_rounded)
 
     # test with different timezone
     times = times.tz_convert('UTC')
     expected = expected.tz_convert('UTC')  # resuse result from previous
-    for col, data in expected.iteritems():
+    for col, data in expected.items():
         expected[col] = data.dt.tz_convert('UTC')
     result = solarposition.sun_rise_set_transit_ephem(
         times,
@@ -274,7 +274,7 @@ def test_sun_rise_set_transit_ephem(expected_rise_set_ephem, golden):
         altitude=golden.altitude, pressure=0, temperature=11, horizon='-0:34')
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('min').tz_convert(times.tz)
     assert_frame_equal(expected, result_rounded)
 

--- a/pvlib/tests/test_solarposition.py
+++ b/pvlib/tests/test_solarposition.py
@@ -163,7 +163,7 @@ def test_sun_rise_set_transit_spa(expected_rise_set_spa, golden):
     result_rounded = pd.DataFrame(index=result.index)
     # need to iterate because to_datetime does not accept 2D data
     # the rounding fails on pandas < 0.17
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('1s')
 
     assert_frame_equal(frame, result_rounded)
@@ -176,7 +176,7 @@ def test_sun_rise_set_transit_spa(expected_rise_set_spa, golden):
     # round to nearest minute
     result_rounded = pd.DataFrame(index=result.index)
     # need to iterate because to_datetime does not accept 2D data
-    for col, data in result.iteritems():
+    for col, data in result.items():
         result_rounded[col] = data.dt.round('s').tz_convert('MST')
 
     assert_frame_equal(expected_rise_set_spa, result_rounded)


### PR DESCRIPTION
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR gets rid of a few warnings emitted by our CI test jobs:

- ```PytestReturnNotNoneWarning: Expected None, but pvlib/tests/test_atmosphere.py::test_kasten96_lt returned array([[[...]]]), which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?` ```
- ```test_solarposition.py:166: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.```
- ```Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: codecov/codecov-action@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.```