### PR TITLE
Fix read_ecmwf_macc test failure for cftime>=1.6.0

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.5.rst
@@ -25,6 +25,9 @@ Bug fixes
 * Fixed incorrect mapping of requested parameters names when using the ``get_psm3``
   function. Also fixed the random reordering of the dataframe columns.
   (:issue:`1629`, :issue:`1647`, :pull:`1648`)
+* When using ``utc_time_range`` with :py:func:`pvlib.iotools.read_ecmwf_macc`,
+  the time index subset is now selected with ``nearest`` instead of ``before``
+  and ``after`` for consistency with ``cftime>=1.6.0``. (:issue:`1609`, :pull:`1656`)
 
 
 Testing
@@ -56,3 +59,4 @@ Contributors
 * Mark Mikofski (:ghuser:`mikofski`)
 * Anton Driesse (:ghuser:`adriesse`)
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
+* Michael Deceglie (:ghuser:`mdeceglie`)

--- a/pvlib/iotools/ecmwf_macc.py
+++ b/pvlib/iotools/ecmwf_macc.py
@@ -294,9 +294,9 @@ def read_ecmwf_macc(filename, latitude, longitude, utc_time_range=None):
         nctime = ecmwf_macc.data['time']
         if utc_time_range:
             start_idx = netCDF4.date2index(
-                utc_time_range[0], nctime, select='before')
+                utc_time_range[0], nctime, select='nearest')
             end_idx = netCDF4.date2index(
-                utc_time_range[-1], nctime, select='after')
+                utc_time_range[-1], nctime, select='nearest')
             time_slice = slice(start_idx, end_idx + 1)
         else:
             time_slice = slice(0, ecmwf_macc.time_size)


### PR DESCRIPTION
 - [x] Closes #1609
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I think this fix is reasonable.  It should get all tests passing again.  Any decision about removal or deprecation can be decided elsewhere.