### PR TITLE
version of scipy upgraded to 1.5.0 in asv

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -117,7 +117,7 @@
             "build": "",
             "numpy": "1.16.5",
             "pandas": "0.25.0",
-            "scipy": "1.4.0",
+            "scipy": "1.5.0",
             // Note: these don't have a minimum in setup.py
             "h5py": "3.1.0",
             "ephem": "3.7.6.0",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ INSTALL_REQUIRES = ['numpy >= 1.16.0',
                     'pandas >= 0.25.0',
                     'pytz',
                     'requests',
-                    'scipy >= 1.4.0',
+                    'scipy >= 1.5.0',
                     'h5py',
                     'importlib-metadata; python_version < "3.8"']
 


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

While running the benchmark I found that minimum scipy version in asv.conf.json was throwing error on incrementing It to 1.5.0 from 1.4.0 runs it. On further Investigation for 1.4.0 requires numpy>=1.17.3 which was greater than minimum.
<img width="587" alt="image" src="https://user-images.githubusercontent.com/72099449/226934530-c8a20e7d-6204-4c19-b5d2-c50b6aa0cc62.png">
but for 1.5.0 numpy requirement is lesser than minimum required
<img width="372" alt="image" src="https://user-images.githubusercontent.com/72099449/226935063-7377cbc6-fd6f-4cc3-a295-785394a9373c.png" >

The error is thrown when I tested it using environment built by asv 