### PR TITLE
Fix typo in documentation pvlib.location.Location.get_sun_rise_set_transit

### DIFF
--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -331,8 +331,9 @@ class Location:
         method : str, default 'pyephem'
             'pyephem', 'spa', or 'geometric'
 
-        kwargs are passed to the relevant functions. See
-        solarposition.sun_rise_set_transit_<method> for details.
+        kwargs :
+            Passed to the relevant functions. See
+            solarposition.sun_rise_set_transit_<method> for details.
 
         Returns
         -------


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fix typo in [pvlib.location.Location.get_sun_rise_set_transit](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.location.Location.get_sun_rise_set_transit.html)
Fixed [docs.](https://pvlib-python--1776.org.readthedocs.build/en/1776/reference/generated/pvlib.location.Location.get_sun_rise_set_transit.html?highlight=get_sun_rise#pvlib.location.Location.get_sun_rise_set_transit)
