### PR TITLE
Use explicit finite difference instead of scipy.misc.derivative in pvsyst_temperature_coeff

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.9.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.5.rst
@@ -32,6 +32,8 @@ Bug fixes
 * When using ``utc_time_range`` with :py:func:`pvlib.iotools.read_ecmwf_macc`,
   the time index subset is now selected with ``nearest`` instead of ``before``
   and ``after`` for consistency with ``cftime>=1.6.0``. (:issue:`1609`, :pull:`1656`)
+* :py:func:`~pvlib.ivtools.sdm.pvsyst_temperature_coeff` no longer raises
+  a scipy deprecation warning (and is slightly more accurate) (:issue:`1644`, :pull:`1674`)
 
 
 Testing

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -18,6 +18,8 @@ from pvlib.singlediode import bishop88_mpp
 from pvlib.ivtools.utils import rectify_iv_curve, _numdiff
 from pvlib.ivtools.sde import _fit_sandia_cocontent
 
+from pvlib.tools import _first_order_centered_difference
+
 
 CONSTANTS = {'E0': 1000.0, 'T0': 25.0, 'k': constants.k, 'q': constants.e}
 
@@ -1343,11 +1345,6 @@ def pvsyst_temperature_coeff(alpha_sc, gamma_ref, mu_gamma, I_L_ref, I_o_ref,
             I_o_ref, R_sh_ref, R_sh_0, R_s, cells_in_series, R_sh_exp, EgRef,
             temp_ref)
     pmp = maxp(temp_ref, *args)
-
-    # first order centered difference at temp_ref
-    dx = 1e-3
-    x0 = temp_ref
-    dy = maxp(x0+dx, *args) - maxp(x0-dx, *args)
-    gamma_pdc = dy / (2*dx)
+    gamma_pdc = _first_order_centered_difference(maxp, x0=temp_ref, args=args)
 
     return gamma_pdc / pmp

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -11,7 +11,6 @@ import numpy as np
 from scipy import constants
 from scipy import optimize
 from scipy.special import lambertw
-from scipy.misc import derivative
 
 from pvlib.pvsystem import calcparams_pvsyst, singlediode, v_from_i
 from pvlib.singlediode import bishop88_mpp
@@ -1344,5 +1343,11 @@ def pvsyst_temperature_coeff(alpha_sc, gamma_ref, mu_gamma, I_L_ref, I_o_ref,
             I_o_ref, R_sh_ref, R_sh_0, R_s, cells_in_series, R_sh_exp, EgRef,
             temp_ref)
     pmp = maxp(temp_ref, *args)
-    gamma_pdc = derivative(maxp, temp_ref, args=args)
+
+    # first order centered difference at temp_ref
+    dx = 1e-3
+    x0 = temp_ref
+    dy = maxp(x0+dx, *args) - maxp(x0-dx, *args)
+    gamma_pdc = dy / (2*dx)
+
     return gamma_pdc / pmp

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -458,3 +458,14 @@ def _degrees_to_index(degrees, coordinate):
         index = int(np.around(index))
 
     return index
+
+
+EPS = np.finfo('float64').eps  # machine precision NumPy-1.20
+DX = EPS**(1/3)  # optimal differential element
+
+
+def _first_order_centered_difference(f, x0, dx=DX, args=()):
+    # simple replacement for scipy.misc.derivative, which is scheduled for
+    # removal in scipy 1.12.0
+    df = f(x0+dx, *args) - f(x0-dx, *args)
+    return df / 2 / dx


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1644
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

`pvsyst_temperature_coeff` uses the default step size of 1 in its call to `scipy.misc.derivative`.  I haven't checked the reference to see if that value is intentional, but if not, it seems a little large to me.  I've reduced the step size to the rather arbitrary value of 1e-3 here, which changes the answer very slightly:

```python
In [49]: kwargs = dict(alpha_sc=0.0054, gamma_ref=1.058, mu_gamma=0.0053585, I_L_ref=7.6626, I_o_ref=2.1003e-09, R_sh_ref=236.57, R_sh_0=886.22, R_s=0.25483, cells_in_series=36)

In [50]: pvsyst_temperature_coeff(**kwargs)  # this PR
Out[50]: 0.0014326198691227289

In [51]: pvlib.ivtools.sdm.pvsyst_temperature_coeff(**kwargs)  # v0.9.4
Out[51]: 0.0014326221939508096
```