### PR TITLE
Add variable mapping to SRML iotools functions

### DIFF
--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -24,7 +24,7 @@ VARIABLE_MAP = {
 }
 
 
-def read_srml(filename):
+def read_srml(filename, map_variables=True):
     """
     Read University of Oregon SRML 1min .tsv file into pandas dataframe.  The
     SRML is described in [1]_.
@@ -33,13 +33,14 @@ def read_srml(filename):
     ----------
     filename: str
         filepath or url to read for the tsv file.
+    map_variables: bool, default: True
+        When true, renames columns of the DataFrame to pvlib variable names
+        where applicable. See variable :const:`VARIABLE_MAP`.
 
     Returns
     -------
     data: Dataframe
-        A dataframe with datetime index and all of the variables listed
-        in the `VARIABLE_MAP` dict inside of the map_columns function,
-        along with their associated quality control flags.
+        A dataframe with datetime index
 
     Notes
     -----
@@ -64,7 +65,8 @@ def read_srml(filename):
     # Drop day of year and time columns
     data = data[data.columns[2:]]
 
-    data = data.rename(columns=map_columns)
+    if map_variables:
+        data = data.rename(columns=map_columns)
 
     # Quality flag columns are all labeled 0 in the original data. They
     # appear immediately after their associated variable and are suffixed
@@ -166,7 +168,8 @@ def format_index(df):
     return df
 
 
-def read_srml_month_from_solardat(station, year, month, filetype='PO'):
+def read_srml_month_from_solardat(station, year, month, filetype='PO',
+                                  map_variables=True):
     """Request a month of SRML data from solardat and read it into
     a Dataframe.  The SRML is described in [1]_.
 
@@ -180,6 +183,9 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO'):
         Month to request data for.
     filetype: string
         SRML file type to gather. See notes for explanation.
+    map_variables: bool, default: True
+        When true, renames columns of the DataFrame to pvlib variable names
+        where applicable. See variable :const:`VARIABLE_MAP`.
 
     Returns
     -------
@@ -214,5 +220,5 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO'):
         year=year % 100,
         month=month)
     url = "http://solardat.uoregon.edu/download/Archive/"
-    data = read_srml(url + file_name)
+    data = read_srml(url + file_name, map_variables=map_variables)
     return data

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -15,7 +15,7 @@ VARIABLE_MAP = {
     '100': 'ghi',
     '201': 'dni',
     '300': 'dhi',
-    '920': 'wind_dir',
+    '920': 'wind_direction',
     '921': 'wind_speed',
     '930': 'temp_air',
     '931': 'temp_dew',

--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -28,6 +28,16 @@ def test_read_srml_columns_exist():
     assert '7008_flag' in data.columns
 
 
+def test_read_srml_map_variables_false():
+    data = srml.read_srml(srml_testfile, map_variables=False)
+    assert '1000' in data.columns
+    assert '1000_flag' in data.columns
+    assert '2010' in data.columns
+    assert '2010_flag' in data.columns
+    assert '7008' in data.columns
+    assert '7008_flag' in data.columns
+
+
 def test_read_srml_nans_exist():
     data = srml.read_srml(srml_testfile)
     assert isnan(data['dni_0'][1119])


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

This PR adds the `map_variables` keyword to the `pvlib.iotools.get_srml` and `pvlib.iotools.read_srml` functions. These functions already were mapping the variables, but this PR gives the option of setting `map_variables=False`.

The main driver for this PR was to make the functions follow the standard pattern and to change the mapping of wind direction to `wind_direction` where it was previously mapped to `wind_dir`.
