### PR TITLE
Set map_variables=True in pvgis_tmy functions

### DIFF
--- a/docs/sphinx/source/user_guide/introtutorial.rst
+++ b/docs/sphinx/source/user_guide/introtutorial.rst
@@ -57,8 +57,7 @@ includes irradiation, temperature and wind speed.
     tmys = []
     for location in coordinates:
         latitude, longitude, name, altitude, timezone = location
-        weather = pvlib.iotools.get_pvgis_tmy(latitude, longitude,
-                                              map_variables=True)[0]
+        weather = pvlib.iotools.get_pvgis_tmy(latitude, longitude)[0]
         weather.index.name = "utc_time"
         tmys.append(weather)
 

--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -17,7 +17,9 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-
+* :func:`~pvlib.iotools.get_pvgis_tmy` and :func:`~pvlib.iotools.read_pvgis_tmy`
+  now rename columns to standard pvlib names by default (``map_variables=True``)
+  (:pull:`1772`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -45,3 +47,4 @@ Requirements
 Contributors
 ~~~~~~~~~~~~
 * Taos Transue (:ghuser:`reepoi`)
+* Adam R. Jensen (:ghuser:`AdamRJensen`)

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -392,7 +392,7 @@ def read_pvgis_hourly(filename, pvgis_format=None, map_variables=True):
 
 def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
                   userhorizon=None, startyear=None, endyear=None, url=URL,
-                  map_variables=None, timeout=30):
+                  map_variables=True, timeout=30):
     """
     Get TMY data from PVGIS.
 
@@ -420,7 +420,7 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         last year to calculate TMY, must be at least 10 years from first year
     url : str, default: :const:`pvlib.iotools.pvgis.URL`
         base url of PVGIS API, append ``tmy`` to get TMY endpoint
-    map_variables: bool
+    map_variables: bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable const:`VARIABLE_MAP`.
     timeout : int, default 30
@@ -508,14 +508,6 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         # the response is HTTP/1.1 400 BAD REQUEST which is handled earlier
         pass
 
-    if map_variables is None:
-        warnings.warn(
-            'PVGIS variable names will be renamed to pvlib conventions by '
-            'default starting in pvlib 0.10.0. Specify map_variables=True '
-            'to enable that behavior now, or specify map_variables=False '
-            'to hide this warning.', pvlibDeprecationWarning
-        )
-        map_variables = False
     if map_variables:
         data = data.rename(columns=VARIABLE_MAP)
 
@@ -573,7 +565,7 @@ def _parse_pvgis_tmy_basic(src):
     return data, None, None, None
 
 
-def read_pvgis_tmy(filename, pvgis_format=None, map_variables=None):
+def read_pvgis_tmy(filename, pvgis_format=None, map_variables=True):
     """
     Read a file downloaded from PVGIS.
 
@@ -589,7 +581,7 @@ def read_pvgis_tmy(filename, pvgis_format=None, map_variables=None):
         ``outputformat='basic'``, please set ``pvgis_format`` to ``'basic'``.
         If ``filename`` is a buffer, then ``pvgis_format`` is required and must
         be in ``['csv', 'epw', 'json', 'basic']``.
-    map_variables: bool
+    map_variables: bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -671,14 +663,6 @@ def read_pvgis_tmy(filename, pvgis_format=None, map_variables=None):
             "'csv', or 'basic'").format(outputformat)
         raise ValueError(err_msg)
 
-    if map_variables is None:
-        warnings.warn(
-            'PVGIS variable names will be renamed to pvlib conventions by '
-            'default starting in pvlib 0.10.0. Specify map_variables=True '
-            'to enable that behavior now, or specify map_variables=False '
-            'to hide this warning.', pvlibDeprecationWarning
-        )
-        map_variables = False
     if map_variables:
         data = data.rename(columns=VARIABLE_MAP)
 

--- a/pvlib/tests/iotools/test_pvgis.py
+++ b/pvlib/tests/iotools/test_pvgis.py
@@ -365,17 +365,6 @@ def pvgis_tmy_mapped_columns():
             'wind_speed', 'wind_direction', 'pressure']
 
 
-@fail_on_pvlib_version('0.10')
-@pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-def test_pvgis_tmy_variable_map_deprecating_warning_0_10():
-    with pytest.warns(pvlibDeprecationWarning, match='names will be renamed'):
-        _ = get_pvgis_tmy(45, 8)
-    with pytest.warns(pvlibDeprecationWarning, match='names will be renamed'):
-        fn = DATA_DIR / 'tmy_45.000_8.000_2005_2016.epw'
-        _ = read_pvgis_tmy(fn)
-
-
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_pvgis_tmy(expected, month_year_expected, inputs_expected,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests updated
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Change `map_variables` to default to `True` instead of `None` and remove the warning in ``get_pvgis_tmy`` and ``read_pvgis_tmy``. See discussion here: https://github.com/pvlib/pvlib-python/issues/1245#issuecomment-890119287

Note, the ``map_variables`` parameter was introduced in #1268.