### PR TITLE
Link custom type aliases (numeric, etc) in docstrings to their definitions

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -58,6 +58,15 @@ extensions = [
 
 napoleon_use_rtype = False  # group rtype on same line together with return
 
+napoleon_type_aliases = {
+    # link to the sphinx targets & definitions in contributing.rst
+    'dict-like': ':ref:`dict-like <dict-like>`',
+    'numeric': ':ref:`numeric <numeric>`',
+    'array-like': ':ref:`array-like <array-like>`',
+}
+napoleon_preprocess_types = True
+
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -238,9 +238,9 @@ allows for multiple input types to work for many parameters. pvlib uses
 the following generic descriptors as short-hand to indicate which
 specific types may be used:
 
-* dict-like : dict, OrderedDict, pd.Series
-* numeric : scalar, np.array, pd.Series. Typically int or float dtype.
-* array-like : np.array, pd.Series. Typically int or float dtype.
+* _`dict-like` : dict, OrderedDict, pd.Series
+* _`numeric` : scalar, np.array, pd.Series. Typically int or float dtype.
+* _`array-like` : np.array, pd.Series. Typically int or float dtype.
 
 Parameters that specify a specific type require that specific input type.
 


### PR DESCRIPTION
 - [x] Closes #1229
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Enabling this feature required setting `napoleon_preprocess_types = True` which messes up the rendering for docstrings that are technically malformed (`pvlib.irradiance.perez` is an example).  Leaving this as a draft until I've surveyed the docs build to assess the damage.