### PR TITLE
Update 3.11 requirements files

### DIFF
--- a/ci/requirements-py3.11.yml
+++ b/ci/requirements-py3.11.yml
@@ -8,7 +8,7 @@ dependencies:
     - ephem
     - h5py
     - netcdf4
-    # - numba  # https://github.com/numba/numba/issues/8304
+    - numba
     - numpy >= 1.16.0
     - pandas >= 0.25.0
     - pip
@@ -25,5 +25,5 @@ dependencies:
     - scipy >= 1.2.0
     - statsmodels
     - pip:
-        # - nrel-pysam>=2.0
+        - nrel-pysam>=2.0
         - pvfactors==1.5.2

--- a/ci/requirements-py3.11.yml
+++ b/ci/requirements-py3.11.yml
@@ -22,7 +22,7 @@ dependencies:
     - python=3.11
     - pytz
     - requests
-    - scipy >= 1.2.0
+    - scipy >= 1.4.0
     - statsmodels
     - pip:
         - nrel-pysam>=2.0


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

When we added python 3.11 to the CI test matrix in #1582, we left out two optional dependencies (numba and pysam) due to them not being easily installable on 3.11 at that time.  They can both be installed now, so this PR brings those dependencies into the 3.11 test environment. 

This PR also fixes an oversight in setting the minimum scipy version.