### PR TITLE
Solve alleged twine warnings on pypi publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,10 +32,16 @@ jobs:
     - name: Build packages
       run: python -m build
 
+    - name: Check metadata verification
+      run: python -m twine check dist/*
+
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        # do not run twine check by default
+        # to avoid duplicated output
+        verify-metadata: false
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,15 +34,12 @@ jobs:
       run: python -m build
 
     - name: Check metadata verification
-      run: python -m twine check dist/*
+      run: python -m twine check --strict dist/*
 
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        # do not run twine check by default
-        # to avoid duplicated output
-        verify-metadata: false
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
+        python -m pip install twine
 
     - name: Build packages
       run: python -m build

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Documentation: http://pvlib-python.readthedocs.io
 
 Source code: https://github.com/pvlib/pvlib-python
 """
-LONG_DESCRIPTION_CONTENT_TYPE = "text/plain"
+LONG_DESCRIPTION_CONTENT_TYPE = "text/x-rst"
 
 DISTNAME = 'pvlib'
 LICENSE = 'BSD 3-Clause'

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ Documentation: http://pvlib-python.readthedocs.io
 
 Source code: https://github.com/pvlib/pvlib-python
 """
+LONG_DESCRIPTION_CONTENT_TYPE = "text/plain"
 
 DISTNAME = 'pvlib'
 LICENSE = 'BSD 3-Clause'
@@ -120,6 +121,7 @@ setup(name=DISTNAME,
       ext_modules=extensions,
       description=DESCRIPTION,
       long_description=LONG_DESCRIPTION,
+      long_description_content_type=LONG_DESCRIPTION_CONTENT_TYPE,
       author=AUTHOR,
       maintainer_email=MAINTAINER_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I'm pretty sure the following warnings are being raised in the publish action, since [metadata verification](https://github.com/pypa/gh-action-pypi-publish#disabling-metadata-verification) is [not disabled](https://github.com/pvlib/pvlib-python/blob/763dd0a7d0bc0f195315717bdf2a6d8b4c7169fc/.github/workflows/publish.yml#LL35C1-L41C47) in the PyPI publishing action. ~Can't compare against last publication as [the logs were deleted](https://github.com/pvlib/pvlib-python/actions/runs/4455700233/jobs/7825668762).
(I was playing with the sdist and installation procedures, in case you were wondering).~ See comments below.

```
(venv) PS C:\...\pvlib-python> py -m twine check dist/*
Checking dist\pvlib-0.9.6.dev25+g763dd0a.d20230618-py3-none-any.whl:
PASSED with warnings WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist\pvlib-0.9.6.dev25+g763dd0a.d20230618.tar.gz:
PASSED with warnings WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
```

This solves it. It currently does not have any impact but just in case.