### PR TITLE
Add mismatch.py and function to combine curves

### DIFF
--- a/pvlib/ivtools/mismatch.py
+++ b/pvlib/ivtools/mismatch.py
@@ -1,0 +1,76 @@
+import pvlib
+import numpy as np
+
+
+def prepare_curves(params, num_pts):
+    # params is an n x 5 array where each row corresponds to one of
+    # the n curves' five defining parameters (photocurrent, saturation
+    # current, series resistance, shunt resistance, nNsVth)
+    # num_pts is the number of points you want calculated for each curve
+    # (this will also be the number of points in the aggregate curve)
+
+    # in case params is a list containing scalars, add a dimension
+    if len(np.shape(params)) == 1:
+        params = params[np.newaxis,:]
+
+    # get range of currents from 0 to max_isc
+    max_isc = np.max(pvlib.singlediode.bishop88_i_from_v(0.0, *params.T))
+    currents = np.linspace(0, max_isc, num=num_pts, endpoint=True)
+
+    # prepare inputs for bishop88
+    bishop_inputs = np.array([[currents[idx]]*len(params) for idx in
+                    range(num_pts)])
+    # each row of bishop_inputs contains n copies of a single current
+    # value, where n is the number of curves being added together
+    # there is a row for each current value
+
+    # get voltages for each curve
+    # transpose result so each row contains voltages for a single curve
+    voltages = pvlib.singlediode.bishop88_v_from_i(bishop_inputs, *params.T).T
+
+    return currents, voltages
+
+
+def combine_curves(currents, voltages, breakdown_voltage=-0.5):
+    # currents is a 1D array that contains a range from 0 to max_isc
+    # voltages is a 2D array where each row corresponds to the
+    # associated voltages of a single curve (should be n by
+    # len(currents), where n is the number of curves we're summing over)
+    # breakdown_voltage is the asymptote we use left of the y-axis
+
+    currents = np.asarray(currents)
+    voltages = np.asarray(voltages)
+    assert currents.ndim == 1
+    assert voltages.ndim == 2
+
+    # any voltages in array that are smaller than breakdown_voltage are
+    # clipped to be breakdown_voltage
+    clipped_voltages = np.clip(voltages, a_min=breakdown_voltage, a_max=None)
+
+    # for each current, add the associated voltages of all the curves
+    # in our setup, this means summing each column of the voltage array
+    combined_voltages = np.sum(clipped_voltages, axis=0)
+
+    # combined_voltages should now have same shape as currents
+    assert np.shape(combined_voltages) == np.shape(currents)
+
+    # find max power point (in the dataset)
+    powers = currents*combined_voltages
+    mpp_idx = np.argmax(powers)
+    vmp = combined_voltages[mpp_idx]
+    imp = currents[mpp_idx]
+    pmp = powers[mpp_idx]
+
+    # get isc
+    # np.interp requires second argument is increasing
+    assert np.all(np.diff(combined_voltages) < 0)
+    # FIXME not sure if I can guarantee that combined_voltages is
+    # decreasing for all inputs
+    isc = np.interp(0., np.flip(combined_voltages), np.flip(currents))
+
+    # get voc
+    voc = combined_voltages[0]
+
+    return {'i_sc': isc, 'v_oc': voc, 'i_mp': imp, 'v_mp': vmp, 'p_mp': pmp,
+            'i': currents, 'v': combined_voltages}
+


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Adds a function combine_curves that combines curves (in series) and a function that prepares inputs for combine_curves. This is part of the work to move some of the functionality of PVMismatch over to pvlib.