### PR TITLE
Docstring cleanup for `pvlib.ivtools`

### DIFF
--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -64,7 +64,8 @@ def fit_sandia_simple(voltage, current, v_oc=None, i_sc=None, v_mp_i_mp=None,
 
     Raises
     ------
-    RuntimeError if parameter extraction is not successful.
+    RuntimeError
+        if parameter extraction is not successful.
 
     Notes
     -----
@@ -289,8 +290,10 @@ def _fit_sandia_cocontent(voltage, current, nsvth):
 
     Raises
     ------
-    ValueError if ``voltage`` and ``current`` are different lengths.
-    ValueError if ``len(voltage)`` < 6
+    ValueError
+        if ``voltage`` and ``current`` are different lengths.
+    ValueError
+        if ``len(voltage)`` < 6
 
     Notes
     -----

--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -124,8 +124,8 @@ def fit_sandia_simple(voltage, current, v_oc=None, i_sc=None, v_mp_i_mp=None,
     .. math::
 
         \log(\beta_{0} - \beta_{1} V - I)
-        &\approx \log(\frac{I_{0}}{1 + G_{p} R_{s}} + \frac{V}{nN_sV_{th}}
-        + \frac{I R_{s}}{nN_sV_{th}}) \\
+        &\approx \log(\frac{I_{0}}{1 + G_{p} R_{s}}) + \frac{V}{nN_sV_{th}}
+        + \frac{I R_{s}}{nN_sV_{th}} \\
         &= \beta_{2} + \beta_{3} V + \beta_{4} I
 
     6. Calculate values for ``IL, I0, Rs, Rsh,`` and ``nNsVth`` from the

--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -140,7 +140,8 @@ def fit_sandia_simple(voltage, current, v_oc=None, i_sc=None, v_mp_i_mp=None,
        0 86758 909 4
     .. [2] C. B. Jones, C. W. Hansen, "Single Diode Parameter Extraction from
        In-Field Photovoltaic I-V Curves on a Single Board Computer", 46th IEEE
-       Photovoltaic Specialist Conference, Chicago, IL, 2019
+       Photovoltaic Specialist Conference, Chicago, IL, 2019.
+       :doi:`10.1109/PVSC40753.2019.8981330`
     """
 
     # If not provided, extract v_oc, i_sc, v_mp and i_mp from the IV curve data

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -76,9 +76,10 @@ def fit_cec_sam(celltype, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc,
 
     Raises
     ------
-        ImportError if NREL-PySAM is not installed.
-
-        RuntimeError if parameter extraction is not successful.
+    ImportError
+        if NREL-PySAM is not installed.
+    RuntimeError
+        if parameter extraction is not successful.
 
     Notes
     -----

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -95,7 +95,7 @@ def fit_cec_sam(celltype, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc,
     ----------
     .. [1] A. Dobos, "An Improved Coefficient Calculator for the California
        Energy Commission 6 Parameter Photovoltaic Module Model", Journal of
-       Solar Energy Engineering, vol 134, 2012.
+       Solar Energy Engineering, vol 134, 2012. :doi:`10.1115/1.4005759`
     """
 
     try:
@@ -205,7 +205,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
     ----------
     .. [1] W. De Soto et al., "Improvement and validation of a model for
        photovoltaic array performance", Solar Energy, vol 80, pp. 78-88,
-       2006.
+       2006. :doi:`10.1016/j.solener.2005.06.010`
     """
 
     # Constants
@@ -406,6 +406,7 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     .. [1] K. Sauer, T. Roessler, C. W. Hansen, Modeling the Irradiance and
        Temperature Dependence of Photovoltaic Modules in PVsyst, IEEE Journal
        of Photovoltaics v5(1), January 2015.
+       :doi:`10.1109/JPHOTOV.2014.2364133`
     .. [2] A. Mermoud, PV Modules modeling, Presentation at the 2nd PV
        Performance Modeling Workshop, Santa Clara, CA, May 2013
     .. [3] A. Mermoud, T. Lejeuene, Performance Assessment of a Simulation
@@ -413,11 +414,13 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
        Photovoltaic Solar Energy Conference, Valencia, Spain, Sept. 2010
     .. [4] C. Hansen, Estimating Parameters for the PVsyst Version 6
        Photovoltaic Module Performance Model, Sandia National Laboratories
-       Report SAND2015-8598
+       Report SAND2015-8598. :doi:`10.2172/1223058`
     .. [5] C. Hansen, Parameter Estimation for Single Diode Models of
-       Photovoltaic Modules, Sandia National Laboratories Report SAND2015-2065
+       Photovoltaic Modules, Sandia National Laboratories Report SAND2015-2065.
+       :doi:`10.2172/1177157`
     .. [6] C. Hansen, Estimation of Parameters for Single Diode Models using
         Measured IV Curves, Proc. of the 39th IEEE PVSC, June 2013.
+        :doi:`10.1109/PVSC.2013.6744135`
     .. [7] PVLib MATLAB https://github.com/sandialabs/MATLAB_PV_LIB
     """
 
@@ -575,11 +578,13 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
     ----------
     .. [1] W. De Soto et al., "Improvement and validation of a model for
        photovoltaic array performance", Solar Energy, vol 80, pp. 78-88,
-       2006.
+       2006. :doi:`10.1016/j.solener.2005.06.010`
     .. [2] C. Hansen, Parameter Estimation for Single Diode Models of
-       Photovoltaic Modules, Sandia National Laboratories Report SAND2015-2065
+       Photovoltaic Modules, Sandia National Laboratories Report SAND2015-2065.
+       :doi:`10.2172/1177157`
     .. [3] C. Hansen, Estimation of Parameters for Single Diode Models using
         Measured IV Curves, Proc. of the 39th IEEE PVSC, June 2013.
+        :doi:`10.1109/PVSC.2013.6744135`
     .. [4] PVLib MATLAB https://github.com/sandialabs/MATLAB_PV_LIB
     """
 

--- a/pvlib/ivtools/utils.py
+++ b/pvlib/ivtools/utils.py
@@ -150,12 +150,12 @@ def rectify_iv_curve(voltage, current, decimals=None):
     ``rectify_iv_curve`` ensures that the IV curve lies in the first quadrant
     of the (voltage, current) plane. The returned IV curve:
 
-      * increases in voltage
-      * contains no negative current or voltage values
-      * contains no NaNs
-      * contains no points with duplicate voltage values. Where voltage
-        values are repeated, a single data point is substituted with current
-        equal to the average of current at duplicated voltages.
+    * increases in voltage
+    * contains no negative current or voltage values
+    * contains no NaNs
+    * contains no points with duplicate voltage values. Where voltage
+      values are repeated, a single data point is substituted with current
+      equal to the average of current at duplicated voltages.
     """
 
     df = pd.DataFrame(data=np.vstack((voltage, current)).T, columns=['v', 'i'])


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR improves the docstrings for the functions in `pvlib.ivtools`:
- add DOI links
- fix broken sphinx rendering of `Raises` sections and a bulleted list
- fixes a misplaced parenthesis in the math of `sde.fit_sandia_simple`