### PR TITLE
Prevent `v_oc` to be negative in `_lambertw`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -75,3 +75,4 @@ Contributors
 * Echedey Luis (:ghuser:`echedey-ls`)
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Cédric Leroy (:ghuser:`cedricleroy`)
+* Jean-Baptiste Pasquier (:ghuser:`pasquierjb`)

--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -49,6 +49,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+* Prevent `v_oc` to be negative in `_lambertw` (:pull:`1782`)
+
 
 Testing
 ~~~~~~~
@@ -71,3 +73,4 @@ Contributors
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
 * Echedey Luis (:ghuser:`echedey-ls`)
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Cédric Leroy (:ghuser:`cedricleroy`)

--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -49,7 +49,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-* Prevent `v_oc` to be negative in `_lambertw` (:pull:`1782`)
+* Prevent small negative values of `v_oc` in :py:func:`pvlib.singlediode._lambertw`
+  which result from accumulated roundoff error. (:issue:`1780`, :issue:`1673`, :pull:`1782`)
 
 
 Testing

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -794,6 +794,13 @@ def _lambertw(photocurrent, saturation_current, resistance_series,
     # Compute open circuit voltage
     v_oc = _lambertw_v_from_i(0., **params)
 
+    # Set elements <0 or close to 0 in v_oc to 0
+    if isinstance(v_oc, np.ndarray):
+        v_oc[(v_oc < 0) | ((v_oc > 0) & (v_oc < 1e-12))] = 0.
+    elif isinstance(v_oc, (float, int)):
+        if v_oc < 0 or 0 < v_oc < 1e-12:
+            v_oc = 0.
+
     # Find the voltage, v_mp, where the power is maximized.
     # Start the golden section search at v_oc * 1.14
     p_mp, v_mp = _golden_sect_DataFrame(params, 0., v_oc * 1.14, _pwr_optfcn)

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -794,11 +794,11 @@ def _lambertw(photocurrent, saturation_current, resistance_series,
     # Compute open circuit voltage
     v_oc = _lambertw_v_from_i(0., **params)
 
-    # Set elements <0 or close to 0 in v_oc to 0
+    # Set small elements <0 in v_oc to 0
     if isinstance(v_oc, np.ndarray):
-        v_oc[(v_oc < 0) | ((v_oc > 0) & (v_oc < 1e-12))] = 0.
+        v_oc[(v_oc < 0) & (v_oc > -1e-12)] = 0.
     elif isinstance(v_oc, (float, int)):
-        if v_oc < 0 or 0 < v_oc < 1e-12:
+        if v_oc < 0 and v_oc > -1e-12:
             v_oc = 0.
 
     # Find the voltage, v_mp, where the power is maximized.

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -168,6 +168,21 @@ def test_singlediode_precision(method, precise_iv_curves):
     assert np.allclose(pc['i_xx'], outs['i_xx'], atol=1e-6, rtol=0)
 
 
+def test_singlediode_lambert_negative_voc():
+
+    x1 = np.array([0., 1.480501e-11, 0.178, 8000., 1.797559])
+    outs = pvsystem.singlediode(*x1, method='lambertw')
+    assert outs['v_oc'] == 0
+
+    x2 = np.array([0., 1.456894e-11, 0.178, 8000., 1.797048])
+    outs = pvsystem.singlediode(*x2, method='lambertw')
+    assert outs['v_oc'] == 0
+
+    x  = np.array([x1, x2]).T
+    outs = pvsystem.singlediode(*x, method='lambertw')
+    assert np.array_equal(outs['v_oc'], [0, 0])
+
+
 @pytest.mark.parametrize('method', ['lambertw'])
 def test_ivcurve_pnts_precision(method, precise_iv_curves):
     """

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -170,15 +170,13 @@ def test_singlediode_precision(method, precise_iv_curves):
 
 def test_singlediode_lambert_negative_voc():
 
-    x1 = np.array([0., 1.480501e-11, 0.178, 8000., 1.797559])
-    outs = pvsystem.singlediode(*x1, method='lambertw')
+    # Those values result in a negative v_oc out of `_lambertw_v_from_i`
+    x = np.array([0., 1.480501e-11, 0.178, 8000., 1.797559])
+    outs = pvsystem.singlediode(*x, method='lambertw')
     assert outs['v_oc'] == 0
 
-    x2 = np.array([0., 1.456894e-11, 0.178, 8000., 1.797048])
-    outs = pvsystem.singlediode(*x2, method='lambertw')
-    assert outs['v_oc'] == 0
-
-    x  = np.array([x1, x2]).T
+    # Testing for an array
+    x  = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method='lambertw')
     assert np.array_equal(outs['v_oc'], [0, 0])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1780, closes #1673
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
