### PR TITLE
Infinite sheds haydavies mod

### DIFF
--- a/pvlib/bifacial/infinite_sheds.py
+++ b/pvlib/bifacial/infinite_sheds.py
@@ -507,7 +507,7 @@ def get_irradiance_poa(surface_tilt, surface_azimuth, solar_zenith,
             raise ValueError(f'must supply dni_extra for {model} model')
         # call haydavies function and request components to help adjust dni/dhi
         sky_diffuse_components = haydavies(0, 180, dhi, dni, dni_extra,
-                                           projection_ratio=1,
+                                           solar_zenith, solar_azimuth,
                                            return_components=True)
         dhi = dhi - sky_diffuse_components['circumsolar']
         dni = (ghi - dhi) / cosd(solar_zenith)

--- a/pvlib/bifacial/infinite_sheds.py
+++ b/pvlib/bifacial/infinite_sheds.py
@@ -7,8 +7,7 @@ import pandas as pd
 from pvlib.tools import cosd, sind, tand
 from pvlib.bifacial import utils
 from pvlib.shading import masking_angle
-from pvlib.irradiance import beam_component, aoi, aoi_projection, haydavies
-from collections import OrderedDict
+from pvlib.irradiance import beam_component, aoi, haydavies
 
 def _vf_ground_sky_integ(surface_tilt, surface_azimuth, gcr, height,
                          pitch, max_rows=10, npoints=100):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Description
This PR adds functionality for users to use the `haydavies` sky-diffuse transposition model with the `get_irradiance()` and `get_irradiance_poa()` functions in the `infinite_sheds` engine. The works by calling the `haydavies()` function inside `get_irradiance_poa()`, and using its `return_components` functionality to isolate `circumsolar`. Once isolated, it is removed from `dhi`, and incorporated into `dni`.

I have not completed checkboxes yet, as I believe this PR warrants a larger discussion from the maintainers and community. Mainly - is this method acceptable from a technical perspective, and even if so, is this the _right_ way to implement it (ie - if we think about adding future sky diffuse models, would the implementation be similar and/or would this approach complicate things).

I appreciate feedback and guidence from the community. This is inspired by https://github.com/pvlib/pvlib-python/discussions/1551, and was brought to my attention again with @mikofski's most recent comment from https://github.com/pvlib/pvlib-python/issues/1553. 
<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
