### PR TITLE
Clarify PVWatts DC and inverter documentation

### DIFF
--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -335,7 +335,7 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     NREL's PVWatts inverter model.
 
     The PVWatts inverter model [1]_ calculates inverter efficiency :math:`\eta`
-    as a function of input DC power
+    as a function of input DC power :math:`P_{dc}`
 
     .. math::
 
@@ -369,6 +369,10 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
 
     Notes
     -----
+    When sourcing ``pdc`` from pvlib functions
+    (e.g. :py:func:`pvlib.pvsystem.pvwatts_dc`) their DC power output is in W,
+    and ``pdc0`` should have the same unit (W).
+
     Note that ``pdc0`` is also used as a symbol in
     :py:func:`pvlib.pvsystem.pvwatts_dc`. ``pdc0`` in this function refers to
     the DC power input limit of the inverter. ``pdc0`` in
@@ -393,6 +397,7 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     pdc_neq_0 = ~np.equal(pdc, 0)
 
     # eta < 0 if zeta < 0.006. power_ac is forced to be >= 0 below. GH 541
+    # differs from Eq. 10 of [1], where parentheses were omitted by mistake
     eta = eta_inv_nom / eta_inv_ref * (
         -0.0162 * zeta - np.divide(0.0059, zeta, out=eta, where=pdc_neq_0)
         + 0.9858)  # noQA: W503

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -397,7 +397,7 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     pdc_neq_0 = ~np.equal(pdc, 0)
 
     # eta < 0 if zeta < 0.006. power_ac is forced to be >= 0 below. GH 541
-    # differs from Eq. 10 of [1], where parentheses were omitted by mistake
+    # In some published versions of [1] the parentheses are missing
     eta = eta_inv_nom / eta_inv_ref * (
         -0.0162 * zeta - np.divide(0.0059, zeta, out=eta, where=pdc_neq_0)
         + 0.9858)  # noQA: W503

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2809,9 +2809,9 @@ def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
 
         P_{dc} = \frac{G_{poa eff}}{1000} P_{dc0} ( 1 + \gamma_{pdc} (T_{cell} - T_{ref}))
 
-    Note that the pdc0 is also used as a symbol in
-    :py:func:`pvlib.inverter.pvwatts`. pdc0 in this function refers to the DC
-    power of the modules at reference conditions. pdc0 in
+    Note that ``pdc0`` is also used as a symbol in
+    :py:func:`pvlib.inverter.pvwatts`. ``pdc0`` in this function refers to the DC
+    power of the modules at reference conditions. ``pdc0`` in
     :py:func:`pvlib.inverter.pvwatts` refers to the DC power input limit of
     the inverter.
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2836,7 +2836,7 @@ def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
     Returns
     -------
     pdc: numeric
-        DC power.
+        DC power. [W]
 
     References
     ----------


### PR DESCRIPTION
 - ~~[ ] Closes #xxxx~~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - ~~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Email exchange with a user pointed out a possible ambiguity with `pvsystem.pvwatts_dc` and `inverter.pvwatts` - neither function provides a unit for the output DC power, or for the input DC power for the inverter.
