### PR TITLE
Python Flake8 linter workflow to replace stickler-ci

### DIFF
--- a/.github/workflows/flake8-pr-annotation-matcher.json
+++ b/.github/workflows/flake8-pr-annotation-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "flake8-linter-error",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+([EWCNF]\\d+\\s+.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '.files[].path')"
+        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '.files[].path' | xargs)"
              >> ${{ github.env }}
       - name: Run Flake8 linter
         run: flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,6 +1,5 @@
 name: Python Flake8 Linter
 on:
-  push:
   pull_request:
 jobs:
   build:
@@ -17,7 +16,11 @@ jobs:
       - name: Setup Flake8 output matcher for PR annotations
         run: echo '::add-matcher::.github/workflows/flake8-pr-annotation-matcher.json'
       - name: Run Flake8 linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: flake8
+               --filename $(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '[.files[].path] | @csv')
                --exclude pvlib/version.py
                --ignore E201,E241,E226,W503,W504
                --max-line-length 79

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,7 +2,7 @@ name: Python Flake8 Linter
 on:
   pull_request:
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -23,7 +23,7 @@ jobs:
              >> ${{ github.env }}
       - name: Run Flake8 linter
         run: flake8
-               --filename ${{ env.CHANGED_FILENAMES }}
+               ${{ env.CHANGED_FILENAMES }}
                --exclude pvlib/version.py
                --ignore E201,E241,E226,W503,W504
                --max-line-length 79

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,24 @@
+name: Python Flake8 Linter
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Install Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Flake8 linter
+        run: pip install flake8
+      - name: Setup Flake8 output matcher for PR annotations
+        run: echo '::add-matcher::.github/workflows/flake8-pr-annotation-matcher.json'
+      - name: Run Flake8 linter
+        run: flake8
+               --exclude pvlib/version.py
+               --ignore E201,E241,E226,W503,W504
+               --max-line-length 79
+               .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,7 +2,7 @@ name: Python Flake8 Linter
 on:
   pull_request:
 jobs:
-  lint:
+  flake8-linter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -27,4 +27,3 @@ jobs:
                --exclude pvlib/version.py
                --ignore E201,E241,E226,W503,W504
                --max-line-length 79
-               .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '[.files[].path] | @csv')"
+        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '.files[].path')"
              >> ${{ github.env }}
       - name: Run Flake8 linter
         run: flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '.files[].path' | xargs)"
+        run: echo CHANGED_FILENAMES="$(gh pr view --repo pvlib/pvlib-python ${{ env.PR_NUMBER }} --json files -q '.files[].path' | xargs)"
              >> ${{ github.env }}
       - name: Run Flake8 linter
         run: flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -15,12 +15,15 @@ jobs:
         run: pip install flake8
       - name: Setup Flake8 output matcher for PR annotations
         run: echo '::add-matcher::.github/workflows/flake8-pr-annotation-matcher.json'
-      - name: Run Flake8 linter
+      - name: Get names of changed files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo CHANGED_FILENAMES="$(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '[.files[].path] | @csv')"
+             >> ${{ github.env }}
+      - name: Run Flake8 linter
         run: flake8
-               --filename $(gh pr view --repo reepoi/pvlib-python ${{ env.PR_NUMBER }} --json files -q '[.files[].path] | @csv')
+               --filename ${{ env.CHANGED_FILENAMES }}
                --exclude pvlib/version.py
                --ignore E201,E241,E226,W503,W504
                --max-line-length 79


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1722 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adds GitHub workflow to replace stickler-ci for Python code linting with flake8. The new workflow annotates the PR changes using the errors outputted by flake8. Here is an example showing what the annotations look like: https://github.com/reepoi/pvlib-python/pull/1/files

The workflow implementation is based on the GitHub action here: https://github.com/pr-annotators/flake8-pr-annotator.