### PR TITLE
Add `model='gueymard2003'` to `get_relative_airmass`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.5.rst
@@ -16,7 +16,9 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
-
+* Add ``model='gueymard2003'``, the airmass model used for REST and REST2,
+  to :py:func:`~pvlib.atmosphere.get_relative_airmass`. (:pull:`1655`)
+  
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/atmosphere.py
+++ b/pvlib/atmosphere.py
@@ -158,9 +158,11 @@ def get_relative_airmass(zenith, model='kastenyoung1989'):
         * 'gueymard1993' - See reference [4] -
           requires apparent sun zenith
         * 'young1994' - See reference [5] -
-          requries true sun zenith
+          requires true sun zenith
         * 'pickering2002' - See reference [6] -
           requires apparent sun zenith
+        * 'gueymard2003' - See reference [7] -
+          requires true sun zenith
 
     Returns
     -------
@@ -196,7 +198,12 @@ def get_relative_airmass(zenith, model='kastenyoung1989'):
 
     .. [6] Keith A. Pickering. "The Ancient Star Catalog". DIO 12:1, 20,
 
-    .. [7] Matthew J. Reno, Clifford W. Hansen and Joshua S. Stein, "Global
+    .. [7] C. Gueymard, "Direct solar transmittance and irradiance
+       predictions with broadband models. Part I: detailed theoretical
+       performance assessment". Solar Energy, vol 74, pp. 355-379, 2003.
+       :doi:`10.1016/S0038-092X(03)00195-6`
+
+    .. [8] Matthew J. Reno, Clifford W. Hansen and Joshua S. Stein, "Global
        Horizontal Irradiance Clear Sky Models: Implementation and Analysis"
        Sandia Report, (2012).
     '''
@@ -229,6 +236,9 @@ def get_relative_airmass(zenith, model='kastenyoung1989'):
     elif 'gueymard1993' == model:
         am = (1.0 / (np.cos(zenith_rad) +
               0.00176759*(z)*((94.37515 - z) ** - 1.21563)))
+    elif 'gueymard2003' == model:
+        am = (1.0 / (np.cos(zenith_rad) +
+              0.48353*(z**0.095846)/(96.741 - z)**1.754))
     else:
         raise ValueError('%s is not a valid model for relativeairmass', model)
 

--- a/pvlib/tests/test_atmosphere.py
+++ b/pvlib/tests/test_atmosphere.py
@@ -35,7 +35,8 @@ def zeniths():
                           ['kastenyoung1989', [nan, 36.467,  5.586,  1.000]],
                           ['gueymard1993', [nan, 36.431,  5.581,  1.000]],
                           ['young1994', [nan, 30.733,  5.541,  1.000]],
-                          ['pickering2002', [nan, 37.064,  5.581,  1.000]]])
+                          ['pickering2002', [nan, 37.064,  5.581,  1.000]],
+                          ['gueymard2003', [nan, 36.676, 5.590, 1.000]]])
 def test_airmass(model, expected, zeniths):
     out = atmosphere.get_relative_airmass(zeniths, model)
     expected = np.array(expected)


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This is the relative air mass model used in REST and REST2, as well as ASTM G222-21.  