### PR TITLE
Deprecate `pvsystem.singlediode` parameter `ivcurve_pnts`

### DIFF
--- a/docs/examples/iv-modeling/plot_singlediode.py
+++ b/docs/examples/iv-modeling/plot_singlediode.py
@@ -32,6 +32,7 @@ Examples of modeling IV curves using a single-diode circuit equivalent model.
 # :py:meth:`pvlib.pvsystem.singlediode` is then used to generate the IV curves.
 
 from pvlib import pvsystem
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -88,26 +89,27 @@ IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
 )
 
 # plug the parameters into the SDE and solve for IV curves:
-curve_info = pvsystem.singlediode(
-    photocurrent=IL,
-    saturation_current=I0,
-    resistance_series=Rs,
-    resistance_shunt=Rsh,
-    nNsVth=nNsVth,
-    ivcurve_pnts=100,
-    method='lambertw'
-)
+SDE_params = {
+    'photocurrent': IL,
+    'saturation_current': I0,
+    'resistance_series': Rs,
+    'resistance_shunt': Rsh,
+    'nNsVth': nNsVth
+}
+curve_info = pvsystem.singlediode(method='lambertw', **SDE_params)
+v = pd.DataFrame(np.linspace(0., curve_info['v_oc'], 100))
+i = pd.DataFrame(pvsystem.i_from_v(voltage=v, method='lambertw', **SDE_params))
 
 # plot the calculated curves:
 plt.figure()
-for i, case in conditions.iterrows():
+for idx, case in conditions.iterrows():
     label = (
         "$G_{eff}$ " + f"{case['Geff']} $W/m^2$\n"
         "$T_{cell}$ " + f"{case['Tcell']} $\\degree C$"
     )
-    plt.plot(curve_info['v'][i], curve_info['i'][i], label=label)
-    v_mp = curve_info['v_mp'][i]
-    i_mp = curve_info['i_mp'][i]
+    plt.plot(v[idx], i[idx], label=label)
+    v_mp = curve_info['v_mp'][idx]
+    i_mp = curve_info['i_mp'][idx]
     # mark the MPP
     plt.plot([v_mp], [i_mp], ls='', marker='o', c='k')
 

--- a/docs/examples/iv-modeling/plot_singlediode.py
+++ b/docs/examples/iv-modeling/plot_singlediode.py
@@ -29,7 +29,7 @@ Examples of modeling IV curves using a single-diode circuit equivalent model.
 # -----------------------
 # This example uses :py:meth:`pvlib.pvsystem.calcparams_desoto` to calculate
 # the 5 electrical parameters needed to solve the single-diode equation.
-# :py:meth:`pvlib.pvsystem.singlediode` is then used to generate the IV curves.
+# :py:meth:`pvlib.pvsystem.singlediode` and :py:meth:`pvlib.pvsystem.i_from_v` are used to generate the IV curves.
 
 from pvlib import pvsystem
 import numpy as np

--- a/docs/examples/iv-modeling/plot_singlediode.py
+++ b/docs/examples/iv-modeling/plot_singlediode.py
@@ -29,7 +29,8 @@ Examples of modeling IV curves using a single-diode circuit equivalent model.
 # -----------------------
 # This example uses :py:meth:`pvlib.pvsystem.calcparams_desoto` to calculate
 # the 5 electrical parameters needed to solve the single-diode equation.
-# :py:meth:`pvlib.pvsystem.singlediode` and :py:meth:`pvlib.pvsystem.i_from_v` are used to generate the IV curves.
+# :py:meth:`pvlib.pvsystem.singlediode` and :py:meth:`pvlib.pvsystem.i_from_v`
+# are used to generate the IV curves.
 
 from pvlib import pvsystem
 import numpy as np

--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -17,6 +17,9 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
+* The ``ivcurve_pnts`` parameter of :py:func:`pvlib.pvsystem.singlediode` is
+  deprecated. Use :py:func:`pvlib.pvsystem.v_from_i` and
+  :py:func:`pvlib.pvsystem.i_from_v` instead. (:issue:`1626`, :pull:`1743`)
 
 
 Enhancements

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2784,7 +2784,7 @@ def singlediode(photocurrent, saturation_current, resistance_series,
             * v_mp - voltage at maximum power point in volts.
             * p_mp - power at maximum power point in watts.
             * i_x - current, in amperes, at ``v = 0.5*v_oc``.
-            * i_xx - current, in amperes, at ``V = 0.5*(v_oc+v_mp)``.
+            * i_xx - current, in amperes, at ``v = 0.5*(v_oc+v_mp)``.
 
         A dict is returned when the input parameters are scalars or
         ``ivcurve_pnts > 0``. If ``ivcurve_pnts > 0``, the output dictionary

--- a/pvlib/tests/ivtools/test_sde.py
+++ b/pvlib/tests/ivtools/test_sde.py
@@ -12,32 +12,32 @@ def get_test_iv_params():
 
 def test_fit_sandia_simple(get_test_iv_params, get_bad_iv_curves):
     test_params = get_test_iv_params
-    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
-        testcurve = pvsystem.singlediode(photocurrent=test_params['IL'],
-                                         saturation_current=test_params['I0'],
-                                         resistance_shunt=test_params['Rsh'],
-                                         resistance_series=test_params['Rs'],
-                                         nNsVth=test_params['nNsVth'],
-                                         ivcurve_pnts=300)
-    expected = tuple(test_params[k] for k in ['IL', 'I0', 'Rs', 'Rsh',
-                     'nNsVth'])
-    result = sde.fit_sandia_simple(voltage=testcurve['v'],
-                                   current=testcurve['i'])
+    test_params = dict(photocurrent=test_params['IL'],
+                       saturation_current=test_params['I0'],
+                       resistance_series=test_params['Rs'],
+                       resistance_shunt=test_params['Rsh'],
+                       nNsVth=test_params['nNsVth'])
+    testcurve = pvsystem.singlediode(**test_params)
+    v = np.linspace(0., testcurve['v_oc'], 300)
+    i = pvsystem.i_from_v(voltage=v, **test_params)
+    expected = tuple(test_params.values())
+
+    result = sde.fit_sandia_simple(voltage=v, current=i)
     assert np.allclose(result, expected, rtol=5e-5)
-    result = sde.fit_sandia_simple(voltage=testcurve['v'],
-                                   current=testcurve['i'],
+
+    result = sde.fit_sandia_simple(voltage=v, current=i,
                                    v_oc=testcurve['v_oc'],
                                    i_sc=testcurve['i_sc'])
     assert np.allclose(result, expected, rtol=5e-5)
-    result = sde.fit_sandia_simple(voltage=testcurve['v'],
-                                   current=testcurve['i'],
+
+    result = sde.fit_sandia_simple(voltage=v, current=i,
                                    v_oc=testcurve['v_oc'],
                                    i_sc=testcurve['i_sc'],
                                    v_mp_i_mp=(testcurve['v_mp'],
-                                   testcurve['i_mp']))
+                                              testcurve['i_mp']))
     assert np.allclose(result, expected, rtol=5e-5)
-    result = sde.fit_sandia_simple(voltage=testcurve['v'],
-                                   current=testcurve['i'], vlim=0.1)
+
+    result = sde.fit_sandia_simple(voltage=v, current=i, vlim=0.1)
     assert np.allclose(result, expected, rtol=5e-5)
 
 

--- a/pvlib/tests/ivtools/test_sde.py
+++ b/pvlib/tests/ivtools/test_sde.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from pvlib import pvsystem
 from pvlib.ivtools import sde
+from pvlib._deprecation import pvlibDeprecationWarning
 
 
 @pytest.fixture
@@ -11,12 +12,13 @@ def get_test_iv_params():
 
 def test_fit_sandia_simple(get_test_iv_params, get_bad_iv_curves):
     test_params = get_test_iv_params
-    testcurve = pvsystem.singlediode(photocurrent=test_params['IL'],
-                                     saturation_current=test_params['I0'],
-                                     resistance_shunt=test_params['Rsh'],
-                                     resistance_series=test_params['Rs'],
-                                     nNsVth=test_params['nNsVth'],
-                                     ivcurve_pnts=300)
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        testcurve = pvsystem.singlediode(photocurrent=test_params['IL'],
+                                         saturation_current=test_params['I0'],
+                                         resistance_shunt=test_params['Rsh'],
+                                         resistance_series=test_params['Rs'],
+                                         nNsVth=test_params['nNsVth'],
+                                         ivcurve_pnts=300)
     expected = tuple(test_params[k] for k in ['IL', 'I0', 'Rs', 'Rsh',
                      'nNsVth'])
     result = sde.fit_sandia_simple(voltage=testcurve['v'],

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 
 from pvlib.ivtools import sdm
 from pvlib import pvsystem
+from pvlib._deprecation import pvlibDeprecationWarning
 
 from pvlib.tests.conftest import requires_pysam, requires_statsmodels
 
@@ -102,7 +103,9 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     tc = np.repeat(temp_cell, len(effective_irradiance))
     iph, io, rs, rsh, nnsvth = pvsystem.calcparams_desoto(
         ee, tc, alpha_sc=specs['alpha_sc'], **params)
-    sim_ivcurves = pvsystem.singlediode(iph, io, rs, rsh, nnsvth, 300)
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        sim_ivcurves = pvsystem.singlediode(iph, io, rs, rsh, nnsvth,
+                                            ivcurve_pnts=300)
     sim_ivcurves['ee'] = ee
     sim_ivcurves['tc'] = tc
 

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -101,13 +101,15 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     temp_cell = np.array([15., 25., 35., 45.])
     ee = np.tile(effective_irradiance, len(temp_cell))
     tc = np.repeat(temp_cell, len(effective_irradiance))
-    iph, io, rs, rsh, nnsvth = pvsystem.calcparams_desoto(
+    IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
         ee, tc, alpha_sc=specs['alpha_sc'], **params)
-    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
-        sim_ivcurves = pvsystem.singlediode(iph, io, rs, rsh, nnsvth,
-                                            ivcurve_pnts=300)
-    sim_ivcurves['ee'] = ee
-    sim_ivcurves['tc'] = tc
+    ivcurve_params = dict(photocurrent=IL, saturation_current=I0,
+                          resistance_series=Rs, resistance_shunt=Rsh,
+                          nNsVth=nNsVth)
+    sim_ivcurves = pvsystem.singlediode(**ivcurve_params).to_dict('series')
+    v = np.linspace(0., sim_ivcurves['v_oc'], 300)
+    i = pvsystem.i_from_v(voltage=v, **ivcurve_params)
+    sim_ivcurves.update(v=v.T, i=i.T, ee=ee, tc=tc)
 
     result = sdm.fit_desoto_sandia(sim_ivcurves, specs)
     modeled = pd.Series(index=params.keys(), data=np.nan)

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1358,8 +1358,9 @@ def test_singlediode_floats():
 
 
 def test_singlediode_floats_ivcurve():
-    out = pvsystem.singlediode(7., 6e-7, .1, 20., .5, ivcurve_pnts=3,
-                               method='lambertw')
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        out = pvsystem.singlediode(7., 6e-7, .1, 20., .5, ivcurve_pnts=3,
+                                   method='lambertw')
     expected = {'i_xx': 4.264060478,
                 'i_mp': 6.136267360,
                 'v_oc': 8.106300147,
@@ -1391,8 +1392,9 @@ def test_singlediode_series_ivcurve(cec_module_params):
                                   EgRef=1.121,
                                   dEgdT=-0.0002677)
 
-    out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3,
-                               method='lambertw')
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3,
+                                   method='lambertw')
 
     expected = OrderedDict([('i_sc', array([0., 3.01079860, 6.00726296])),
                             ('v_oc', array([0., 9.96959733, 10.29603253])),
@@ -1411,7 +1413,8 @@ def test_singlediode_series_ivcurve(cec_module_params):
     for k, v in out.items():
         assert_allclose(v, expected[k], atol=1e-2)
 
-    out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3)
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        out = pvsystem.singlediode(IL, I0, Rs, Rsh, nNsVth, ivcurve_pnts=3)
 
     expected['i_mp'] = pvsystem.i_from_v(out['v_mp'], IL, I0, Rs, Rsh, nNsVth,
                                          method='lambertw')
@@ -1428,7 +1431,7 @@ def test_singlediode_series_ivcurve(cec_module_params):
 
 @pytest.mark.parametrize('method', ['lambertw', 'brentq', 'newton'])
 def test_singlediode_ivcurvepnts_deprecation_warning(method):
-    with pytest.warns(pvlibDeprecationWarning):
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
         pvsystem.singlediode(7., 6e-7, .1, 20., .5, ivcurve_pnts=3,
                              method=method)
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1429,6 +1429,7 @@ def test_singlediode_series_ivcurve(cec_module_params):
         assert_allclose(v, expected[k], atol=1e-6)
 
 
+@fail_on_pvlib_version('0.11')
 @pytest.mark.parametrize('method', ['lambertw', 'brentq', 'newton'])
 def test_singlediode_ivcurvepnts_deprecation_warning(method):
     with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1426,6 +1426,13 @@ def test_singlediode_series_ivcurve(cec_module_params):
         assert_allclose(v, expected[k], atol=1e-6)
 
 
+@pytest.mark.parametrize('method', ['lambertw', 'brentq', 'newton'])
+def test_singlediode_ivcurvepnts_deprecation_warning(method):
+    with pytest.warns(pvlibDeprecationWarning):
+        pvsystem.singlediode(7., 6e-7, .1, 20., .5, ivcurve_pnts=3,
+                             method=method)
+
+
 def test_scale_voltage_current_power():
     data = pd.DataFrame(
         np.array([[2, 1.5, 10, 8, 12, 0.5, 1.5]]),

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -8,6 +8,7 @@ import scipy
 from pvlib import pvsystem
 from pvlib.singlediode import (bishop88_mpp, estimate_voc, VOLTAGE_BUILTIN,
                                bishop88, bishop88_i_from_v, bishop88_v_from_i)
+from pvlib._deprecation import pvlibDeprecationWarning
 import pytest
 from .conftest import DATA_DIR
 
@@ -176,7 +177,10 @@ def test_ivcurve_pnts_precision(method, precise_iv_curves):
     x, pc = precise_iv_curves
     pc_i, pc_v = np.stack(pc['Currents']), np.stack(pc['Voltages'])
     ivcurve_pnts = len(pc['Currents'][0])
-    outs = pvsystem.singlediode(method=method, ivcurve_pnts=ivcurve_pnts, **x)
+
+    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
+        outs = pvsystem.singlediode(method=method, ivcurve_pnts=ivcurve_pnts,
+                                    **x)
 
     assert np.allclose(pc_i, outs['i'], atol=1e-10, rtol=0)
     assert np.allclose(pc_v, outs['v'], atol=1e-10, rtol=0)

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -377,6 +377,9 @@ def _golden_sect_DataFrame(params, lower, upper, func, atol=1e-8):
     df['max'] = 0.5 * (df['V1'] + df['V2'])
     func_result = func(df, 'max')
     x = np.where(np.isnan(func_result), np.nan, df['max'])
+    if np.isscalar(df['max']):
+        # np.where always returns an ndarray, converting scalars to 0d-arrays
+        x = x.item()
 
     return func_result, x
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Partially addresses #1626 (last three checkboxes), [comment one](https://github.com/pvlib/pvlib-python/issues/1626#issuecomment-1363345991), and [comment two](https://github.com/pvlib/pvlib-python/issues/1626#issuecomment-1363385583).
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

The `ivcurve_pnts` parameter of `pvsystem.singlediode` is deprecated in favor of using `pvsystem.i_from_v` and `v_from_i` to get additional points on an IV curve. The test cases and `docs/examples/iv-modeling/plot_singlediode.py` are updated. Also, a bug in `tools._golden_sect_DataFrame` where scalars were converted into 0d-arrays is fixed.

`pvsystem.singlediode` returns a `dict` or a `pd.DataFrame`. A `dict` is returned only when all inputs are scalars or `ivcurve_pnts > 0`.
