### PR TITLE
Refactor docstring params

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.0.rst
@@ -29,6 +29,11 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
+* The return values of :py:func:`pvlib.pvsystem.calcparams_desoto`,
+  :py:func:`pvlib.pvsystem.calcparams_cec`, and
+  :py:func:`pvlib.pvsystem.calcparams_pvsyst` are all numeric types and have
+  the same Python type as the `effective_irradiance` and `temp_cell` parameters. (:issue:`1626`, :pull:`1700`)
+
 * Added `map_variables` parameter to :py:func:`pvlib.iotools.read_srml`
   and :py:func:`pvlib.iotools.read_srml_month_from_solardat` (:pull:`1773`)
 * Allow passing keyword arguments to :py:func:`scipy:scipy.optimize.brentq` and

--- a/pvlib/atmosphere.py
+++ b/pvlib/atmosphere.py
@@ -361,7 +361,7 @@ def bird_hulstrom80_aod_bb(aod380, aod500):
     aod_bb : numeric
         Broadband AOD.  [unitless]
 
-    See also
+    See Also
     --------
     pvlib.atmosphere.kasten96_lt
 
@@ -407,7 +407,7 @@ def kasten96_lt(airmass_absolute, precipitable_water, aod_bb):
     lt : numeric
         Linke turbidity. [unitless]
 
-    See also
+    See Also
     --------
     pvlib.atmosphere.bird_hulstrom80_aod_bb
     pvlib.atmosphere.angstrom_aod_at_lambda
@@ -488,7 +488,7 @@ def angstrom_aod_at_lambda(aod0, lambda0, alpha=1.14, lambda1=700.0):
     aod1 : numeric
         AOD at desired wavelength ``lambda1``. [unitless]
 
-    See also
+    See Also
     --------
     pvlib.atmosphere.angstrom_alpha
 
@@ -528,7 +528,7 @@ def angstrom_alpha(aod1, lambda1, aod2, lambda2):
         Angstrom :math:`\alpha` exponent for wavelength in
         ``(lambda1, lambda2)``. [unitless]
 
-    See also
+    See Also
     --------
     pvlib.atmosphere.angstrom_aod_at_lambda
     """

--- a/pvlib/bifacial/infinite_sheds.py
+++ b/pvlib/bifacial/infinite_sheds.py
@@ -284,7 +284,7 @@ def get_irradiance_poa(surface_tilt, surface_azimuth, solar_zenith,
        Photovoltaic Specialists Conference (PVSC), 2019, pp. 1282-1287.
        :doi:`10.1109/PVSC40753.2019.8980572`.
 
-    See also
+    See Also
     --------
     get_irradiance
     """
@@ -518,7 +518,7 @@ def get_irradiance(surface_tilt, surface_azimuth, solar_zenith, solar_azimuth,
        Photovoltaic Specialists Conference (PVSC), 2019, pp. 1282-1287.
        :doi:`10.1109/PVSC40753.2019.8980572`.
 
-    See also
+    See Also
     --------
     get_irradiance_poa
     """

--- a/pvlib/bifacial/pvfactors.py
+++ b/pvlib/bifacial/pvfactors.py
@@ -23,58 +23,58 @@ def pvfactors_timeseries(
 
     Parameters
     ----------
-    solar_azimuth: numeric
+    solar_azimuth : numeric
         Sun's azimuth angles using pvlib's azimuth convention (deg)
-    solar_zenith: numeric
+    solar_zenith : numeric
         Sun's zenith angles (deg)
-    surface_azimuth: numeric
+    surface_azimuth : numeric
         Azimuth angle of the front surface of the PV modules, using pvlib's
         convention (deg)
-    surface_tilt: numeric
+    surface_tilt : numeric
         Tilt angle of the PV modules, going from 0 to 180 (deg)
-    axis_azimuth: float
+    axis_azimuth : float
         Azimuth angle of the rotation axis of the PV modules, using pvlib's
         convention (deg). This is supposed to be fixed for all timestamps.
         When modeling fixed-tilt arrays, set this value to be 90 degrees
         clockwise from ``surface_azimuth``.
-    timestamps: datetime or DatetimeIndex
+    timestamps : datetime or DatetimeIndex
         List of simulation timestamps
-    dni: numeric
+    dni : numeric
         Direct normal irradiance (W/m2)
-    dhi: numeric
+    dhi : numeric
         Diffuse horizontal irradiance (W/m2)
-    gcr: float
+    gcr : float
         Ground coverage ratio of the pv array
-    pvrow_height: float
+    pvrow_height : float
         Height of the pv rows, measured at their center (m)
-    pvrow_width: float
+    pvrow_width : float
         Width of the pv rows in the considered 2D plane (m)
-    albedo: float
+    albedo : float
         Ground albedo
-    n_pvrows: int, default 3
+    n_pvrows : int, default 3
         Number of PV rows to consider in the PV array
-    index_observed_pvrow: int, default 1
+    index_observed_pvrow : int, default 1
         Index of the PV row whose incident irradiance will be returned. Indices
         of PV rows go from 0 to n_pvrows-1.
-    rho_front_pvrow: float, default 0.03
+    rho_front_pvrow : float, default 0.03
         Front surface reflectivity of PV rows
-    rho_back_pvrow: float, default 0.05
+    rho_back_pvrow : float, default 0.05
         Back surface reflectivity of PV rows
-    horizon_band_angle: float, default 15
+    horizon_band_angle : float, default 15
         Elevation angle of the sky dome's diffuse horizon band (deg)
 
     Returns
     -------
-    poa_front: numeric
+    poa_front : numeric
         Calculated incident irradiance on the front surface of the PV modules
         (W/m2)
-    poa_back: numeric
+    poa_back : numeric
         Calculated incident irradiance on the back surface of the PV modules
         (W/m2)
-    poa_front_absorbed: numeric
+    poa_front_absorbed : numeric
         Calculated absorbed irradiance on the front surface of the PV modules
         (W/m2), after AOI losses
-    poa_back_absorbed: numeric
+    poa_back_absorbed : numeric
         Calculated absorbed irradiance on the back surface of the PV modules
         (W/m2), after AOI losses
 

--- a/pvlib/bifacial/utils.py
+++ b/pvlib/bifacial/utils.py
@@ -365,11 +365,11 @@ def vf_row_ground_2d_integ(surface_tilt, gcr, x0=0, x1=1):
         = 0, surface facing horizon = 90. [degree]
     gcr : numeric
         Ratio of the row slant length to the row spacing (pitch). [unitless]
-    x0 : numeric, default 0.
+    x0 : numeric, default 0
         Position on the row's slant length, as a fraction of the slant length.
         x0=0 corresponds to the bottom of the row. x0 should be less than x1.
         [unitless]
-    x1 : numeric, default 1.
+    x1 : numeric, default 1
         Position on the row's slant length, as a fraction of the slant length.
         x1 should be greater than x0. [unitless]
 

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -673,7 +673,7 @@ def detect_clearsky(measured, clearsky, times=None, window_length=10,
         Time series of measured GHI. [W/m2]
     clearsky : array or Series
         Time series of the expected clearsky GHI. [W/m2]
-    times : DatetimeIndex or None, default None.
+    times : DatetimeIndex or None, default None
         Times of measured and clearsky values. If None the index of measured
         will be used.
     window_length : int, default 10

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -61,7 +61,7 @@ def ineichen(apparent_zenith, airmass_absolute, linke_turbidity,
         DataFrame/OrderedDict contains the columns/keys
         ``'dhi', 'dni', 'ghi'``.
 
-    See also
+    See Also
     --------
     lookup_linke_turbidity
     pvlib.location.Location.get_clearsky
@@ -909,7 +909,7 @@ def bird(zenith, airmass_relative, aod380, aod500, precipitable_water,
         DataFrame/OrderedDict contains the columns/keys
         ``'dhi', 'dni', 'ghi', 'direct_horizontal'`` in  [W/m^2].
 
-    See also
+    See Also
     --------
     pvlib.atmosphere.bird_hulstrom80_aod_bb
     pvlib.atmosphere.get_relative_airmass

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -159,7 +159,7 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
 
     longitude : float or int
 
-    filepath : None or string, default None
+    filepath : string, optional
         The path to the ``.h5`` file.
 
     interp_turbidity : bool, default True
@@ -673,7 +673,7 @@ def detect_clearsky(measured, clearsky, times=None, window_length=10,
         Time series of measured GHI. [W/m2]
     clearsky : array or Series
         Time series of the expected clearsky GHI. [W/m2]
-    times : DatetimeIndex or None, default None
+    times : DatetimeIndex, optional
         Times of measured and clearsky values. If None the index of measured
         will be used.
     window_length : int, default 10

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -318,7 +318,7 @@ def martin_ruiz_diffuse(surface_tilt, a_r=0.16, c1=0.4244, c2=None):
 
     Parameters
     ----------
-    surface_tilt: float or array-like, default 0
+    surface_tilt : float or array-like, default 0
         Surface tilt angles in decimal degrees.
         The tilt angle is defined as degrees from horizontal
         (e.g. surface facing up = 0, surface facing horizon = 90)

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -514,7 +514,7 @@ def sapm(aoi, module, upper=None):
         A dict or Series with the SAPM IAM model parameters.
         See the :py:func:`sapm` notes section for more details.
 
-    upper : None or float, default None
+    upper : float, optional
         Upper limit on the results.
 
     Returns

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -354,17 +354,17 @@ def pvwatts(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     ----------
     pdc : numeric
         DC power. Same unit as ``pdc0``.
-    pdc0: numeric
+    pdc0 : numeric
         DC input limit of the inverter.  Same unit as ``pdc``.
-    eta_inv_nom: numeric, default 0.96
+    eta_inv_nom : numeric, default 0.96
         Nominal inverter efficiency. [unitless]
-    eta_inv_ref: numeric, default 0.9637
+    eta_inv_ref : numeric, default 0.9637
         Reference inverter efficiency. PVWatts defines it to be 0.9637
         and is included here for flexibility. [unitless]
 
     Returns
     -------
-    power_ac: numeric
+    power_ac : numeric
         AC power.  Same unit as ``pdc0``.
 
     Notes
@@ -417,17 +417,17 @@ def pvwatts_multi(pdc, pdc0, eta_inv_nom=0.96, eta_inv_ref=0.9637):
     pdc : tuple, list or array of numeric
         DC power on each MPPT input of the inverter. If type is array, must
         be 2d with axis 0 being the MPPT inputs. Same unit as ``pdc0``.
-    pdc0: numeric
+    pdc0 : numeric
         Total DC power limit of the inverter.  Same unit as ``pdc``.
-    eta_inv_nom: numeric, default 0.96
+    eta_inv_nom : numeric, default 0.96
         Nominal inverter efficiency. [unitless]
-    eta_inv_ref: numeric, default 0.9637
+    eta_inv_ref : numeric, default 0.9637
         Reference inverter efficiency. PVWatts defines it to be 0.9637
         and is included here for flexibility. [unitless]
 
     Returns
     -------
-    power_ac: numeric
+    power_ac : numeric
         AC power.  Same unit as ``pdc0``.
 
     See Also

--- a/pvlib/inverter.py
+++ b/pvlib/inverter.py
@@ -119,7 +119,7 @@ def sandia(v_dc, p_dc, inverter):
 
     .. [2] System Advisor Model web page. https://sam.nrel.gov.
 
-    See also
+    See Also
     --------
     pvlib.pvsystem.retrieve_sam
     '''
@@ -182,7 +182,7 @@ def sandia_multi(v_dc, p_dc, inverter):
        Efficiency Of Inverters With Multiple Inputs", 49th IEEE Photovoltaic
        Specialist Conference, Philadelphia, PA, USA. June 2022.
 
-    See also
+    See Also
     --------
     pvlib.inverter.sandia
     '''
@@ -273,7 +273,7 @@ def adr(v_dc, p_dc, inverter, vtol=0.10):
        of Photovoltaic Inverters", 33rd IEEE Photovoltaic Specialist
        Conference (PVSC), June 2008
 
-    See also
+    See Also
     --------
     pvlib.inverter.sandia
     pvlib.pvsystem.retrieve_sam

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -84,7 +84,7 @@ def get_bsrn(station, start, end, username, password,
         username for accessing the BSRN FTP server
     password : str
         password for accessing the BSRN FTP server
-    logical_records : list or tuple, default: ('0100',)
+    logical_records : list or tuple, default ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
     save_path : str or path-like, optional
@@ -221,7 +221,7 @@ def parse_bsrn(fbuf, logical_records=('0100',)):
     ----------
     fbuf : file-like buffer
         Buffer of a BSRN station-to-archive data file
-    logical_records : list or tuple, default: ('0100',)
+    logical_records : list or tuple, default ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
 
@@ -379,7 +379,7 @@ def read_bsrn(filename, logical_records=('0100',)):
     ----------
     filename : str or path-like
         Name or path of a BSRN station-to-archive data file
-    logical_records : list or tuple, default: ('0100',)
+    logical_records : list or tuple, default ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
 

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -74,29 +74,29 @@ def get_bsrn(station, start, end, username, password,
 
     Parameters
     ----------
-    station: str
+    station : str
         3-letter BSRN station abbreviation
-    start: datetime-like
+    start : datetime-like
         First day of the requested period
-    end: datetime-like
+    end : datetime-like
         Last day of the requested period
-    username: str
+    username : str
         username for accessing the BSRN FTP server
-    password: str
+    password : str
         password for accessing the BSRN FTP server
     logical_records: list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
-    save_path: str or path-like, optional
+    save_path : str or path-like, optional
         If specified, a directory path of where to save each monthly file.
 
     Returns
     -------
-    data: DataFrame
+    data : DataFrame
         timeseries data from the BSRN archive, see
         :func:`pvlib.iotools.read_bsrn` for fields. An empty DataFrame is
         returned if no data was found for the time period.
-    metadata: dict
+    metadata : dict
         metadata for the last available monthly file.
 
     Raises
@@ -219,7 +219,7 @@ def parse_bsrn(fbuf, logical_records=('0100',)):
 
     Parameters
     ----------
-    fbuf: file-like buffer
+    fbuf : file-like buffer
         Buffer of a BSRN station-to-archive data file
     logical_records: list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
@@ -227,11 +227,11 @@ def parse_bsrn(fbuf, logical_records=('0100',)):
 
     Returns
     -------
-    data: DataFrame
+    data : DataFrame
         timeseries data from the BSRN archive, see
         :func:`pvlib.iotools.read_bsrn` for fields. An empty DataFrame is
         returned if the specified logical records were not found.
-    metadata: dict
+    metadata : dict
         Dictionary containing metadata (primarily from LR0004).
 
     See Also
@@ -377,7 +377,7 @@ def read_bsrn(filename, logical_records=('0100',)):
 
     Parameters
     ----------
-    filename: str or path-like
+    filename : str or path-like
         Name or path of a BSRN station-to-archive data file
     logical_records: list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
@@ -385,11 +385,11 @@ def read_bsrn(filename, logical_records=('0100',)):
 
     Returns
     -------
-    data: DataFrame
+    data : DataFrame
         A DataFrame with the columns as described below. For a more extensive
         description of the variables, consult [2]_. An empty DataFrame is
         returned if the specified logical records were not found.
-    metadata: dict
+    metadata : dict
         Dictionary containing metadata (primarily from LR0004).
 
     Notes

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -84,7 +84,7 @@ def get_bsrn(station, start, end, username, password,
         username for accessing the BSRN FTP server
     password : str
         password for accessing the BSRN FTP server
-    logical_records: list or tuple, default: ('0100',)
+    logical_records : list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
     save_path : str or path-like, optional
@@ -221,7 +221,7 @@ def parse_bsrn(fbuf, logical_records=('0100',)):
     ----------
     fbuf : file-like buffer
         Buffer of a BSRN station-to-archive data file
-    logical_records: list or tuple, default: ('0100',)
+    logical_records : list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
 
@@ -379,7 +379,7 @@ def read_bsrn(filename, logical_records=('0100',)):
     ----------
     filename : str or path-like
         Name or path of a BSRN station-to-archive data file
-    logical_records: list or tuple, default: ('0100',)
+    logical_records : list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
 

--- a/pvlib/iotools/crn.py
+++ b/pvlib/iotools/crn.py
@@ -68,7 +68,7 @@ def read_crn(filename, map_variables=True):
     ----------
     filename : str, path object, or file-like
         filepath or url to read for the fixed-width file.
-    map_variables : boolean, default: True
+    map_variables : boolean, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/crn.py
+++ b/pvlib/iotools/crn.py
@@ -66,7 +66,7 @@ def read_crn(filename, map_variables=True):
 
     Parameters
     ----------
-    filename: str, path object, or file-like
+    filename : str, path object, or file-like
         filepath or url to read for the fixed-width file.
     map_variables: boolean, default: True
         When true, renames columns of the Dataframe to pvlib variable names
@@ -74,7 +74,7 @@ def read_crn(filename, map_variables=True):
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         A dataframe with DatetimeIndex and all of the variables in the
         file.
 

--- a/pvlib/iotools/crn.py
+++ b/pvlib/iotools/crn.py
@@ -68,7 +68,7 @@ def read_crn(filename, map_variables=True):
     ----------
     filename : str, path object, or file-like
         filepath or url to read for the fixed-width file.
-    map_variables: boolean, default: True
+    map_variables : boolean, default: True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/epw.py
+++ b/pvlib/iotools/epw.py
@@ -25,7 +25,7 @@ def read_epw(filename, coerce_year=None):
     filename : String
         Can be a relative file path, absolute file path, or url.
 
-    coerce_year : None or int, default None
+    coerce_year : int, optional
         If supplied, the year of the data will be set to this value. This can
         be a useful feature because EPW data is composed of data from
         different years.
@@ -247,7 +247,7 @@ def parse_epw(csvdata, coerce_year=None):
     csvdata : file-like buffer
         a file-like buffer containing data in the EPW format
 
-    coerce_year : None or int, default None
+    coerce_year : int, optional
         If supplied, the year of the data will be set to this value. This can
         be a useful feature because EPW data is composed of data from
         different years.

--- a/pvlib/iotools/midc.py
+++ b/pvlib/iotools/midc.py
@@ -108,13 +108,13 @@ def _format_index(data):
 
     Parameters
     ----------
-    data: Dataframe
+    data : Dataframe
         Must contain 'DATE (MM/DD/YYYY)' column, second column must be labeled
         with the timezone and contain times in 'HH:MM' format.
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         Dataframe with DatetimeIndex localized to the provided timezone.
     """
     tz_raw = data.columns[1]
@@ -132,13 +132,13 @@ def _format_index_raw(data):
 
     Parameters
     ----------
-    data: Dataframe
+    data : Dataframe
         Must contain columns 'Year' and 'DOY'. Timezone must be found as the
         label of the third (time) column.
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         The data with a Datetime index localized to the provided timezone.
     """
     tz_raw = data.columns[3]
@@ -158,13 +158,13 @@ def read_midc(filename, variable_map={}, raw_data=False, **kwargs):
 
     Parameters
     ----------
-    filename: string or file-like object
+    filename : string or file-like object
         Filename, url, or file-like object of data to read.
-    variable_map: dictionary
+    variable_map : dictionary
         Dictionary for mapping MIDC field names to pvlib names. Used to rename
         the columns of the resulting DataFrame. Does not map names by default.
         See Notes for an example.
-    raw_data: boolean
+    raw_data : boolean
         Set to true to use format_index_raw to correctly format the date/time
         columns of MIDC raw data files.
     kwargs : dict
@@ -172,7 +172,7 @@ def read_midc(filename, variable_map={}, raw_data=False, **kwargs):
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         A dataframe with DatetimeIndex localized to the provided timezone.
 
     Notes
@@ -213,13 +213,13 @@ def read_midc_raw_data_from_nrel(site, start, end, variable_map={},
 
     Parameters
     ----------
-    site: string
+    site : string
         The MIDC station id.
-    start: datetime
+    start : datetime
         Start date for requested data.
-    end: datetime
+    end : datetime
         End date for requested data.
-    variable_map: dict
+    variable_map : dict
         A dictionary mapping MIDC field names to pvlib names. Used to
         rename columns of the resulting DataFrame. See Notes of
         :py:func:`pvlib.iotools.read_midc` for example.

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -239,9 +239,9 @@ def parse_psm3(fbuf, map_variables=None):
 
     Parameters
     ----------
-    fbuf: file-like object
+    fbuf : file-like object
         File-like object containing data to read.
-    map_variables: bool
+    map_variables : bool
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable VARIABLE_MAP.
 
@@ -384,9 +384,9 @@ def read_psm3(filename, map_variables=None):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         Filename of a file containing data to read.
-    map_variables: bool
+    map_variables : bool
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable VARIABLE_MAP.
 

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -63,13 +63,13 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
         In decimal degrees, between -90 and 90, north is positive (ISO 19115)
     longitude : float
         In decimal degrees, between -180 and 180, east is positive (ISO 19115)
-    start : int or datetime like, default None
+    start : int or datetime like, optional
         First year of the radiation time series. Defaults to first year
         available.
-    end : int or datetime like, default None
+    end : int or datetime like, optional
         Last year of the radiation time series. Defaults to last year
         available.
-    raddatabase : str, default None
+    raddatabase : str, optional
         Name of radiation database. Options depend on location, see [3]_.
     components : bool, default True
         Output solar radiation components (beam, diffuse, and reflected).
@@ -87,14 +87,14 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
            PVGIS website and pvlib<=0.9.5 is offset by 180 degrees.
     usehorizon : bool, default True
         Include effects of horizon
-    userhorizon : list of float, default None
+    userhorizon : list of float, optional
         Optional user specified elevation of horizon in degrees, at equally
         spaced azimuth clockwise from north, only valid if ``usehorizon`` is
         true, if ``usehorizon`` is true but ``userhorizon`` is ``None`` then
         PVGIS will calculate the horizon [4]_
     pvcalculation : bool, default False
         Return estimate of hourly PV production.
-    peakpower : float, default None
+    peakpower : float, optional
         Nominal power of PV system in kW. Required if pvcalculation=True.
     pvtechchoice : {'crystSi', 'CIS', 'CdTe', 'Unknown'}, default 'crystSi'
         PV technology.
@@ -309,7 +309,7 @@ def read_pvgis_hourly(filename, pvgis_format=None, map_variables=True):
     ----------
     filename : str, pathlib.Path, or file-like buffer
         Name, path, or buffer of hourly data file downloaded from PVGIS.
-    pvgis_format : str, default None
+    pvgis_format : str, optional
         Format of PVGIS file or buffer. Equivalent to the ``outputformat``
         parameter in the PVGIS API. If ``filename`` is a file and
         ``pvgis_format`` is ``None`` then the file extension will be used to
@@ -409,14 +409,14 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         documentation [2]_ for more info.
     usehorizon : bool, default True
         include effects of horizon
-    userhorizon : list of float, default None
+    userhorizon : list of float, optional
         optional user specified elevation of horizon in degrees, at equally
         spaced azimuth clockwise from north, only valid if ``usehorizon`` is
         true, if ``usehorizon`` is true but ``userhorizon`` is ``None`` then
         PVGIS will calculate the horizon [3]_
-    startyear : int, default None
+    startyear : int, optional
         first year to calculate TMY
-    endyear : int, default None
+    endyear : int, optional
         last year to calculate TMY, must be at least 10 years from first year
     url : str, default :const:`pvlib.iotools.pvgis.URL`
         base url of PVGIS API, append ``tmy`` to get TMY endpoint
@@ -573,7 +573,7 @@ def read_pvgis_tmy(filename, pvgis_format=None, map_variables=True):
     ----------
     filename : str, pathlib.Path, or file-like buffer
         Name, path, or buffer of file downloaded from PVGIS.
-    pvgis_format : str, default None
+    pvgis_format : str, optional
         Format of PVGIS file or buffer. Equivalent to the ``outputformat``
         parameter in the PVGIS TMY API. If ``filename`` is a file and
         ``pvgis_format`` is ``None`` then the file extension will be used to

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -63,20 +63,20 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
         In decimal degrees, between -90 and 90, north is positive (ISO 19115)
     longitude : float
         In decimal degrees, between -180 and 180, east is positive (ISO 19115)
-    start : int or datetime like, default: None
+    start : int or datetime like, default None
         First year of the radiation time series. Defaults to first year
         available.
-    end : int or datetime like, default: None
+    end : int or datetime like, default None
         Last year of the radiation time series. Defaults to last year
         available.
-    raddatabase : str, default: None
+    raddatabase : str, default None
         Name of radiation database. Options depend on location, see [3]_.
-    components : bool, default: True
+    components : bool, default True
         Output solar radiation components (beam, diffuse, and reflected).
         Otherwise only global irradiance is returned.
-    surface_tilt : float, default: 0
+    surface_tilt : float, default 0
         Tilt angle from horizontal plane. Ignored for two-axis tracking.
-    surface_azimuth : float, default: 180
+    surface_azimuth : float, default 180
         Orientation (azimuth angle) of the (fixed) plane. Counter-clockwise
         from north (north=0, south=180). This is offset 180 degrees from
         the convention used by PVGIS. Ignored for tracking systems.
@@ -85,45 +85,45 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
            The `surface_azimuth` parameter now follows the pvlib convention, which
            is counterclockwise from north. However, the convention used by the
            PVGIS website and pvlib<=0.9.5 is offset by 180 degrees.
-    usehorizon : bool, default: True
+    usehorizon : bool, default True
         Include effects of horizon
-    userhorizon : list of float, default: None
+    userhorizon : list of float, default None
         Optional user specified elevation of horizon in degrees, at equally
         spaced azimuth clockwise from north, only valid if ``usehorizon`` is
         true, if ``usehorizon`` is true but ``userhorizon`` is ``None`` then
         PVGIS will calculate the horizon [4]_
-    pvcalculation : bool, default: False
+    pvcalculation : bool, default False
         Return estimate of hourly PV production.
-    peakpower : float, default: None
+    peakpower : float, default None
         Nominal power of PV system in kW. Required if pvcalculation=True.
-    pvtechchoice : {'crystSi', 'CIS', 'CdTe', 'Unknown'}, default: 'crystSi'
+    pvtechchoice : {'crystSi', 'CIS', 'CdTe', 'Unknown'}, default 'crystSi'
         PV technology.
-    mountingplace : {'free', 'building'}, default: free
+    mountingplace : {'free', 'building'}, default free
         Type of mounting for PV system. Options of 'free' for free-standing
         and 'building' for building-integrated.
-    loss : float, default: 0
+    loss : float, default 0
         Sum of PV system losses in percent. Required if pvcalculation=True
-    trackingtype : {0, 1, 2, 3, 4, 5}, default: 0
+    trackingtype : {0, 1, 2, 3, 4, 5}, default 0
         Type of suntracking. 0=fixed, 1=single horizontal axis aligned
         north-south, 2=two-axis tracking, 3=vertical axis tracking, 4=single
         horizontal axis aligned east-west, 5=single inclined axis aligned
         north-south.
-    optimal_surface_tilt : bool, default: False
+    optimal_surface_tilt : bool, default False
         Calculate the optimum tilt angle. Ignored for two-axis tracking
-    optimalangles : bool, default: False
+    optimalangles : bool, default False
         Calculate the optimum tilt and azimuth angles. Ignored for two-axis
         tracking.
-    outputformat : str, default: 'json'
+    outputformat : str, default 'json'
         Must be in ``['json', 'csv']``. See PVGIS hourly data
         documentation [2]_ for more info.
-    url : str, default: :const:`pvlib.iotools.pvgis.URL`
+    url : str, default :const:`pvlib.iotools.pvgis.URL`
         Base url of PVGIS API. ``seriescalc`` is appended to get hourly data
         endpoint. Note, a specific PVGIS version can be specified, e.g.,
         https://re.jrc.ec.europa.eu/api/v5_2/
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
-    timeout : int, default: 30
+    timeout : int, default 30
         Time in seconds to wait for server response before timeout
 
     Returns
@@ -418,7 +418,7 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         first year to calculate TMY
     endyear : int, default None
         last year to calculate TMY, must be at least 10 years from first year
-    url : str, default: :const:`pvlib.iotools.pvgis.URL`
+    url : str, default :const:`pvlib.iotools.pvgis.URL`
         base url of PVGIS API, append ``tmy`` to get TMY endpoint
     map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
@@ -678,7 +678,7 @@ def get_pvgis_horizon(latitude, longitude, url=URL, **kwargs):
         Latitude in degrees north
     longitude : float
         Longitude in degrees east
-    url : str, default: :const:`pvlib.iotools.pvgis.URL`
+    url : str, default :const:`pvlib.iotools.pvgis.URL`
         Base URL for PVGIS
     kwargs:
         Passed to requests.get

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -63,20 +63,20 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
         In decimal degrees, between -90 and 90, north is positive (ISO 19115)
     longitude : float
         In decimal degrees, between -180 and 180, east is positive (ISO 19115)
-    start: int or datetime like, default: None
+    start : int or datetime like, default: None
         First year of the radiation time series. Defaults to first year
         available.
-    end: int or datetime like, default: None
+    end : int or datetime like, default: None
         Last year of the radiation time series. Defaults to last year
         available.
-    raddatabase: str, default: None
+    raddatabase : str, default: None
         Name of radiation database. Options depend on location, see [3]_.
-    components: bool, default: True
+    components : bool, default: True
         Output solar radiation components (beam, diffuse, and reflected).
         Otherwise only global irradiance is returned.
-    surface_tilt: float, default: 0
+    surface_tilt : float, default: 0
         Tilt angle from horizontal plane. Ignored for two-axis tracking.
-    surface_azimuth: float, default: 180
+    surface_azimuth : float, default: 180
         Orientation (azimuth angle) of the (fixed) plane. Counter-clockwise
         from north (north=0, south=180). This is offset 180 degrees from
         the convention used by PVGIS. Ignored for tracking systems.
@@ -85,45 +85,45 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
            The `surface_azimuth` parameter now follows the pvlib convention, which
            is counterclockwise from north. However, the convention used by the
            PVGIS website and pvlib<=0.9.5 is offset by 180 degrees.
-    usehorizon: bool, default: True
+    usehorizon : bool, default: True
         Include effects of horizon
-    userhorizon: list of float, default: None
+    userhorizon : list of float, default: None
         Optional user specified elevation of horizon in degrees, at equally
         spaced azimuth clockwise from north, only valid if ``usehorizon`` is
         true, if ``usehorizon`` is true but ``userhorizon`` is ``None`` then
         PVGIS will calculate the horizon [4]_
-    pvcalculation: bool, default: False
+    pvcalculation : bool, default: False
         Return estimate of hourly PV production.
-    peakpower: float, default: None
+    peakpower : float, default: None
         Nominal power of PV system in kW. Required if pvcalculation=True.
-    pvtechchoice: {'crystSi', 'CIS', 'CdTe', 'Unknown'}, default: 'crystSi'
+    pvtechchoice : {'crystSi', 'CIS', 'CdTe', 'Unknown'}, default: 'crystSi'
         PV technology.
-    mountingplace: {'free', 'building'}, default: free
+    mountingplace : {'free', 'building'}, default: free
         Type of mounting for PV system. Options of 'free' for free-standing
         and 'building' for building-integrated.
-    loss: float, default: 0
+    loss : float, default: 0
         Sum of PV system losses in percent. Required if pvcalculation=True
-    trackingtype: {0, 1, 2, 3, 4, 5}, default: 0
+    trackingtype : {0, 1, 2, 3, 4, 5}, default: 0
         Type of suntracking. 0=fixed, 1=single horizontal axis aligned
         north-south, 2=two-axis tracking, 3=vertical axis tracking, 4=single
         horizontal axis aligned east-west, 5=single inclined axis aligned
         north-south.
-    optimal_surface_tilt: bool, default: False
+    optimal_surface_tilt : bool, default: False
         Calculate the optimum tilt angle. Ignored for two-axis tracking
-    optimalangles: bool, default: False
+    optimalangles : bool, default: False
         Calculate the optimum tilt and azimuth angles. Ignored for two-axis
         tracking.
-    outputformat: str, default: 'json'
+    outputformat : str, default: 'json'
         Must be in ``['json', 'csv']``. See PVGIS hourly data
         documentation [2]_ for more info.
-    url: str, default: :const:`pvlib.iotools.pvgis.URL`
+    url : str, default: :const:`pvlib.iotools.pvgis.URL`
         Base url of PVGIS API. ``seriescalc`` is appended to get hourly data
         endpoint. Note, a specific PVGIS version can be specified, e.g.,
         https://re.jrc.ec.europa.eu/api/v5_2/
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
-    timeout: int, default: 30
+    timeout : int, default: 30
         Time in seconds to wait for server response before timeout
 
     Returns
@@ -678,7 +678,7 @@ def get_pvgis_horizon(latitude, longitude, url=URL, **kwargs):
         Latitude in degrees north
     longitude : float
         Longitude in degrees east
-    url: str, default: :const:`pvlib.iotools.pvgis.URL`
+    url : str, default: :const:`pvlib.iotools.pvgis.URL`
         Base URL for PVGIS
     kwargs:
         Passed to requests.get

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -59,9 +59,9 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
 
     Parameters
     ----------
-    latitude: float
+    latitude : float
         In decimal degrees, between -90 and 90, north is positive (ISO 19115)
-    longitude: float
+    longitude : float
         In decimal degrees, between -180 and 180, east is positive (ISO 19115)
     start: int or datetime like, default: None
         First year of the radiation time series. Defaults to first year
@@ -315,7 +315,7 @@ def read_pvgis_hourly(filename, pvgis_format=None, map_variables=True):
         ``pvgis_format`` is ``None`` then the file extension will be used to
         determine the PVGIS format to parse. If ``filename`` is a buffer, then
         ``pvgis_format`` is required and must be in ``['csv', 'json']``.
-    map_variables: bool, default True
+    map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -420,7 +420,7 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         last year to calculate TMY, must be at least 10 years from first year
     url : str, default: :const:`pvlib.iotools.pvgis.URL`
         base url of PVGIS API, append ``tmy`` to get TMY endpoint
-    map_variables: bool, default True
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
     timeout : int, default 30
@@ -581,7 +581,7 @@ def read_pvgis_tmy(filename, pvgis_format=None, map_variables=True):
         ``outputformat='basic'``, please set ``pvgis_format`` to ``'basic'``.
         If ``filename`` is a buffer, then ``pvgis_format`` is required and must
         be in ``['csv', 'epw', 'json', 'basic']``.
-    map_variables: bool, default True
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -61,19 +61,19 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
 
     Parameters
     ----------
-    latitude: float
+    latitude : float
         in decimal degrees, between -90 and 90, north is positive (ISO 19115)
     longitude : float
         in decimal degrees, between -180 and 180, east is positive (ISO 19115)
-    start: datetime like
+    start : datetime like
         First day of the requested period
-    end: datetime like
+    end : datetime like
         Last day of the requested period
-    email: str
+    email : str
         Email address linked to a SoDa account
-    identifier: {'mcclear', 'cams_radiation'}
+    identifier : {'mcclear', 'cams_radiation'}
         Specify whether to retrieve CAMS Radiation or McClear parameters
-    altitude: float, optional
+    altitude : float, optional
         Altitude in meters. If None, then the altitude is determined from the
         NASA SRTM database
     time_step: str, {'1min', '15min', '1h', '1d', '1M'}, default: '1h'
@@ -84,7 +84,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     verbose: boolean, default: False
         Verbose mode outputs additional parameters (aerosols). Only available
         for 1 minute and universal time. See [1]_ for parameter description.
-    integrated: boolean, default False
+    integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
     label: {'right', 'left'}, default: None
@@ -100,9 +100,9 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
 
     Returns
     -------
-    data: pandas.DataFrame
+    data : pandas.DataFrame
         Timeseries data, see Notes for columns
-    metadata: dict
+    metadata : dict
         Metadata of the requested time-series
 
     Notes
@@ -235,9 +235,9 @@ def parse_cams(fbuf, integrated=False, label=None, map_variables=True):
 
     Parameters
     ----------
-    fbuf: file-like object
+    fbuf : file-like object
         File-like object containing data to read.
-    integrated: boolean, default False
+    integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
     label: {'right', 'left'}, default: None
@@ -249,9 +249,9 @@ def parse_cams(fbuf, integrated=False, label=None, map_variables=True):
 
     Returns
     -------
-    data: pandas.DataFrame
+    data : pandas.DataFrame
         Timeseries data from CAMS Radiation or McClear
-    metadata: dict
+    metadata : dict
         Metadata available in the file.
 
     See Also
@@ -336,9 +336,9 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         Filename of a file containing data to read.
-    integrated: boolean, default False
+    integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
     label: {'right', 'left}, default: None
@@ -350,10 +350,10 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
 
     Returns
     -------
-    data: pandas.DataFrame
+    data : pandas.DataFrame
         Timeseries data from CAMS Radiation or McClear.
         See :func:`pvlib.iotools.get_cams` for fields.
-    metadata: dict
+    metadata : dict
         Metadata available in the file.
 
     See Also

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -76,24 +76,24 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     altitude : float, optional
         Altitude in meters. If None, then the altitude is determined from the
         NASA SRTM database
-    time_step: str, {'1min', '15min', '1h', '1d', '1M'}, default: '1h'
+    time_step : str, {'1min', '15min', '1h', '1d', '1M'}, default: '1h'
         Time step of the time series, either 1 minute, 15 minute, hourly,
         daily, or monthly.
-    time_ref: str, {'UT', 'TST'}, default: 'UT'
+    time_ref : str, {'UT', 'TST'}, default: 'UT'
         'UT' (universal time) or 'TST' (True Solar Time)
-    verbose: boolean, default: False
+    verbose : boolean, default: False
         Verbose mode outputs additional parameters (aerosols). Only available
         for 1 minute and universal time. See [1]_ for parameter description.
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label: {'right', 'left'}, default: None
+    label : {'right', 'left'}, default: None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
-    server: str, default: :const:`pvlib.iotools.sodapro.URL`
+    server : str, default: :const:`pvlib.iotools.sodapro.URL`
         Base url of the SoDa Pro CAMS Radiation API.
     timeout : int, default: 30
         Time in seconds to wait for server response before timeout
@@ -240,10 +240,10 @@ def parse_cams(fbuf, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label: {'right', 'left'}, default: None
+    label : {'right', 'left'}, default: None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -341,10 +341,10 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label: {'right', 'left}, default: None
+    label : {'right', 'left}, default: None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -87,7 +87,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left'}, default None
+    label : {'right', 'left'}, optional
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
     map_variables : bool, default True
@@ -240,7 +240,7 @@ def parse_cams(fbuf, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left'}, default None
+    label : {'right', 'left'}, optional
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
     map_variables : bool, default True
@@ -341,7 +341,7 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left}, default None
+    label : {'right', 'left}, optional
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
     map_variables : bool, default True

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -76,26 +76,26 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     altitude : float, optional
         Altitude in meters. If None, then the altitude is determined from the
         NASA SRTM database
-    time_step : str, {'1min', '15min', '1h', '1d', '1M'}, default: '1h'
+    time_step : str, {'1min', '15min', '1h', '1d', '1M'}, default '1h'
         Time step of the time series, either 1 minute, 15 minute, hourly,
         daily, or monthly.
-    time_ref : str, {'UT', 'TST'}, default: 'UT'
+    time_ref : str, {'UT', 'TST'}, default 'UT'
         'UT' (universal time) or 'TST' (True Solar Time)
-    verbose : boolean, default: False
+    verbose : boolean, default False
         Verbose mode outputs additional parameters (aerosols). Only available
         for 1 minute and universal time. See [1]_ for parameter description.
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left'}, default: None
+    label : {'right', 'left'}, default None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
-    server : str, default: :const:`pvlib.iotools.sodapro.URL`
+    server : str, default :const:`pvlib.iotools.sodapro.URL`
         Base url of the SoDa Pro CAMS Radiation API.
-    timeout : int, default: 30
+    timeout : int, default 30
         Time in seconds to wait for server response before timeout
 
     Returns
@@ -240,10 +240,10 @@ def parse_cams(fbuf, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left'}, default: None
+    label : {'right', 'left'}, default None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -341,10 +341,10 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
     integrated : boolean, default False
         Whether to return radiation parameters as integrated values (Wh/m^2)
         or as average irradiance values (W/m^2) (pvlib preferred units)
-    label : {'right', 'left}, default: None
+    label : {'right', 'left}, default None
         Which bin edge label to label time-step with. The default is 'left' for
         all time steps except for '1M' which has a default of 'right'.
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/solrad.py
+++ b/pvlib/iotools/solrad.py
@@ -54,12 +54,12 @@ def read_solrad(filename):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         filepath or url to read for the fixed-width file.
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         A dataframe with DatetimeIndex and all of the variables in the
         file.
 

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -31,7 +31,7 @@ def read_srml(filename, map_variables=True):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         filepath or url to read for the tsv file.
     map_variables: bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
@@ -39,7 +39,7 @@ def read_srml(filename, map_variables=True):
 
     Returns
     -------
-    data: Dataframe
+    data : Dataframe
         A dataframe with datetime index
 
     Notes
@@ -97,7 +97,7 @@ def _map_columns(col):
 
     Parameters
     ----------
-    col: str
+    col : str
         Column label to be mapped.
 
     Returns
@@ -125,12 +125,12 @@ def _format_index(df):
 
     Parameters
     ----------
-    df: pd.Dataframe
+    df : pd.Dataframe
         The srml data to reindex.
 
     Returns
     -------
-    df: pd.Dataframe
+    df : pd.Dataframe
         The Dataframe with a DatetimeIndex localized to 'Etc/GMT+8'.
     """
     # Name of the second column indicates the year of the file, but
@@ -175,13 +175,13 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO',
 
     Parameters
     ----------
-    station: str
+    station : str
         The name of the SRML station to request.
-    year: int
+    year : int
         Year to request data for
-    month: int
+    month : int
         Month to request data for.
-    filetype: string
+    filetype : string
         SRML file type to gather. See notes for explanation.
     map_variables: bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
@@ -189,7 +189,7 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO',
 
     Returns
     -------
-    data: pd.DataFrame
+    data : pd.DataFrame
         One month of data from SRML.
 
     Notes

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -33,7 +33,7 @@ def read_srml(filename, map_variables=True):
     ----------
     filename : str
         filepath or url to read for the tsv file.
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -183,7 +183,7 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO',
         Month to request data for.
     filetype : string
         SRML file type to gather. See notes for explanation.
-    map_variables: bool, default: True
+    map_variables : bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -33,7 +33,7 @@ def read_srml(filename, map_variables=True):
     ----------
     filename : str
         filepath or url to read for the tsv file.
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -183,7 +183,7 @@ def read_srml_month_from_solardat(station, year, month, filetype='PO',
         Month to request data for.
     filetype : string
         SRML file type to gather. See notes for explanation.
-    map_variables : bool, default: True
+    map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 

--- a/pvlib/iotools/surfrad.py
+++ b/pvlib/iotools/surfrad.py
@@ -43,9 +43,9 @@ def read_surfrad(filename, map_variables=True):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         Filepath or URL. URL can be either FTP or HTTP.
-    map_variables: bool
+    map_variables : bool
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
 
@@ -53,9 +53,9 @@ def read_surfrad(filename, map_variables=True):
     -------
     Tuple of the form (data, metadata).
 
-    data: Dataframe
+    data : Dataframe
         Dataframe with the fields found below.
-    metadata: dict
+    metadata : dict
         Site metadata included in the file.
 
     Notes
@@ -164,13 +164,13 @@ def _format_index(data):
 
     Parameters
     ----------
-    data: Dataframe
+    data : Dataframe
         Must contain columns 'year', 'jday', 'hour' and
         'minute'.
 
     Return
     ------
-    data: Dataframe
+    data : Dataframe
         Dataframe with a DatetimeIndex localized to UTC.
     """
     year = data.year.apply(str)

--- a/pvlib/iotools/tmy.py
+++ b/pvlib/iotools/tmy.py
@@ -40,11 +40,11 @@ def read_tmy3(filename, coerce_year=None, map_variables=None, recolumn=None,
     ----------
     filename : str
         A relative file path or absolute file path.
-    coerce_year : None or int, default None
+    coerce_year : int, optional
         If supplied, the year of the index will be set to `coerce_year`, except
         for the last index value which will be set to the *next* year so that
         the index increases monotonically.
-    map_variables : bool, default None
+    map_variables : bool, optional
         When True, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
     recolumn : bool (deprecated, use map_variables instead)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -564,7 +564,7 @@ def get_ground_diffuse(surface_tilt, ghi, albedo=.25, surface_type=None):
         the reflection coefficient. Must be >=0 and <=1. Will be
         overridden if surface_type is supplied.
 
-    surface_type: None or string, default None
+    surface_type : None or string, default None
         If not None, overrides albedo. String can be one of 'urban',
         'grass', 'fresh grass', 'snow', 'fresh snow', 'asphalt', 'concrete',
         'aluminum', 'copper', 'fresh steel', 'dirty steel', 'sea'.
@@ -906,7 +906,7 @@ def reindl(surface_tilt, surface_azimuth, dhi, dni, ghi, dni_extra,
     dni : numeric
         direct normal irradiance in W/m^2.
 
-    ghi: numeric
+    ghi : numeric
         Global irradiance in W/m^2.
 
     dni_extra : numeric
@@ -2192,9 +2192,9 @@ def erbs(ghi, zenith, datetime_or_doy, min_cos_zenith=0.065, max_zenith=87):
 
     Parameters
     ----------
-    ghi: numeric
+    ghi : numeric
         Global horizontal irradiance in W/m^2.
-    zenith: numeric
+    zenith : numeric
         True (not refraction-corrected) zenith angles in decimal degrees.
     datetime_or_doy : int, float, array, pd.DatetimeIndex
         Day of year or array of days of year e.g.
@@ -2282,9 +2282,9 @@ def boland(ghi, solar_zenith, datetime_or_doy, a_coeff=8.645, b_coeff=0.613,
 
     Parameters
     ----------
-    ghi: numeric
+    ghi : numeric
         Global horizontal irradiance. [W/m^2]
-    solar_zenith: numeric
+    solar_zenith : numeric
         True (not refraction-corrected) zenith angles in decimal degrees.
     datetime_or_doy : numeric, pandas.DatetimeIndex
         Day of year or array of days of year e.g.
@@ -2377,23 +2377,23 @@ def campbell_norman(zenith, transmittance, pressure=101325.0,
 
     Parameters
     ----------
-    zenith: pd.Series
+    zenith : pd.Series
         True (not refraction-corrected) zenith angles in decimal
         degrees. If Z is a vector it must be of the same size as all
         other vector inputs. Z must be >=0 and <=180.
 
-    transmittance: float
+    transmittance : float
         Atmospheric transmittance between 0 and 1.
 
-    pressure: float, default 101325.0
+    pressure : float, default 101325.0
         Air pressure
 
-    dni_extra: float, default 1367.0
+    dni_extra : float, default 1367.0
         Direct irradiance incident at the top of the atmosphere.
 
     Returns
     -------
-    irradiance: DataFrame
+    irradiance : DataFrame
         Modeled direct normal irradiance, direct horizontal irradiance,
         and global horizontal irradiance in W/m^2
 
@@ -2434,23 +2434,23 @@ def _liujordan(zenith, transmittance, airmass, dni_extra=1367.0):
 
     Parameters
     ----------
-    zenith: pd.Series
+    zenith : pd.Series
         True (not refraction-corrected) zenith angles in decimal
         degrees. If Z is a vector it must be of the same size as all
         other vector inputs. Z must be >=0 and <=180.
 
-    transmittance: float
+    transmittance : float
         Atmospheric transmittance between 0 and 1.
 
-    pressure: float, default 101325.0
+    pressure : float, default 101325.0
         Air pressure
 
-    dni_extra: float, default 1367.0
+    dni_extra : float, default 1367.0
         Direct irradiance incident at the top of the atmosphere.
 
     Returns
     -------
-    irradiance: DataFrame
+    irradiance : DataFrame
         Modeled direct normal irradiance, direct horizontal irradiance,
         and global horizontal irradiance in W/m^2
 
@@ -3138,7 +3138,7 @@ def louche(ghi, solar_zenith, datetime_or_doy, max_zenith=90):
 
     Returns
     -------
-    data: OrderedDict or DataFrame
+    data : OrderedDict or DataFrame
         Contains the following keys/columns:
 
             * ``dni``: the modeled direct normal irradiance in W/m^2.

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -340,13 +340,13 @@ def get_total_irradiance(surface_tilt, surface_azimuth,
         Global horizontal irradiance. [W/m2]
     dhi : numeric
         Diffuse horizontal irradiance. [W/m2]
-    dni_extra : None or numeric, default None
+    dni_extra : numeric, optional
         Extraterrestrial direct normal irradiance. [W/m2]
-    airmass : None or numeric, default None
+    airmass : numeric, optional
         Relative airmass (not adjusted for pressure). [unitless]
     albedo : numeric, default 0.25
         Ground surface albedo. [unitless]
-    surface_type : None or str, default None
+    surface_type : str, optional
         Surface type. See :py:func:`~pvlib.irradiance.get_ground_diffuse` for
         the list of accepted values.
     model : str, default 'isotropic'
@@ -417,9 +417,9 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
         Global horizontal irradiance. [W/m2]
     dhi : numeric
         Diffuse horizontal irradiance. [W/m2]
-    dni_extra : None or numeric, default None
+    dni_extra : numeric, optional
         Extraterrestrial direct normal irradiance. [W/m2]
-    airmass : None or numeric, default None
+    airmass : numeric, optional
         Relative airmass (not adjusted for pressure). [unitless]
     model : str, default 'isotropic'
         Irradiance model. Can be one of ``'isotropic'``, ``'klucher'``,
@@ -564,7 +564,7 @@ def get_ground_diffuse(surface_tilt, ghi, albedo=.25, surface_type=None):
         the reflection coefficient. Must be >=0 and <=1. Will be
         overridden if surface_type is supplied.
 
-    surface_type : None or string, default None
+    surface_type : string, optional
         If not None, overrides albedo. String can be one of 'urban',
         'grass', 'fresh grass', 'snow', 'fresh snow', 'asphalt', 'concrete',
         'aluminum', 'copper', 'fresh steel', 'dirty steel', 'sea'.
@@ -777,17 +777,17 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     dni_extra : numeric
         Extraterrestrial normal irradiance in W/m^2.
 
-    solar_zenith : None or numeric, default None
+    solar_zenith : numeric, optional
         Solar apparent (refraction-corrected) zenith angles in decimal
         degrees. Must supply ``solar_zenith`` and ``solar_azimuth`` or
         supply ``projection_ratio``.
 
-    solar_azimuth : None or numeric, default None
+    solar_azimuth : numeric, optional
         Solar azimuth angles in decimal degrees. Must supply
         ``solar_zenith`` and ``solar_azimuth`` or supply
         ``projection_ratio``.
 
-    projection_ratio : None or numeric, default None
+    projection_ratio : numeric, optional
         Ratio of angle of incidence projection to solar zenith angle
         projection. Must supply ``solar_zenith`` and ``solar_azimuth``
         or supply ``projection_ratio``.
@@ -1541,7 +1541,7 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
         GHI points is 1.5 hours or greater. If use_delta_kt_prime=True,
         input data must be Series.
 
-    temp_dew : None, float, or array-like, default None
+    temp_dew : None, float, or array-like, optional
         Surface dew point temperatures, in degrees C. Values of temp_dew
         may be numeric or NaN. Any single time period point with a
         temp_dew=NaN does not have dew point improvements applied. If
@@ -1790,7 +1790,7 @@ def dirindex(ghi, ghi_clearsky, dni_clearsky, zenith, times, pressure=101325.,
         GHI points is 1.5 hours or greater. If use_delta_kt_prime=True,
         input data must be Series.
 
-    temp_dew : None, float, or array-like, default None
+    temp_dew : None, float, or array-like, optional
         Surface dew point temperatures, in degrees C. Values of temp_dew
         may be numeric or NaN. Any single time period point with a
         temp_dew=NaN does not have dew point improvements applied. If
@@ -1898,7 +1898,7 @@ def gti_dirint(poa_global, aoi, solar_zenith, solar_azimuth, times,
         GHI points is 1.5 hours or greater. If use_delta_kt_prime=True,
         input data must be Series.
 
-    temp_dew : None, float, or array-like, default None
+    temp_dew : None, float, or array-like, optional
         Surface dew point temperatures, in degrees C. Values of temp_dew
         may be numeric or NaN. Any single time period point with a
         temp_dew=NaN does not have dew point improvements applied. If
@@ -3008,7 +3008,7 @@ def dni(ghi, dhi, zenith, clearsky_dni=None, clearsky_tolerance=1.1,
         True (not refraction-corrected) zenith angles in decimal
         degrees. Angles must be >=0 and <=180.
 
-    clearsky_dni : None or Series, default None
+    clearsky_dni : Series, optional
         Clearsky direct normal irradiance.
 
     clearsky_tolerance : float, default 1.1

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2223,7 +2223,7 @@ def erbs(ghi, zenith, datetime_or_doy, min_cos_zenith=0.065, max_zenith=87):
        diffuse radiation fraction for hourly, daily and monthly-average
        global radiation, Solar Energy 28(4), pp 293-302, 1982. Eq. 1
 
-    See also
+    See Also
     --------
     dirint
     disc
@@ -2321,7 +2321,7 @@ def boland(ghi, solar_zenith, datetime_or_doy, a_coeff=8.645, b_coeff=0.613,
        Environmetrics 12(2), pp 103-116, 2001,
        :doi:`10.1002/1099-095X(200103)12:2%3C103::AID-ENV447%3E3.0.CO;2-2`
 
-    See also
+    See Also
     --------
     dirint
     disc

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1086,7 +1086,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         * 'capecanaveral1988'
         * 'albany1988'
 
-    return_components: bool (optional, default=False)
+    return_components : bool (optional, default=False)
         Flag used to decide whether to return the calculated diffuse components
         or not.
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1068,7 +1068,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         inputs. AM must be >=0 (careful using the 1/sec(z) model of AM
         generation)
 
-    model : string (optional, default='allsitescomposite1990')
+    model : string, default 'allsitescomposite1990'
         A string which selects the desired set of Perez coefficients. If
         model is not provided as an input, the default, '1990' will be
         used. All possible model selections are:
@@ -1086,7 +1086,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         * 'capecanaveral1988'
         * 'albany1988'
 
-    return_components : bool (optional, default=False)
+    return_components : bool, default False
         Flag used to decide whether to return the calculated diffuse components
         or not.
 
@@ -2488,7 +2488,7 @@ def _get_perez_coefficients(perezmodel):
     Parameters
     ----------
 
-    perezmodel : string (optional, default='allsitescomposite1990')
+    perezmodel : string, default 'allsitescomposite1990'
 
           a character string which selects the desired set of Perez
           coefficients. If model is not provided as an input, the default,

--- a/pvlib/ivtools/sde.py
+++ b/pvlib/ivtools/sde.py
@@ -25,15 +25,15 @@ def fit_sandia_simple(voltage, current, v_oc=None, i_sc=None, v_mp_i_mp=None,
         1D array of `float` type containing current at each point on the IV
         curve, from ``i_sc`` to 0 inclusive. [A]
 
-    v_oc : float, default None
+    v_oc : float, optional
         Open circuit voltage. If not provided, ``v_oc`` is taken as the
         last point in the ``voltage`` array. [V]
 
-    i_sc : float, default None
+    i_sc : float, optional
         Short circuit current. If not provided, ``i_sc`` is taken as the
         first point in the ``current`` array. [A]
 
-    v_mp_i_mp : tuple of float, default None
+    v_mp_i_mp : tuple of float, optional
         Voltage, current at maximum power point. If not provided, the maximum
         power point is found at the maximum of ``voltage`` \times ``current``.
         [V], [A]

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -166,7 +166,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
         Reference temperature condition [C]
     irrad_ref : float, default 1000
         Reference irradiance condition [W/m2]
-    root_kwargs : dictionary, default None
+    root_kwargs : dictionary, optional
         Dictionary of arguments to pass onto scipy.optimize.root()
 
     Returns

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -1025,7 +1025,7 @@ def _check_converge(prevparams, result, vmp, imp, i):
 
     Returns
     -------
-    convergeparam: dict containing the following for Imp, Vmp and Pmp:
+    convergeparam : dict containing the following for Imp, Vmp and Pmp:
         - maximum percent difference between measured and modeled values
         - minimum percent difference between measured and modeled values
         - maximum absolute percent difference between measured and modeled

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -142,59 +142,59 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
 
     Parameters
     ----------
-    v_mp: float
+    v_mp : float
         Module voltage at the maximum-power point at reference conditions [V].
-    i_mp: float
+    i_mp : float
         Module current at the maximum-power point at reference conditions [A].
-    v_oc: float
+    v_oc : float
         Open-circuit voltage at reference conditions [V].
-    i_sc: float
+    i_sc : float
         Short-circuit current at reference conditions [A].
-    alpha_sc: float
+    alpha_sc : float
         The short-circuit current (i_sc) temperature coefficient of the
         module [A/K].
-    beta_voc: float
+    beta_voc : float
         The open-circuit voltage (v_oc) temperature coefficient of the
         module [V/K].
-    cells_in_series: integer
+    cells_in_series : integer
         Number of cell in the module.
-    EgRef: float, default 1.121 eV - value for silicon
+    EgRef : float, default 1.121 eV - value for silicon
         Energy of bandgap of semi-conductor used [eV]
-    dEgdT: float, default -0.0002677 - value for silicon
+    dEgdT : float, default -0.0002677 - value for silicon
         Variation of bandgap according to temperature [eV/K]
-    temp_ref: float, default 25
+    temp_ref : float, default 25
         Reference temperature condition [C]
-    irrad_ref: float, default 1000
+    irrad_ref : float, default 1000
         Reference irradiance condition [W/m2]
-    root_kwargs: dictionary, default None
+    root_kwargs : dictionary, default None
         Dictionary of arguments to pass onto scipy.optimize.root()
 
     Returns
     -------
     dict with the following elements:
-        I_L_ref: float
+        I_L_ref : float
             Light-generated current at reference conditions [A]
-        I_o_ref: float
+        I_o_ref : float
             Diode saturation current at reference conditions [A]
-        R_s: float
+        R_s : float
             Series resistance [ohm]
-        R_sh_ref: float
+        R_sh_ref : float
             Shunt resistance at reference conditions [ohm].
-        a_ref: float
+        a_ref : float
             Modified ideality factor at reference conditions.
             The product of the usual diode ideality factor (n, unitless),
             number of cells in series (Ns), and cell thermal voltage at
             specified effective irradiance and cell temperature.
-        alpha_sc: float
+        alpha_sc : float
             The short-circuit current (i_sc) temperature coefficient of the
             module [A/K].
-        EgRef: float
+        EgRef : float
             Energy of bandgap of semi-conductor used [eV]
-        dEgdT: float
+        dEgdT : float
             Variation of bandgap according to temperature [eV/K]
-        irrad_ref: float
+        irrad_ref : float
             Reference irradiance condition [W/m2]
-        temp_ref: float
+        temp_ref : float
             Reference temperature condition [C]
 
     scipy.optimize.OptimizeResult
@@ -257,10 +257,10 @@ def _system_of_equations_desoto(params, specs):
 
     Parameters
     ----------
-    params: ndarray
+    params : ndarray
         Array with parameters of the De Soto single diode model. Must be
         given in the following order: IL, Io, a, Rs, Rsh
-    specs: tuple
+    specs : tuple
         Specifications of pv module given by manufacturer. Must be given
         in the following order: Isc, Voc, Imp, Vmp, beta_oc, alpha_sc
 
@@ -353,7 +353,7 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
         input that sets the maximum number of iterations for the parameter
         updating part of the algorithm.
 
-    eps1: float, default 1e-3
+    eps1 : float, default 1e-3
         Tolerance for the IV curve fitting. The parameter updating stops when
         absolute values of the percent change in mean, max and standard
         deviation of Imp, Vmp and Pmp between iterations are all less than
@@ -536,7 +536,7 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
         input that sets the maximum number of iterations for the parameter
         updating part of the algorithm.
 
-    eps1: float, default 1e-3
+    eps1 : float, default 1e-3
         Tolerance for the IV curve fitting. The parameter updating stops when
         absolute values of the percent change in mean, max and standard
         deviation of Imp, Vmp and Pmp between iterations are all less than
@@ -917,12 +917,12 @@ def _update_io(voc, iph, io, rs, rsh, nnsvth):
 
     Parameters
     ----------
-    voc: a numpy array of length N of values for Voc (V)
-    iph: a numpy array of length N of values for lighbt current IL (A)
-    io: a numpy array of length N of initial values for Io (A)
-    rs: a numpy array of length N of values for the series resistance (ohm)
-    rsh: a numpy array of length N of values for the shunt resistance (ohm)
-    nnsvth: a numpy array of length N of values for the diode factor x thermal
+    voc : a numpy array of length N of values for Voc (V)
+    iph : a numpy array of length N of values for lighbt current IL (A)
+    io : a numpy array of length N of initial values for Io (A)
+    rs : a numpy array of length N of values for the series resistance (ohm)
+    rsh : a numpy array of length N of values for the shunt resistance (ohm)
+    nnsvth : a numpy array of length N of values for the diode factor x thermal
             voltage for the module, equal to Ns (number of cells in series) x
             Vth (thermal voltage per cell).
 
@@ -1015,13 +1015,13 @@ def _check_converge(prevparams, result, vmp, imp, i):
 
     Parameters
     ----------
-    prevparams: Convergence Parameters from the previous Iteration (used to
+    prevparams : Convergence Parameters from the previous Iteration (used to
                 determine Percent Change in values between iterations)
-    result: performacne paramters of the (predicted) single diode fitting,
+    result : performacne paramters of the (predicted) single diode fitting,
             which includes Voc, Vmp, Imp, Pmp and Isc
-    vmp: measured values for each IV curve
-    imp: measured values for each IV curve
-    i: Index of current iteration in cec_parameter_estimation
+    vmp : measured values for each IV curve
+    imp : measured values for each IV curve
+    i : Index of current iteration in cec_parameter_estimation
 
     Returns
     -------
@@ -1123,13 +1123,13 @@ def _update_rsh_fixed_pt(vmp, imp, iph, io, rs, rsh, nnsvth):
 
     Parameters
     ----------
-    vmp: a numpy array of length N of values for Vmp (V)
-    imp: a numpy array of length N of values for Imp (A)
-    iph: a numpy array of length N of values for light current IL (A)
-    io: a numpy array of length N of values for Io (A)
-    rs: a numpy array of length N of values for series resistance (ohm)
-    rsh: a numpy array of length N of initial values for shunt resistance (ohm)
-    nnsvth: a numpy array length N of values for the diode factor x thermal
+    vmp : a numpy array of length N of values for Vmp (V)
+    imp : a numpy array of length N of values for Imp (A)
+    iph : a numpy array of length N of values for light current IL (A)
+    io : a numpy array of length N of values for Io (A)
+    rs : a numpy array of length N of values for series resistance (ohm)
+    rsh : a numpy array of length N of initial values for shunt resistance (ohm)
+    nnsvth : a numpy array length N of values for the diode factor x thermal
             voltage for the module, equal to Ns (number of cells in series) x
             Vth (thermal voltage per cell).
 
@@ -1165,22 +1165,22 @@ def _calc_theta_phi_exact(vmp, imp, iph, io, rs, rsh, nnsvth):
 
     Parameters
     ----------
-    vmp: a numpy array of length N of values for Vmp (V)
-    imp: a numpy array of length N of values for Imp (A)
-    iph: a numpy array of length N of values for the light current IL (A)
-    io: a numpy array of length N of values for Io (A)
-    rs: a numpy array of length N of values for the series resistance (ohm)
-    rsh: a numpy array of length N of values for the shunt resistance (ohm)
-    nnsvth: a numpy array of length N of values for the diode factor x
+    vmp : a numpy array of length N of values for Vmp (V)
+    imp : a numpy array of length N of values for Imp (A)
+    iph : a numpy array of length N of values for the light current IL (A)
+    io : a numpy array of length N of values for Io (A)
+    rs : a numpy array of length N of values for the series resistance (ohm)
+    rsh : a numpy array of length N of values for the shunt resistance (ohm)
+    nnsvth : a numpy array of length N of values for the diode factor x
             thermal voltage for the module, equal to Ns
             (number of cells in series) x Vth
             (thermal voltage per cell).
 
     Returns
     -------
-    theta: a numpy array of values for the Lamber W function for solving
+    theta : a numpy array of values for the Lamber W function for solving
            I = I(V)
-    phi: a numpy array of values for the Lambert W function for solving
+    phi : a numpy array of values for the Lambert W function for solving
          V = V(I)
 
     Notes

--- a/pvlib/ivtools/utils.py
+++ b/pvlib/ivtools/utils.py
@@ -136,7 +136,7 @@ def rectify_iv_curve(voltage, current, decimals=None):
     ----------
     voltage : numeric [V]
     current : numeric [A]
-    decimals : int or None, default None
+    decimals : int, optional
         number of decimal places to which voltage is rounded to remove
         duplicated points. If None, no rounding is done.
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -205,14 +205,14 @@ class Location:
 
         Parameters
         ----------
-        times: DatetimeIndex
-        model: str, default 'ineichen'
+        times : DatetimeIndex
+        model : str, default 'ineichen'
             The clear sky model to use. Must be one of
             'ineichen', 'haurwitz', 'simplified_solis'.
         solar_position : None or DataFrame, default None
             DataFrame with columns 'apparent_zenith', 'zenith',
             'apparent_elevation'.
-        dni_extra: None or numeric, default None
+        dni_extra : None or numeric, default None
             If None, will be calculated from times.
 
         kwargs

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -50,7 +50,7 @@ class Location:
     name : string, optional
         Sets the name attribute of the Location object.
 
-    See also
+    See Also
     --------
     pvlib.pvsystem.PVSystem
     """
@@ -293,7 +293,7 @@ class Location:
         airmass : DataFrame
             Columns are 'airmass_relative', 'airmass_absolute'
 
-        See also
+        See Also
         --------
         pvlib.atmosphere.get_relative_airmass
         """

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -29,25 +29,25 @@ class Location:
 
     Parameters
     ----------
-    latitude : float.
+    latitude : float
         Positive is north of the equator.
         Use decimal degrees notation.
 
-    longitude : float.
+    longitude : float
         Positive is east of the prime meridian.
         Use decimal degrees notation.
 
-    tz : str, int, float, or pytz.timezone, default 'UTC'.
+    tz : str, int, float, or pytz.timezone, default 'UTC'
         See
         http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
         for a list of valid time zones.
         pytz.timezone objects will be converted to strings.
         ints and floats must be in hours from UTC.
 
-    altitude : float, default 0.
+    altitude : float, default 0
         Altitude from sea level in meters.
 
-    name : None or string, default None.
+    name : None or string, default None
         Sets the name attribute of the Location object.
 
     See also
@@ -376,11 +376,11 @@ def lookup_altitude(latitude, longitude):
 
     Parameters
     ----------
-    latitude : float.
+    latitude : float
         Positive is north of the equator.
         Use decimal degrees notation.
 
-    longitude : float.
+    longitude : float
         Positive is east of the prime meridian.
         Use decimal degrees notation.
 

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -47,7 +47,7 @@ class Location:
     altitude : float, default 0
         Altitude from sea level in meters.
 
-    name : None or string, default None
+    name : string, optional
         Sets the name attribute of the Location object.
 
     See also
@@ -94,7 +94,7 @@ class Location:
         ----------
         tmy_metadata : dict
             Returned from tmy.readtmy2 or tmy.readtmy3
-        tmy_data : None or DataFrame, default None
+        tmy_data : DataFrame, optional
             Optionally attach the TMY data to this object.
 
         Returns
@@ -138,7 +138,7 @@ class Location:
         ----------
         metadata : dict
             Returned from epw.read_epw
-        data : None or DataFrame, default None
+        data : DataFrame, optional
             Optionally attach the epw data to this object.
 
         Returns
@@ -173,7 +173,7 @@ class Location:
         ----------
         times : pandas.DatetimeIndex
             Must be localized or UTC will be assumed.
-        pressure : None, float, or array-like, default None
+        pressure : None, float, or array-like, optional
             If None, pressure will be calculated using
             :py:func:`pvlib.atmosphere.alt2pres` and ``self.altitude``.
         temperature : None, float, or array-like, default 12
@@ -209,10 +209,10 @@ class Location:
         model : str, default 'ineichen'
             The clear sky model to use. Must be one of
             'ineichen', 'haurwitz', 'simplified_solis'.
-        solar_position : None or DataFrame, default None
+        solar_position : DataFrame, optional
             DataFrame with columns 'apparent_zenith', 'zenith',
             'apparent_elevation'.
-        dni_extra : None or numeric, default None
+        dni_extra : numeric, optional
             If None, will be calculated from times.
 
         kwargs
@@ -279,9 +279,9 @@ class Location:
 
         Parameters
         ----------
-        times : None or DatetimeIndex, default None
+        times : DatetimeIndex, optional
             Only used if solar_position is not provided.
-        solar_position : None or DataFrame, default None
+        solar_position : DataFrame, optional
             DataFrame with with columns 'apparent_zenith', 'zenith'.
         model : str, default 'kastenyoung1989'
             Relative airmass model. See

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -823,7 +823,7 @@ class ModelChain:
         -------
         self
 
-        See also
+        See Also
         --------
         pvlib.pvsystem.PVSystem.pvwatts_dc
         pvlib.pvsystem.PVSystem.scale_voltage_current_power
@@ -1539,7 +1539,7 @@ class ModelChain:
         Assigns attributes to ``results``: ``times``, ``weather``,
         ``solar_position``, ``airmass``, ``total_irrad``, ``aoi``, ``albedo``.
 
-        See also
+        See Also
         --------
         ModelChain.complete_irradiance
         """
@@ -1621,7 +1621,7 @@ class ModelChain:
         Assigns attributes to ``results``: ``times``, ``weather``,
         ``total_irrad``, ``solar_position``, ``airmass``, ``aoi``.
 
-        See also
+        See Also
         --------
         pvlib.modelchain.ModelChain.prepare_inputs
         """
@@ -1798,7 +1798,7 @@ class ModelChain:
         ``losses``, ``diode_params`` (if dc_model is a single diode
         model).
 
-        See also
+        See Also
         --------
         pvlib.modelchain.ModelChain.run_model_from_poa
         pvlib.modelchain.ModelChain.run_model_from_effective_irradiance
@@ -1859,7 +1859,7 @@ class ModelChain:
         ``losses``, ``diode_params`` (if dc_model is a single diode
         model).
 
-        See also
+        See Also
         --------
         pvlib.modelchain.ModelChain.run_model
         pvlib.modelchain.ModelChain.run_model_from_effective_irradiance
@@ -1955,7 +1955,7 @@ class ModelChain:
         ``effective_irradiance``, ``cell_temperature``, ``dc``, ``ac``,
         ``losses``, ``diode_params`` (if dc_model is a single diode model).
 
-        See also
+        See Also
         --------
         pvlib.modelchain.ModelChain.run_model
         pvlib.modelchain.ModelChain.run_model_from_poa

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -90,11 +90,11 @@ def basic_chain(times, latitude, longitude,
     times : DatetimeIndex
         Times at which to evaluate the model.
 
-    latitude : float.
+    latitude : float
         Positive is north of the equator.
         Use decimal degrees notation.
 
-    longitude : float.
+    longitude : float
         Positive is east of the prime meridian.
         Use decimal degrees notation.
 
@@ -113,7 +113,7 @@ def basic_chain(times, latitude, longitude,
         Module parameters as defined by the SAPM. See pvsystem.sapm for
         details.
 
-    temperature_model_parameters : None, dict or Series.
+    temperature_model_parameters : None, dict or Series
         Temperature model parameters as defined by the SAPM.
         See temperature.sapm_cell for details.
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -229,7 +229,7 @@ def get_orientation(strategy, **kwargs):
 
     Parameters
     ----------
-    strategy: str
+    strategy : str
         The orientation strategy.
         Allowed strategies include 'flat', 'south_at_latitude_tilt'.
     **kwargs:
@@ -472,49 +472,49 @@ class ModelChain:
     airmass_model : str, default 'kastenyoung1989'
         Passed to location.get_airmass.
 
-    dc_model: None, str, or function, default None
+    dc_model : None, str, or function, default None
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'sapm', 'desoto', 'cec', 'pvsyst', 'pvwatts'.
         The ModelChain instance will be passed as the first argument
         to a user-defined function.
 
-    ac_model: None, str, or function, default None
+    ac_model : None, str, or function, default None
         If None, the model will be inferred from the parameters that
         are common to all of system.inverter_parameters.
         Valid strings are 'sandia', 'adr', 'pvwatts'. The
         ModelChain instance will be passed as the first argument to a
         user-defined function.
 
-    aoi_model: None, str, or function, default None
+    aoi_model : None, str, or function, default None
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'physical', 'ashrae', 'sapm', 'martin_ruiz',
         'no_loss'. The ModelChain instance will be passed as the
         first argument to a user-defined function.
 
-    spectral_model: None, str, or function, default None
+    spectral_model : None, str, or function, default None
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'sapm', 'first_solar', 'no_loss'.
         The ModelChain instance will be passed as the first argument to
         a user-defined function.
 
-    temperature_model: None, str or function, default None
+    temperature_model : None, str or function, default None
         Valid strings are: 'sapm', 'pvsyst', 'faiman', 'fuentes', 'noct_sam'.
         The ModelChain instance will be passed as the first argument to a
         user-defined function.
 
-    dc_ohmic_model: str or function, default 'no_loss'
+    dc_ohmic_model : str or function, default 'no_loss'
         Valid strings are 'dc_ohms_from_percent', 'no_loss'. The ModelChain
         instance will be passed as the first argument to a user-defined
         function.
 
-    losses_model: str or function, default 'no_loss'
+    losses_model : str or function, default 'no_loss'
         Valid strings are 'pvwatts', 'no_loss'. The ModelChain instance
         will be passed as the first argument to a user-defined function.
 
-    name: None or str, default None
+    name : None or str, default None
         Name of ModelChain instance.
     """
 
@@ -575,7 +575,7 @@ class ModelChain:
         airmass_model : str, default 'kastenyoung1989'
             Passed to location.get_airmass.
 
-        name: None or str, default None
+        name : None or str, default None
             Name of ModelChain instance.
 
         **kwargs
@@ -651,7 +651,7 @@ class ModelChain:
         airmass_model : str, default 'kastenyoung1989'
             Passed to location.get_airmass.
 
-        name: None or str, default None
+        name : None or str, default None
             Name of ModelChain instance.
 
         **kwargs

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -121,11 +121,11 @@ def basic_chain(times, latitude, longitude,
         Inverter parameters as defined by the CEC. See
         :py:func:`inverter.sandia` for details.
 
-    irradiance : None or DataFrame, default None
+    irradiance : DataFrame, optional
         If None, calculates clear sky data.
         Columns must be 'dni', 'ghi', 'dhi'.
 
-    weather : None or DataFrame, default None
+    weather : DataFrame, optional
         If None, assumes air temperature is 20 C and
         wind speed is 0 m/s.
         Columns must be 'wind_speed', 'temp_air'.
@@ -139,11 +139,11 @@ def basic_chain(times, latitude, longitude,
     airmass_model : str, default 'kastenyoung1989'
         Passed to atmosphere.relativeairmass.
 
-    altitude : None or float, default None
+    altitude : float, optional
         If None, computed from pressure. Assumed to be 0 m
         if pressure is also None.
 
-    pressure : None or float, default None
+    pressure : float, optional
         If None, computed from altitude. Assumed to be 101325 Pa
         if altitude is also None.
 
@@ -472,35 +472,35 @@ class ModelChain:
     airmass_model : str, default 'kastenyoung1989'
         Passed to location.get_airmass.
 
-    dc_model : None, str, or function, default None
+    dc_model : None, str, or function, optional
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'sapm', 'desoto', 'cec', 'pvsyst', 'pvwatts'.
         The ModelChain instance will be passed as the first argument
         to a user-defined function.
 
-    ac_model : None, str, or function, default None
+    ac_model : None, str, or function, optional
         If None, the model will be inferred from the parameters that
         are common to all of system.inverter_parameters.
         Valid strings are 'sandia', 'adr', 'pvwatts'. The
         ModelChain instance will be passed as the first argument to a
         user-defined function.
 
-    aoi_model : None, str, or function, default None
+    aoi_model : None, str, or function, optional
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'physical', 'ashrae', 'sapm', 'martin_ruiz',
         'no_loss'. The ModelChain instance will be passed as the
         first argument to a user-defined function.
 
-    spectral_model : None, str, or function, default None
+    spectral_model : None, str, or function, optional
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'sapm', 'first_solar', 'no_loss'.
         The ModelChain instance will be passed as the first argument to
         a user-defined function.
 
-    temperature_model : None, str or function, default None
+    temperature_model : None, str or function, optional
         Valid strings are: 'sapm', 'pvsyst', 'faiman', 'fuentes', 'noct_sam'.
         The ModelChain instance will be passed as the first argument to a
         user-defined function.
@@ -514,7 +514,7 @@ class ModelChain:
         Valid strings are 'pvwatts', 'no_loss'. The ModelChain instance
         will be passed as the first argument to a user-defined function.
 
-    name : None or str, default None
+    name : str, optional
         Name of ModelChain instance.
     """
 
@@ -575,7 +575,7 @@ class ModelChain:
         airmass_model : str, default 'kastenyoung1989'
             Passed to location.get_airmass.
 
-        name : None or str, default None
+        name : str, optional
             Name of ModelChain instance.
 
         **kwargs
@@ -651,7 +651,7 @@ class ModelChain:
         airmass_model : str, default 'kastenyoung1989'
             Passed to location.get_airmass.
 
-        name : None or str, default None
+        name : str, optional
             Name of ModelChain instance.
 
         **kwargs

--- a/pvlib/pvarray.py
+++ b/pvlib/pvarray.py
@@ -78,7 +78,7 @@ def pvefficiency_adr(effective_irradiance, temp_cell,
     are array-like they must be the same shape or broadcastable to the
     same shape.
 
-    See also
+    See Also
     --------
     pvlib.pvarray.fit_pvefficiency_adr
 
@@ -175,7 +175,7 @@ def fit_pvefficiency_adr(effective_irradiance, temp_cell, eta,
     would consist of 6 operating points covering low, medium and high
     irradiance levels at two operating temperatures.
 
-    See also
+    See Also
     --------
     pvlib.pvarray.pvefficiency_adr
     scipy.optimize.curve_fit

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -118,12 +118,12 @@ class PVSystem:
         - `modules_per_string`
         - `strings_per_inverter`
 
-    surface_tilt: float or array-like, default 0
+    surface_tilt : float or array-like, default 0
         Surface tilt angles in decimal degrees.
         The tilt angle is defined as degrees from horizontal
         (e.g. surface facing up = 0, surface facing horizon = 90)
 
-    surface_azimuth: float or array-like, default 180
+    surface_azimuth : float or array-like, default 180
         Azimuth angle of the module surface.
         North=0, East=90, South=180, West=270.
 
@@ -153,10 +153,10 @@ class PVSystem:
         Temperature model parameters as required by one of the models in
         pvlib.temperature (excluding poa_global, temp_air and wind_speed).
 
-    modules_per_string: int or float, default 1
+    modules_per_string : int or float, default 1
         See system topology discussion above.
 
-    strings_per_inverter: int or float, default 1
+    strings_per_inverter : int or float, default 1
         See system topology discussion above.
 
     inverter : None or string, default None
@@ -278,7 +278,7 @@ class PVSystem:
 
         Returns
         -------
-        cell_type: str
+        cell_type : str
         """
         return tuple(array._infer_cell_type() for array in self.arrays)
 
@@ -690,7 +690,7 @@ class PVSystem:
 
         Returns
         -------
-        modifier: array-like or tuple of array-like
+        modifier : array-like or tuple of array-like
             spectral mismatch factor (unitless) which can be multiplied
             with broadband irradiance reaching a module's cells to estimate
             effective irradiance, i.e., the irradiance that is converted to
@@ -819,13 +819,13 @@ class PVSystem:
 
         Parameters
         ----------
-        data: DataFrame or tuple of DataFrame
+        data : DataFrame or tuple of DataFrame
             May contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
             'i_sc', 'p_mp'`.
 
         Returns
         -------
-        scaled_data: DataFrame or tuple of DataFrame
+        scaled_data : DataFrame or tuple of DataFrame
             A scaled copy of the input data.
         """
         data = self._validate_per_array(data)
@@ -897,7 +897,7 @@ class Array:
 
     Parameters
     ----------
-    mount: FixedMount, SingleAxisTrackerMount, or other
+    mount : FixedMount, SingleAxisTrackerMount, or other
         Mounting for the array, either on fixed-tilt racking or horizontal
         single axis tracker. Mounting is used to determine module orientation.
         If not provided, a FixedMount with zero tilt is used.
@@ -928,16 +928,16 @@ class Array:
         Parameters for the module temperature model, e.g., SAPM, Pvsyst, or
         other.
 
-    modules_per_string: int, default 1
+    modules_per_string : int, default 1
         Number of modules per string in the array.
 
-    strings: int, default 1
+    strings : int, default 1
         Number of parallel strings in the array.
 
-    array_losses_parameters: None, dict or Series, default None.
+    array_losses_parameters : None, dict or Series, default None.
         Supported keys are 'dc_ohmic_percent'.
 
-    name: None or str, default None
+    name : None or str, default None
         Name of Array instance.
     """
 
@@ -1014,7 +1014,7 @@ class Array:
 
         Returns
         -------
-        cell_type: str
+        cell_type : str
 
         """
 
@@ -2773,17 +2773,17 @@ def scale_voltage_current_power(data, voltage=1, current=1):
 
     Parameters
     ----------
-    data: DataFrame
+    data : DataFrame
         May contain columns `'v_mp', 'v_oc', 'i_mp' ,'i_x', 'i_xx',
         'i_sc', 'p_mp'`.
-    voltage: numeric, default 1
+    voltage : numeric, default 1
         The amount by which to multiply the voltages.
-    current: numeric, default 1
+    current : numeric, default 1
         The amount by which to multiply the currents.
 
     Returns
     -------
-    scaled_data: DataFrame
+    scaled_data : DataFrame
         A scaled copy of the input data.
         `'p_mp'` is scaled by `voltage * current`.
     """
@@ -2817,25 +2817,25 @@ def pvwatts_dc(g_poa_effective, temp_cell, pdc0, gamma_pdc, temp_ref=25.):
 
     Parameters
     ----------
-    g_poa_effective: numeric
+    g_poa_effective : numeric
         Irradiance transmitted to the PV cells. To be
         fully consistent with PVWatts, the user must have already
         applied angle of incidence losses, but not soiling, spectral,
         etc. [W/m^2]
-    temp_cell: numeric
+    temp_cell : numeric
         Cell temperature [C].
-    pdc0: numeric
+    pdc0 : numeric
         Power of the modules at 1000 W/m^2 and cell reference temperature. [W]
-    gamma_pdc: numeric
+    gamma_pdc : numeric
         The temperature coefficient of power. Typically -0.002 to
         -0.005 per degree C. [1/C]
-    temp_ref: numeric, default 25.0
+    temp_ref : numeric, default 25.0
         Cell reference temperature. PVWatts defines it to be 25 C and
         is included here for flexibility. [C]
 
     Returns
     -------
-    pdc: numeric
+    pdc : numeric
         DC power.
 
     References
@@ -2867,21 +2867,21 @@ def pvwatts_losses(soiling=2, shading=3, snow=0, mismatch=2, wiring=2,
 
     Parameters
     ----------
-    soiling: numeric, default 2
-    shading: numeric, default 3
-    snow: numeric, default 0
-    mismatch: numeric, default 2
-    wiring: numeric, default 2
-    connections: numeric, default 0.5
-    lid: numeric, default 1.5
+    soiling : numeric, default 2
+    shading : numeric, default 3
+    snow : numeric, default 0
+    mismatch : numeric, default 2
+    wiring : numeric, default 2
+    connections : numeric, default 0.5
+    lid : numeric, default 1.5
         Light induced degradation
-    nameplate_rating: numeric, default 1
-    age: numeric, default 0
-    availability: numeric, default 3
+    nameplate_rating : numeric, default 1
+    age : numeric, default 0
+    availability : numeric, default 3
 
     Returns
     -------
-    losses: numeric
+    losses : numeric
         System losses in units of %.
 
     References
@@ -2924,20 +2924,20 @@ def dc_ohms_from_percent(vmp_ref, imp_ref, dc_ohmic_percent,
 
     Parameters
     ----------
-    vmp_ref: numeric
+    vmp_ref : numeric
         Voltage at maximum power in reference conditions [V]
-    imp_ref: numeric
+    imp_ref : numeric
         Current at maximum power in reference conditions [V]
-    dc_ohmic_percent: numeric, default 0
+    dc_ohmic_percent : numeric, default 0
         input dc loss as a percent, e.g. 1.5% loss is input as 1.5
-    modules_per_string: int, default 1
+    modules_per_string : int, default 1
         Number of modules per string in the array.
-    strings: int, default 1
+    strings : int, default 1
         Number of parallel strings in the array.
 
     Returns
     ----------
-    Rw: numeric
+    Rw : numeric
         Equivalent resistance [ohm]
 
     See Also
@@ -2965,14 +2965,14 @@ def dc_ohmic_losses(resistance, current):
 
     Parameters
     ----------
-    resistance: numeric
+    resistance : numeric
         Equivalent resistance of wires [ohm]
-    current: numeric, float or array-like
+    current : numeric, float or array-like
         Operating current [A]
 
     Returns
     ----------
-    loss: numeric
+    loss : numeric
         Power Loss [W]
 
     See Also

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -149,7 +149,7 @@ class PVSystem:
     module_parameters : None, dict or Series, default None
         Module parameters as defined by the SAPM, CEC, or other.
 
-    temperature_model_parameters : None, dict or Series, default None.
+    temperature_model_parameters : None, dict or Series, default None
         Temperature model parameters as required by one of the models in
         pvlib.temperature (excluding poa_global, temp_air and wind_speed).
 
@@ -288,9 +288,9 @@ class PVSystem:
 
         Parameters
         ----------
-        solar_zenith : float or Series.
+        solar_zenith : float or Series
             Solar zenith angle.
-        solar_azimuth : float or Series.
+        solar_azimuth : float or Series
             Solar azimuth angle.
 
         Returns
@@ -924,7 +924,7 @@ class Array:
     module_parameters : None, dict or Series, default None
         Parameters for the module model, e.g., SAPM, CEC, or other.
 
-    temperature_model_parameters : None, dict or Series, default None.
+    temperature_model_parameters : None, dict or Series, default None
         Parameters for the module temperature model, e.g., SAPM, Pvsyst, or
         other.
 
@@ -934,7 +934,7 @@ class Array:
     strings : int, default 1
         Number of parallel strings in the array.
 
-    array_losses_parameters : None, dict or Series, default None.
+    array_losses_parameters : None, dict or Series, default None
         Supported keys are 'dc_ohmic_percent'.
 
     name : None or str, default None
@@ -1081,9 +1081,9 @@ class Array:
 
         Parameters
         ----------
-        solar_zenith : float or Series.
+        solar_zenith : float or Series
             Solar zenith angle.
-        solar_azimuth : float or Series.
+        solar_azimuth : float or Series
             Solar azimuth angle.
         dni : float or Series
             Direct normal irradiance. [W/m2]

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1525,10 +1525,10 @@ def calcparams_desoto(effective_irradiance, temp_cell,
         the SAM CEC module database, dEgdT=-0.0002677 is implicit for all cell
         types in the parameter estimation algorithm used by NREL.
 
-    irrad_ref : float (optional, default=1000)
+    irrad_ref : float, default 1000
         Reference irradiance in W/m^2.
 
-    temp_ref : float (optional, default=25)
+    temp_ref : float, default 25
         Reference cell temperature in C.
 
     Returns
@@ -1741,10 +1741,10 @@ def calcparams_cec(effective_irradiance, temp_cell,
         the SAM CEC module database, dEgdT=-0.0002677 is implicit for all cell
         types in the parameter estimation algorithm used by NREL.
 
-    irrad_ref : float (optional, default=1000)
+    irrad_ref : float, default 1000
         Reference irradiance in W/m^2.
 
-    temp_ref : float (optional, default=25)
+    temp_ref : float, default 25
         Reference cell temperature in C.
 
     Returns
@@ -1858,10 +1858,10 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
         The energy bandgap at reference temperature in units of eV.
         1.121 eV for crystalline silicon. EgRef must be >0.
 
-    irrad_ref : float (optional, default=1000)
+    irrad_ref : float, default 1000
         Reference irradiance in W/m^2.
 
-    temp_ref : float (optional, default=25)
+    temp_ref : float, default 25
         Reference cell temperature in C.
 
     Returns

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -127,17 +127,17 @@ class PVSystem:
         Azimuth angle of the module surface.
         North=0, East=90, South=180, West=270.
 
-    albedo : None or float, default None
+    albedo : float, optional
         Ground surface albedo. If ``None``, then ``surface_type`` is used
         to look up a value in ``irradiance.SURFACE_ALBEDOS``.
         If ``surface_type`` is also None then a ground surface albedo
         of 0.25 is used.
 
-    surface_type : None or string, default None
+    surface_type : string, optional
         The ground surface type. See ``irradiance.SURFACE_ALBEDOS`` for
         valid values.
 
-    module : None or string, default None
+    module : string, optional
         The model name of the modules.
         May be used to look up the module_parameters dictionary
         via some other method.
@@ -146,10 +146,10 @@ class PVSystem:
          Describes the module's construction. Valid strings are 'glass_polymer'
          and 'glass_glass'. Used for cell and module temperature calculations.
 
-    module_parameters : None, dict or Series, default None
+    module_parameters : None, dict or Series, optional
         Module parameters as defined by the SAPM, CEC, or other.
 
-    temperature_model_parameters : None, dict or Series, default None
+    temperature_model_parameters : None, dict or Series, optional
         Temperature model parameters as required by one of the models in
         pvlib.temperature (excluding poa_global, temp_air and wind_speed).
 
@@ -159,22 +159,22 @@ class PVSystem:
     strings_per_inverter : int or float, default 1
         See system topology discussion above.
 
-    inverter : None or string, default None
+    inverter : string, optional
         The model name of the inverters.
         May be used to look up the inverter_parameters dictionary
         via some other method.
 
-    inverter_parameters : None, dict or Series, default None
+    inverter_parameters : None, dict or Series, optional
         Inverter parameters as defined by the SAPM, CEC, or other.
 
     racking_model : None or string, default 'open_rack'
         Valid strings are 'open_rack', 'close_mount', and 'insulated_back'.
         Used to identify a parameter set for the SAPM cell temperature model.
 
-    losses_parameters : None, dict or Series, default None
+    losses_parameters : None, dict or Series, optional
         Losses parameters as defined by PVWatts or other.
 
-    name : None or string, default None
+    name : string, optional
 
     **kwargs
         Arbitrary keyword arguments.
@@ -327,9 +327,9 @@ class PVSystem:
         dni_extra : None, float, Series or tuple of float or Series,\
             default None
             Extraterrestrial direct normal irradiance. [W/m2]
-        airmass : None, float or Series, default None
+        airmass : None, float or Series, optional
             Airmass. [unitless]
-        albedo : None, float or Series, default None
+        albedo : None, float or Series, optional
             Ground surface albedo. [unitless]
         model : String, default 'haydavies'
             Irradiance model.
@@ -902,29 +902,29 @@ class Array:
         single axis tracker. Mounting is used to determine module orientation.
         If not provided, a FixedMount with zero tilt is used.
 
-    albedo : None or float, default None
+    albedo : float, optional
         Ground surface albedo. If ``None``, then ``surface_type`` is used
         to look up a value in ``irradiance.SURFACE_ALBEDOS``.
         If ``surface_type`` is also None then a ground surface albedo
         of 0.25 is used.
 
-    surface_type : None or string, default None
+    surface_type : string, optional
         The ground surface type. See ``irradiance.SURFACE_ALBEDOS`` for valid
         values.
 
-    module : None or string, default None
+    module : string, optional
         The model name of the modules.
         May be used to look up the module_parameters dictionary
         via some other method.
 
-    module_type : None or string, default None
+    module_type : string, optional
          Describes the module's construction. Valid strings are 'glass_polymer'
          and 'glass_glass'. Used for cell and module temperature calculations.
 
-    module_parameters : None, dict or Series, default None
+    module_parameters : None, dict or Series, optional
         Parameters for the module model, e.g., SAPM, CEC, or other.
 
-    temperature_model_parameters : None, dict or Series, default None
+    temperature_model_parameters : None, dict or Series, optional
         Parameters for the module temperature model, e.g., SAPM, Pvsyst, or
         other.
 
@@ -934,10 +934,10 @@ class Array:
     strings : int, default 1
         Number of parallel strings in the array.
 
-    array_losses_parameters : None, dict or Series, default None
+    array_losses_parameters : None, dict or Series, optional
         Supported keys are 'dc_ohmic_percent'.
 
-    name : None or str, default None
+    name : str, optional
         Name of Array instance.
     """
 
@@ -1091,11 +1091,11 @@ class Array:
             Global horizontal irradiance
         dhi : float or Series
             Diffuse horizontal irradiance. [W/m2]
-        dni_extra : None, float or Series, default None
+        dni_extra : None, float or Series, optional
             Extraterrestrial direct normal irradiance. [W/m2]
-        airmass : None, float or Series, default None
+        airmass : None, float or Series, optional
             Airmass. [unitless]
-        albedo : None, float or Series, default None
+        albedo : None, float or Series, optional
             Ground surface albedo. [unitless]
         model : String, default 'haydavies'
             Irradiance model.
@@ -1963,7 +1963,7 @@ def retrieve_sam(name=None, path=None):
 
     Parameters
     ----------
-    name : None or string, default None
+    name : string, optional
         Name can be one of:
 
         * 'CECMod' - returns the CEC module database
@@ -1974,7 +1974,7 @@ def retrieve_sam(name=None, path=None):
         * 'SandiaMod' - returns the Sandia Module database
         * 'ADRInverter' - returns the ADR Inverter database
 
-    path : None or string, default None
+    path : string, optional
         Path to the SAM file. May also be a URL.
 
     Returns
@@ -2382,7 +2382,7 @@ def singlediode(photocurrent, saturation_current, resistance_series,
         junction in Kelvin, and :math:`q` is the charge of an electron
         (coulombs). ``0 < nNsVth``.  [V]
 
-    ivcurve_pnts : None or int, default None
+    ivcurve_pnts : int, optional
         Number of points in the desired IV curve. If None or 0, no points on
         the IV curves will be produced.
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -185,7 +185,7 @@ class PVSystem:
     ValueError
         If `arrays` is not None and has length 0.
 
-    See also
+    See Also
     --------
     pvlib.location.Location
     """
@@ -351,7 +351,7 @@ class PVSystem:
             Column names are: ``'poa_global', 'poa_direct', 'poa_diffuse',
             'poa_sky_diffuse', 'poa_ground_diffuse'``.
 
-        See also
+        See Also
         --------
         pvlib.irradiance.get_total_irradiance
         """
@@ -770,7 +770,7 @@ class PVSystem:
         ValueError
             If model='adr' and the PVSystem has more than one array.
 
-        See also
+        See Also
         --------
         pvlib.inverter.sandia
         pvlib.inverter.sandia_multi
@@ -1110,7 +1110,7 @@ class Array:
             Column names are: ``'poa_global', 'poa_direct', 'poa_diffuse',
             'poa_sky_diffuse', 'poa_ground_diffuse'``.
 
-        See also
+        See Also
         --------
         :py:func:`pvlib.irradiance.get_total_irradiance`
         """
@@ -2313,7 +2313,7 @@ def sapm_effective_irradiance(poa_direct, poa_diffuse, airmass_absolute, aoi,
     .. [1] D. King et al, "Sandia Photovoltaic Array Performance Model",
        SAND2004-3535, Sandia National Laboratories, Albuquerque, NM
 
-    See also
+    See Also
     --------
     pvlib.iam.sapm
     pvlib.spectrum.spectral_factor_sapm
@@ -2414,7 +2414,7 @@ def singlediode(photocurrent, saturation_current, resistance_series,
             * i - IV curve current in amperes.
             * v - IV curve voltage in volts.
 
-    See also
+    See Also
     --------
     calcparams_desoto
     calcparams_cec

--- a/pvlib/scaling.py
+++ b/pvlib/scaling.py
@@ -40,10 +40,10 @@ def wvm(clearsky_index, positions, cloud_speed, dt=None):
     smoothed : numeric or pandas.Series
         The Clear Sky Index time series smoothed for the described plant.
 
-    wavelet: numeric
+    wavelet : numeric
         The individual wavelets for the time series before smoothing.
 
-    tmscales: numeric
+    tmscales : numeric
         The timescales associated with the wavelets in seconds [s].
 
     References
@@ -100,7 +100,7 @@ def _compute_vr(positions, cloud_speed, tmscales):
     cloud_speed : numeric
         Speed of cloud movement in meters per second [m/s].
 
-    tmscales: numeric
+    tmscales : numeric
         The timescales associated with the wavelets in seconds [s].
 
     Returns
@@ -223,11 +223,11 @@ def _compute_wavelet(clearsky_index, dt=None):
 
     Returns
     -------
-    wavelet: numeric
+    wavelet : numeric
         The individual wavelets for the time series. Format follows increasing
         scale (decreasing frequency): [CD1, CD2, ..., CDn, CAn]
 
-    tmscales: numeric
+    tmscales : numeric
         The timescales associated with the wavelets in seconds [s]
 
     References

--- a/pvlib/scaling.py
+++ b/pvlib/scaling.py
@@ -30,7 +30,7 @@ def wvm(clearsky_index, positions, cloud_speed, dt=None):
     cloud_speed : numeric
         Speed of cloud movement in meters per second [m/s].
 
-    dt : float, default None
+    dt : float, optional
         The time series time delta. By default, is inferred from the
         clearsky_index. Must be specified for a time series that doesn't
         include an index. Units of seconds [s].
@@ -216,7 +216,7 @@ def _compute_wavelet(clearsky_index, dt=None):
     clearsky_index : numeric or pandas.Series
         Clear Sky Index time series that will be smoothed.
 
-    dt : float, default None
+    dt : float, optional
         The time series time delta. By default, is inferred from the
         clearsky_index. Must be specified for a time series that doesn't
         include an index. Units of seconds [s].

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -93,7 +93,7 @@ def bishop88(diode_voltage, photocurrent, saturation_current,
         diode reverse saturation current :math:`I_{0}` [A]
     resistance_series : numeric
         series resistance :math:`R_{s}` [ohms]
-    resistance_shunt: numeric
+    resistance_shunt : numeric
         shunt resistance :math:`R_{sh}` [ohms]
     nNsVth : numeric
         product of thermal voltage :math:`V_{th}` [V], diode ideality factor

--- a/pvlib/snow.py
+++ b/pvlib/snow.py
@@ -29,7 +29,7 @@ def fully_covered_nrel(snowfall, threshold_snowfall=1.):
 
     Returns
     ----------
-    boolean: Series
+    boolean : Series
         True where the snowfall exceeds the defined threshold to fully cover
         the panel.
 
@@ -170,7 +170,7 @@ def dc_loss_nrel(snow_coverage, num_strings):
     snow_coverage : numeric
         The fraction of row slant height covered by snow at each time step.
 
-    num_strings: int
+    num_strings : int
         The number of parallel-connected strings along a row slant height.
 
     Returns

--- a/pvlib/snow.py
+++ b/pvlib/snow.py
@@ -88,7 +88,7 @@ def coverage_nrel(snowfall, poa_irradiance, temp_air, surface_tilt,
     threshold_snowfall : float, default 1.0
         Hourly snowfall above which snow coverage is set to the row's slant
         height. [cm/hr]
-    can_slide_coefficient : float, default -80.
+    can_slide_coefficient : float, default -80
         Coefficient to determine if snow can slide given irradiance and air
         temperature. [W/(m^2 C)]
     slide_amount_coefficient : float, default 0.197

--- a/pvlib/soiling.py
+++ b/pvlib/soiling.py
@@ -116,11 +116,11 @@ def kimber(rainfall, cleaning_threshold=6, soiling_loss_rate=0.0015,
 
     Parameters
     ----------
-    rainfall: pandas.Series
+    rainfall : pandas.Series
         Accumulated rainfall at the end of each time period. [mm]
-    cleaning_threshold: float, default 6
+    cleaning_threshold : float, default 6
         Amount of daily rainfall required to clean the panels. [mm]
-    soiling_loss_rate: float, default 0.0015
+    soiling_loss_rate : float, default 0.0015
         Fraction of energy lost due to one day of soiling. [unitless]
     grace_period : int, default 14
         Number of days after a rainfall event when it's assumed the ground is

--- a/pvlib/soiling.py
+++ b/pvlib/soiling.py
@@ -128,7 +128,7 @@ def kimber(rainfall, cleaning_threshold=6, soiling_loss_rate=0.0015,
     max_soiling : float, default 0.3
         Maximum fraction of energy lost due to soiling. Soiling will build up
         until this value. [unitless]
-    manual_wash_dates : sequence or None, default None
+    manual_wash_dates : sequence, optional
         List or tuple of dates as Python ``datetime.date`` when the panels were
         washed manually. Note there is no grace period after a manual wash, so
         soiling begins to build up immediately.

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -189,7 +189,7 @@ def spa_c(time, latitude, longitude, pressure=101325, altitude=0,
     .. [2] USNO delta T:
        http://www.usno.navy.mil/USNO/earth-orientation/eo-products/long-term
 
-    See also
+    See Also
     --------
     pyephem, spa_python, ephemeris
     """
@@ -346,7 +346,7 @@ def spa_python(time, latitude, longitude,
     .. [3] USNO delta T:
        http://www.usno.navy.mil/USNO/earth-orientation/eo-products/long-term
 
-    See also
+    See Also
     --------
     pyephem, spa_c, ephemeris
     """
@@ -539,7 +539,7 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
         index is the same as input `time` argument
         columns are 'sunrise', 'sunset', and 'transit'
 
-    See also
+    See Also
     --------
     pyephem
     """
@@ -625,7 +625,7 @@ def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
         apparent_azimuth, azimuth,
         apparent_zenith, zenith.
 
-    See also
+    See Also
     --------
     spa_python, spa_c, ephemeris
     """
@@ -725,7 +725,7 @@ def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
     .. [1] Grover Hughes' class and related class materials on Engineering
        Astronomy at Sandia National Laboratories, 1985.
 
-    See also
+    See Also
     --------
     pyephem, spa_c, spa_python
 

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -51,11 +51,11 @@ def get_solarposition(time, latitude, longitude,
         Longitude in decimal degrees. Positive east of prime meridian,
         negative to west.
 
-    altitude : None or float, default None
+    altitude : float, optional
         If None, computed from pressure. Assumed to be 0 m
         if pressure is also None.
 
-    pressure : None or float, default None
+    pressure : float, optional
         If None, computed from altitude. Assumed to be 101325 Pa
         if altitude is also None.
 
@@ -312,7 +312,7 @@ def spa_python(time, latitude, longitude,
         *Note: delta_t = None will break code using nrel_numba,
         this will be fixed in a future version.*
         The USNO has historical and forecasted delta_t [3]_.
-    atmos_refrac : None or float, optional, default None
+    atmos_refrac : float, optional, optional
         The approximate atmospheric refraction (in degrees)
         at sunrise and sunset.
     how : str, optional, default 'numpy'

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -1061,7 +1061,7 @@ def solar_position(unixtime, lat, lon, elev, pressure, temp, delta_t,
     atmos_refrac : float
         The approximate atmospheric refraction (in degrees)
         at sunrise and sunset.
-    numthreads: int, optional, default 8
+    numthreads : int, optional, default 8
         Number of threads to use for computation if numba>=0.17
         is installed.
     sst : bool, default False

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -115,7 +115,7 @@ def get_am15g(wavelength=None):
     References
     ----------
     .. [1] ASTM "G173-03 Standard Tables for Reference Solar Spectral
-        Irradiances: Direct Normal and Hemispherical on 37° Tilted Surface."
+       Irradiances: Direct Normal and Hemispherical on 37° Tilted Surface."
     '''
     # Contributed by Anton Driesse (@adriesse), PV Performance Labs. Aug. 2022
 

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -17,7 +17,7 @@ def get_example_spectral_response(wavelength=None):
 
     Parameters
     ----------
-    wavelength: 1-D sequence of numeric, optional
+    wavelength : 1-D sequence of numeric, optional
         Wavelengths at which spectral response values are generated.
         By default ``wavelength`` is from 280 to 1200 in 5 nm intervals. [nm]
 
@@ -89,13 +89,13 @@ def get_am15g(wavelength=None):
 
     Parameters
     ----------
-    wavelength: 1-D sequence of numeric, optional
+    wavelength : 1-D sequence of numeric, optional
         Wavelengths at which the spectrum is interpolated.
         By default the 2002 wavelengths of the standard are returned. [nm]
 
     Returns
     -------
-    am15g: pandas.Series
+    am15g : pandas.Series
         The AM1.5g standard spectrum indexed by ``wavelength``. [(W/m^2)/nm]
 
     Notes
@@ -147,24 +147,24 @@ def calc_spectral_mismatch_field(sr, e_sun, e_ref=None):
 
     Parameters
     ----------
-    sr: pandas.Series
+    sr : pandas.Series
         The relative spectral response of one (photovoltaic) test device.
         The index of the Series must contain wavelength values in nm. [-]
 
-    e_sun: pandas.DataFrame or pandas.Series
+    e_sun : pandas.DataFrame or pandas.Series
         One or more measured solar irradiance spectra in a pandas.DataFrame
         having wavelength in nm as column index.  A single spectrum may be
         be given as a pandas.Series having wavelength in nm as index.
         [(W/m^2)/nm]
 
-    e_ref: pandas.Series, optional
+    e_ref : pandas.Series, optional
         The reference spectrum to use for the mismatch calculation.
         The index of the Series must contain wavelength values in nm.
         The default is the ASTM G173-03 global tilted spectrum. [(W/m^2)/nm]
 
     Returns
     -------
-    smm: pandas.Series or float if a single measured spectrum is provided. [-]
+    smm : pandas.Series or float if a single measured spectrum is provided. [-]
 
     Notes
     -----
@@ -323,7 +323,7 @@ def spectral_factor_firstsolar(precipitable_water, airmass_absolute,
 
     Returns
     -------
-    modifier: array-like
+    modifier : array-like
         spectral mismatch factor (unitless) which can be multiplied
         with broadband irradiance reaching a module's cells to estimate
         effective irradiance, i.e., the irradiance that is converted to
@@ -494,7 +494,7 @@ def spectral_factor_caballero(precipitable_water, airmass_absolute, aod500,
 
     Returns
     -------
-    modifier: numeric
+    modifier : numeric
         spectral mismatch factor (unitless) which is multiplied
         with broadband irradiance reaching a module's cells to estimate
         effective irradiance, i.e., the irradiance that is converted to

--- a/pvlib/spectrum/spectrl2.py
+++ b/pvlib/spectrum/spectrl2.py
@@ -99,11 +99,11 @@ def _spectrl2_transmittances(apparent_zenith, relative_airmass,
 
     Returns
     -------
-    earth_sun_distance_correction: float or 1d np.array
+    earth_sun_distance_correction : float or 1d np.array
         Same shape/type as apparent_zenith
     rayleigh_transmittance, aerosol_transmittance, vapor_transmittance,
     ozone_transmittance, mixed_transmittance, aerosol_scattering,
-    aerosol_absorption: np.ndarray
+    aerosol_absorption : np.ndarray
         Array with shape (122, N) where N is len(apparent_zenith)
     """
     # add a dimension so that each ndarray is 2d with shape (122, 1)

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -131,7 +131,7 @@ def sapm_cell(poa_global, temp_air, wind_speed, a, b, deltaT,
        Model", SAND Report 3535, Sandia National Laboratories, Albuquerque,
        NM.
 
-    See also
+    See Also
     --------
     sapm_cell_from_module
     sapm_module
@@ -212,7 +212,7 @@ def sapm_module(poa_global, temp_air, wind_speed, a, b):
        Model", SAND Report 3535, Sandia National Laboratories, Albuquerque,
        NM.
 
-    See also
+    See Also
     --------
     sapm_cell
     sapm_cell_from_module
@@ -282,7 +282,7 @@ def sapm_cell_from_module(module_temperature, poa_global, deltaT,
        Model", SAND Report 3535, Sandia National Laboratories, Albuquerque,
        NM.
 
-    See also
+    See Also
     --------
     sapm_cell
     sapm_module
@@ -439,7 +439,7 @@ def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
     .. [3] "IEC 61853-3 Photovoltaic (PV) module performance testing and energy
        rating - Part 3: Energy rating of PV modules". IEC, Geneva, 2018.
 
-    See also
+    See Also
     --------
     pvlib.temperature.faiman_rad
 
@@ -545,7 +545,7 @@ def faiman_rad(poa_global, temp_air, wind_speed=1.0, ir_down=None,
        Models by Incorporating Radiative Losses to the Sky". SAND2022-11604.
        :doi:`10.2172/1884890`
 
-    See also
+    See Also
     --------
     pvlib.temperature.faiman
 
@@ -1133,7 +1133,7 @@ def generic_linear(poa_global, temp_air, wind_speed, u_const, du_wind,
        Model Equivalence and Parameter Translation". 2022 IEEE
        Photovoltaic Specialists Conference (PVSC), 2022.
 
-    See also
+    See Also
     --------
     pvlib.temperature.GenericLinearModel
     """
@@ -1203,7 +1203,7 @@ class GenericLinearModel():
     >>> pvsyst_cell(800, 20, 1, **parmdict)
     53.33333333333333
 
-    See also
+    See Also
     --------
     pvlib.temperature.generic_linear
     '''
@@ -1248,7 +1248,7 @@ class GenericLinearModel():
         -------
         numeric, values in degrees Celsius
 
-        See also
+        See Also
         --------
         get_generic
         pvlib.temperature.generic_linear
@@ -1269,7 +1269,7 @@ class GenericLinearModel():
         -------
         model_parameters : dict
 
-        See also
+        See Also
         --------
         pvlib.temperature.generic_linear
         '''

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -872,7 +872,7 @@ def noct_sam(poa_global, temp_air, wind_speed, noct, module_efficiency,
         :math:`\eta_{m} = \frac{V_{mp} I_{mp}}{A \times 1000 W/m^2}`
         where A is module area [m^2].
 
-    effective_irradiance : numeric, default None
+    effective_irradiance : numeric, optional
         The irradiance that is converted to photocurrent. If None,
         assumed equal to poa_global. [W/m^2]
 

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -872,7 +872,7 @@ def noct_sam(poa_global, temp_air, wind_speed, noct, module_efficiency,
         :math:`\eta_{m} = \frac{V_{mp} I_{mp}}{A \times 1000 W/m^2}`
         where A is module area [m^2].
 
-    effective_irradiance : numeric, default None.
+    effective_irradiance : numeric, default None
         The irradiance that is converted to photocurrent. If None,
         assumed equal to poa_global. [W/m^2]
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -767,10 +767,10 @@ def _calcparams_correct_Python_type_check(out_value, numeric_args):
 
     Parameters
     ----------
-    out_value: numeric
+    out_value : numeric
         A value returned by a pvsystem.calcparams_ function.
 
-    numeric_args: numeric
+    numeric_args : numeric
         An iterable of the numeric-type arguments to the
         pvsystem.calcparams_ functions:
         ``effective_irradiance`` and ``temp_cell``.

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -771,8 +771,9 @@ def _calcparams_correct_Python_type_check(out_value, numeric_args):
         A value returned by a pvsystem.calcparams_ function.
 
     numeric_args: numeric
-        An iterable of the numeric-type arguments to the pvsystem.calcparams_
-        functions: ``effective_irradiance`` and ``temp_cell``.
+        An iterable of the numeric-type arguments to the
+        pvsystem.calcparams_ functions:
+        ``effective_irradiance`` and ``temp_cell``.
 
     Returns
     -------

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import itertools
 
 import numpy as np
 from numpy import nan, array
@@ -738,28 +739,220 @@ def test_Array__infer_cell_type():
     assert array._infer_cell_type() is None
 
 
+def _calcparams_correct_Python_type_numeric_type_cases():
+    """
+    An auxilary function used in the unit tests named
+    ``test_calcparams_*_returns_correct_Python_type``.
+
+    Returns
+    -------
+        Returns a list of tuples of functions intended for transforming a
+        Python scalar into a numeric type: scalar, np.ndarray, or pandas.Series
+    """
+    return list(itertools.product(*(2 * [[
+        # scalars (e.g. Python floats)
+        lambda x: x,
+        # np.ndarrays (0d and 1d-arrays)
+        np.array,
+        lambda x: np.array([x]),
+        # pd.Series (1d-arrays)
+        pd.Series
+    ]])))
+
+
+def _calcparams_correct_Python_type_check(out_value, numeric_args):
+    """
+    An auxilary function used in the unit tests named
+    ``test_calcparams_*_returns_correct_Python_type``.
+
+    Parameters
+    ----------
+    out_value: numeric
+        A value returned by a pvsystem.calcparams_ function.
+
+    numeric_args: numeric
+        An iterable of the numeric-type arguments to the pvsystem.calcparams_
+        functions: ``effective_irradiance`` and ``temp_cell``.
+
+    Returns
+    -------
+        bool indicating whether ``out_value`` has the correct Python type
+        based on the Python types of ``effective_irradiance`` and
+        ``temp_cell``.
+    """
+    if any(isinstance(a, pd.Series) for a in numeric_args):
+        return isinstance(out_value, pd.Series)
+    elif any(isinstance(a, np.ndarray) for a in numeric_args):
+        return isinstance(out_value, np.ndarray)  # 0d or 1d-arrays
+    return np.isscalar(out_value)
+
+
+@pytest.mark.parametrize('numeric_type_funcs',
+                         _calcparams_correct_Python_type_numeric_type_cases())
+def test_calcparams_desoto_returns_correct_Python_type(numeric_type_funcs,
+                                                       cec_module_params):
+    numeric_args = dict(
+        effective_irradiance=numeric_type_funcs[0](800.0),
+        temp_cell=numeric_type_funcs[1](25),
+    )
+    out = pvsystem.calcparams_desoto(
+        **numeric_args,
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
+
+    assert all(_calcparams_correct_Python_type_check(a, numeric_args.values())
+               for a in out)
+
+
+@pytest.mark.parametrize('numeric_type_funcs',
+                         _calcparams_correct_Python_type_numeric_type_cases())
+def test_calcparams_cec_returns_correct_Python_type(numeric_type_funcs,
+                                                    cec_module_params):
+    numeric_args = dict(
+        effective_irradiance=numeric_type_funcs[0](800.0),
+        temp_cell=numeric_type_funcs[1](25),
+    )
+    out = pvsystem.calcparams_cec(
+        **numeric_args,
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        Adjust=cec_module_params['Adjust'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
+
+    assert all(_calcparams_correct_Python_type_check(a, numeric_args.values())
+               for a in out)
+
+
+@pytest.mark.parametrize('numeric_type_funcs',
+                         _calcparams_correct_Python_type_numeric_type_cases())
+def test_calcparams_pvsyst_returns_correct_Python_type(numeric_type_funcs,
+                                                       pvsyst_module_params):
+    numeric_args = dict(
+        effective_irradiance=numeric_type_funcs[0](800.0),
+        temp_cell=numeric_type_funcs[1](25),
+    )
+    out = pvsystem.calcparams_pvsyst(
+        **numeric_args,
+        alpha_sc=pvsyst_module_params['alpha_sc'],
+        gamma_ref=pvsyst_module_params['gamma_ref'],
+        mu_gamma=pvsyst_module_params['mu_gamma'],
+        I_L_ref=pvsyst_module_params['I_L_ref'],
+        I_o_ref=pvsyst_module_params['I_o_ref'],
+        R_sh_ref=pvsyst_module_params['R_sh_ref'],
+        R_sh_0=pvsyst_module_params['R_sh_0'],
+        R_s=pvsyst_module_params['R_s'],
+        cells_in_series=pvsyst_module_params['cells_in_series'],
+        EgRef=pvsyst_module_params['EgRef']
+    )
+
+    assert all(_calcparams_correct_Python_type_check(a, numeric_args.values())
+               for a in out)
+
+
+def test_calcparams_desoto_all_scalars(cec_module_params):
+    IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
+        effective_irradiance=800.0,
+        temp_cell=25,
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
+
+    assert np.isclose(IL, 6.036, atol=1e-4, rtol=0)
+    assert np.isclose(I0, 1.94e-9, atol=1e-4, rtol=0)
+    assert np.isclose(Rs, 0.094, atol=1e-4, rtol=0)
+    assert np.isclose(Rsh, 19.65, atol=1e-4, rtol=0)
+    assert np.isclose(nNsVth, 0.473, atol=1e-4, rtol=0)
+
+
+def test_calcparams_cec_all_scalars(cec_module_params):
+    IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_cec(
+        effective_irradiance=800.0,
+        temp_cell=25,
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        Adjust=cec_module_params['Adjust'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
+
+    assert np.isclose(IL, 6.036, atol=1e-4, rtol=0)
+    assert np.isclose(I0, 1.94e-9, atol=1e-4, rtol=0)
+    assert np.isclose(Rs, 0.094, atol=1e-4, rtol=0)
+    assert np.isclose(Rsh, 19.65, atol=1e-4, rtol=0)
+    assert np.isclose(nNsVth, 0.473, atol=1e-4, rtol=0)
+
+
+def test_calcparams_pvsyst_all_scalars(pvsyst_module_params):
+    IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_pvsyst(
+        effective_irradiance=800.0,
+        temp_cell=50,
+        alpha_sc=pvsyst_module_params['alpha_sc'],
+        gamma_ref=pvsyst_module_params['gamma_ref'],
+        mu_gamma=pvsyst_module_params['mu_gamma'],
+        I_L_ref=pvsyst_module_params['I_L_ref'],
+        I_o_ref=pvsyst_module_params['I_o_ref'],
+        R_sh_ref=pvsyst_module_params['R_sh_ref'],
+        R_sh_0=pvsyst_module_params['R_sh_0'],
+        R_s=pvsyst_module_params['R_s'],
+        cells_in_series=pvsyst_module_params['cells_in_series'],
+        EgRef=pvsyst_module_params['EgRef'])
+
+    assert np.isclose(IL, 4.8200, atol=1e-4, rtol=0)
+    assert np.isclose(I0, 1.47e-7, atol=1e-4, rtol=0)
+    assert np.isclose(Rs, 0.500, atol=1e-4, rtol=0)
+    assert np.isclose(Rsh, 305.757, atol=1e-4, rtol=0)
+    assert np.isclose(nNsVth, 1.7961, atol=1e-4, rtol=0)
+
+
 def test_calcparams_desoto(cec_module_params):
     times = pd.date_range(start='2015-01-01', periods=3, freq='12H')
-    effective_irradiance = pd.Series([0.0, 800.0, 800.0], index=times)
-    temp_cell = pd.Series([25, 25, 50], index=times)
+    df = pd.DataFrame({
+        'effective_irradiance': [0.0, 800.0, 800.0],
+        'temp_cell': [25, 25, 50]
+    }, index=times)
 
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_desoto(
-                                  effective_irradiance,
-                                  temp_cell,
-                                  alpha_sc=cec_module_params['alpha_sc'],
-                                  a_ref=cec_module_params['a_ref'],
-                                  I_L_ref=cec_module_params['I_L_ref'],
-                                  I_o_ref=cec_module_params['I_o_ref'],
-                                  R_sh_ref=cec_module_params['R_sh_ref'],
-                                  R_s=cec_module_params['R_s'],
-                                  EgRef=1.121,
-                                  dEgdT=-0.0002677)
+        df['effective_irradiance'],
+        df['temp_cell'],
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
 
     assert_series_equal(IL, pd.Series([0.0, 6.036, 6.096], index=times),
                         check_less_precise=3)
     assert_series_equal(I0, pd.Series([0.0, 1.94e-9, 7.419e-8], index=times),
                         check_less_precise=3)
-    assert_allclose(Rs, 0.094)
+    assert_series_equal(Rs, pd.Series([0.094, 0.094, 0.094], index=times),
+                        check_less_precise=3)
     assert_series_equal(Rsh, pd.Series([np.inf, 19.65, 19.65], index=times),
                         check_less_precise=3)
     assert_series_equal(nNsVth, pd.Series([0.473, 0.473, 0.5127], index=times),
@@ -768,27 +961,31 @@ def test_calcparams_desoto(cec_module_params):
 
 def test_calcparams_cec(cec_module_params):
     times = pd.date_range(start='2015-01-01', periods=3, freq='12H')
-    effective_irradiance = pd.Series([0.0, 800.0, 800.0], index=times)
-    temp_cell = pd.Series([25, 25, 50], index=times)
+    df = pd.DataFrame({
+        'effective_irradiance': [0.0, 800.0, 800.0],
+        'temp_cell': [25, 25, 50]
+    }, index=times)
 
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_cec(
-                                  effective_irradiance,
-                                  temp_cell,
-                                  alpha_sc=cec_module_params['alpha_sc'],
-                                  a_ref=cec_module_params['a_ref'],
-                                  I_L_ref=cec_module_params['I_L_ref'],
-                                  I_o_ref=cec_module_params['I_o_ref'],
-                                  R_sh_ref=cec_module_params['R_sh_ref'],
-                                  R_s=cec_module_params['R_s'],
-                                  Adjust=cec_module_params['Adjust'],
-                                  EgRef=1.121,
-                                  dEgdT=-0.0002677)
+        df['effective_irradiance'],
+        df['temp_cell'],
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        Adjust=cec_module_params['Adjust'],
+        EgRef=1.121,
+        dEgdT=-0.0002677
+    )
 
     assert_series_equal(IL, pd.Series([0.0, 6.036, 6.0896], index=times),
                         check_less_precise=3)
     assert_series_equal(I0, pd.Series([0.0, 1.94e-9, 7.419e-8], index=times),
                         check_less_precise=3)
-    assert_allclose(Rs, 0.094)
+    assert_series_equal(Rs, pd.Series([0.094, 0.094, 0.094], index=times),
+                        check_less_precise=3)
     assert_series_equal(Rsh, pd.Series([np.inf, 19.65, 19.65], index=times),
                         check_less_precise=3)
     assert_series_equal(nNsVth, pd.Series([0.473, 0.473, 0.5127], index=times),
@@ -834,12 +1031,14 @@ def test_calcparams_cec_extra_params_propagation(cec_module_params, mocker):
 
 def test_calcparams_pvsyst(pvsyst_module_params):
     times = pd.date_range(start='2015-01-01', periods=2, freq='12H')
-    effective_irradiance = pd.Series([0.0, 800.0], index=times)
-    temp_cell = pd.Series([25, 50], index=times)
+    df = pd.DataFrame({
+        'effective_irradiance': [0.0, 800.0],
+        'temp_cell': [25, 50]
+    }, index=times)
 
     IL, I0, Rs, Rsh, nNsVth = pvsystem.calcparams_pvsyst(
-        effective_irradiance,
-        temp_cell,
+        df['effective_irradiance'],
+        df['temp_cell'],
         alpha_sc=pvsyst_module_params['alpha_sc'],
         gamma_ref=pvsyst_module_params['gamma_ref'],
         mu_gamma=pvsyst_module_params['mu_gamma'],
@@ -855,7 +1054,8 @@ def test_calcparams_pvsyst(pvsyst_module_params):
         IL.round(decimals=3), pd.Series([0.0, 4.8200], index=times))
     assert_series_equal(
         I0.round(decimals=3), pd.Series([0.0, 1.47e-7], index=times))
-    assert_allclose(Rs, 0.500)
+    assert_series_equal(
+        Rs.round(decimals=3), pd.Series([0.500, 0.500], index=times))
     assert_series_equal(
         Rsh.round(decimals=3), pd.Series([1000.0, 305.757], index=times))
     assert_series_equal(
@@ -873,21 +1073,23 @@ def test_PVSystem_calcparams_desoto(cec_module_params, mocker):
     IL, I0, Rs, Rsh, nNsVth = system.calcparams_desoto(effective_irradiance,
                                                        temp_cell)
     pvsystem.calcparams_desoto.assert_called_once_with(
-                                  effective_irradiance,
-                                  temp_cell,
-                                  alpha_sc=cec_module_params['alpha_sc'],
-                                  a_ref=cec_module_params['a_ref'],
-                                  I_L_ref=cec_module_params['I_L_ref'],
-                                  I_o_ref=cec_module_params['I_o_ref'],
-                                  R_sh_ref=cec_module_params['R_sh_ref'],
-                                  R_s=cec_module_params['R_s'],
-                                  EgRef=module_parameters['EgRef'],
-                                  dEgdT=module_parameters['dEgdT'])
+        effective_irradiance,
+        temp_cell,
+        alpha_sc=cec_module_params['alpha_sc'],
+        a_ref=cec_module_params['a_ref'],
+        I_L_ref=cec_module_params['I_L_ref'],
+        I_o_ref=cec_module_params['I_o_ref'],
+        R_sh_ref=cec_module_params['R_sh_ref'],
+        R_s=cec_module_params['R_s'],
+        EgRef=module_parameters['EgRef'],
+        dEgdT=module_parameters['dEgdT']
+    )
+
     assert_allclose(IL, np.array([0.0, 6.036]), atol=1)
-    assert_allclose(I0, 2.0e-9, atol=1.0e-9)
-    assert_allclose(Rs, 0.1, atol=0.1)
+    assert_allclose(I0, np.array([2.0e-9, 2.0e-9]), atol=1.0e-9)
+    assert_allclose(Rs, np.array([0.1, 0.1]), atol=0.1)
     assert_allclose(Rsh, np.array([np.inf, 20]), atol=1)
-    assert_allclose(nNsVth, 0.5, atol=0.1)
+    assert_allclose(nNsVth, np.array([0.5, 0.5]), atol=0.1)
 
 
 def test_PVSystem_calcparams_pvsyst(pvsyst_module_params, mocker):
@@ -899,23 +1101,24 @@ def test_PVSystem_calcparams_pvsyst(pvsyst_module_params, mocker):
     IL, I0, Rs, Rsh, nNsVth = system.calcparams_pvsyst(effective_irradiance,
                                                        temp_cell)
     pvsystem.calcparams_pvsyst.assert_called_once_with(
-                                  effective_irradiance,
-                                  temp_cell,
-                                  alpha_sc=pvsyst_module_params['alpha_sc'],
-                                  gamma_ref=pvsyst_module_params['gamma_ref'],
-                                  mu_gamma=pvsyst_module_params['mu_gamma'],
-                                  I_L_ref=pvsyst_module_params['I_L_ref'],
-                                  I_o_ref=pvsyst_module_params['I_o_ref'],
-                                  R_sh_ref=pvsyst_module_params['R_sh_ref'],
-                                  R_sh_0=pvsyst_module_params['R_sh_0'],
-                                  R_s=pvsyst_module_params['R_s'],
-                    cells_in_series=pvsyst_module_params['cells_in_series'],
-                                  EgRef=pvsyst_module_params['EgRef'],
-                                  R_sh_exp=pvsyst_module_params['R_sh_exp'])
+        effective_irradiance,
+        temp_cell,
+        alpha_sc=pvsyst_module_params['alpha_sc'],
+        gamma_ref=pvsyst_module_params['gamma_ref'],
+        mu_gamma=pvsyst_module_params['mu_gamma'],
+        I_L_ref=pvsyst_module_params['I_L_ref'],
+        I_o_ref=pvsyst_module_params['I_o_ref'],
+        R_sh_ref=pvsyst_module_params['R_sh_ref'],
+        R_sh_0=pvsyst_module_params['R_sh_0'],
+        R_s=pvsyst_module_params['R_s'],
+        cells_in_series=pvsyst_module_params['cells_in_series'],
+        EgRef=pvsyst_module_params['EgRef'],
+        R_sh_exp=pvsyst_module_params['R_sh_exp']
+    )
 
     assert_allclose(IL, np.array([0.0, 4.8200]), atol=1)
     assert_allclose(I0, np.array([0.0, 1.47e-7]), atol=1.0e-5)
-    assert_allclose(Rs, 0.5, atol=0.1)
+    assert_allclose(Rs, np.array([0.5, 0.5]), atol=0.1)
     assert_allclose(Rsh, np.array([1000, 305.757]), atol=50)
     assert_allclose(nNsVth, np.array([1.6186, 1.7961]), atol=0.1)
 

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -74,10 +74,10 @@ def build_precise_iv_curve_dataframe(file_csv, file_json):
 
     Parameters
     ----------
-    file_csv: str
+    file_csv : str
         Path to a CSV file of IV curve parameter sets.
 
-    file_json: str
+    file_json : str
         Path to a JSON file of precise IV curves.
 
     Returns

--- a/pvlib/tests/test_tools.py
+++ b/pvlib/tests/test_tools.py
@@ -2,6 +2,7 @@ import pytest
 
 from pvlib import tools
 import numpy as np
+import pandas as pd
 
 
 @pytest.mark.parametrize('keys, input_dict, expected', [
@@ -95,3 +96,27 @@ def test_degrees_to_index_1():
     'latitude' or 'longitude' is passed."""
     with pytest.raises(IndexError):  # invalid value for coordinate argument
         tools._degrees_to_index(degrees=22.0, coordinate='width')
+
+
+@pytest.mark.parametrize('args, args_idx', [
+    # no pandas.Series or pandas.DataFrame args
+    ((1,), None),
+    (([1],), None),
+    ((np.array(1),), None),
+    ((np.array([1]),), None),
+    # has pandas.Series or pandas.DataFrame args
+    ((pd.DataFrame([1], index=[1]),), 0),
+    ((pd.Series([1], index=[1]),), 0),
+    ((1, pd.Series([1], index=[1]),), 1),
+    ((1, pd.DataFrame([1], index=[1]),), 1),
+    # first pandas.Series or pandas.DataFrame is used
+    ((1, pd.Series([1], index=[1]), pd.DataFrame([2], index=[2]),), 1),
+    ((1, pd.DataFrame([1], index=[1]), pd.Series([2], index=[2]),), 1),
+])
+def test_get_pandas_index(args, args_idx):
+    index = tools.get_pandas_index(*args)
+
+    if args_idx is None:
+        assert index is None
+    else:
+        pd.testing.assert_index_equal(args[args_idx].index, index)

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -310,15 +310,15 @@ def _golden_sect_DataFrame(params, lower, upper, func, atol=1e-8):
         Parameters to be passed to `func`. Each entry must be of the same
         length.
 
-    lower: numeric
+    lower : numeric
         Lower bound for the optimization. Must be the same length as each
         entry of params.
 
-    upper: numeric
+    upper : numeric
         Upper bound for the optimization. Must be the same length as each
         entry of params.
 
-    func: function
+    func : function
         Function to be optimized. Must be in the form
         result = f(dict or DataFrame, str), where result is a dict or DataFrame
         that also contains the function output, and str is the key
@@ -481,7 +481,7 @@ def get_pandas_index(*args):
 
     Parameters
     ----------
-    args: positional arguments
+    args : positional arguments
         The numeric values to scan for a pandas index.
 
     Returns

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -472,3 +472,25 @@ def _first_order_centered_difference(f, x0, dx=DX, args=()):
     # removal in scipy 1.12.0
     df = f(x0+dx, *args) - f(x0-dx, *args)
     return df / 2 / dx
+
+
+def get_pandas_index(*args):
+    """
+    Get the index of the first pandas DataFrame or Series in a list of
+    arguments.
+
+    Parameters
+    ----------
+    args: positional arguments
+        The numeric values to scan for a pandas index.
+
+    Returns
+    -------
+    A pandas index or None
+        None is returned if there are no pandas DataFrames or Series in the
+        args list.
+    """
+    return next(
+        (a.index for a in args if isinstance(a, (pd.DataFrame, pd.Series))),
+        None
+    )

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -337,7 +337,7 @@ def _golden_sect_DataFrame(params, lower, upper, func, atol=1e-8):
     This function will find the points where the function is maximized.
     Returns nan where lower or upper is nan, or where func evaluates to nan.
 
-    See also
+    See Also
     --------
     pvlib.singlediode._pwr_optfcn
     """

--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -89,7 +89,7 @@ def singleaxis(apparent_zenith, apparent_azimuth,
           projecting the vector normal to the panel's surface to the earth's
           surface. [degrees]
 
-    See also
+    See Also
     --------
     pvlib.tracking.calc_axis_tilt
     pvlib.tracking.calc_cross_axis_tilt
@@ -287,7 +287,7 @@ def calc_axis_tilt(slope_azimuth, slope_tilt, axis_azimuth):
     axis_tilt : float
         tilt of tracker [degrees]
 
-    See also
+    See Also
     --------
     pvlib.tracking.singleaxis
     pvlib.tracking.calc_cross_axis_tilt
@@ -396,7 +396,7 @@ def calc_cross_axis_tilt(
         between the slope containing the tracker axes and a plane perpendicular
         to the tracker axes [degrees]
 
-    See also
+    See Also
     --------
     pvlib.tracking.singleaxis
     pvlib.tracking.calc_axis_tilt


### PR DESCRIPTION
 - [x] Closes #1574 among other updates. See bottom of PR body.
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] Current code includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments everywhere.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I just want the docstrings to be homogeneus and compliant with numpydoc.

## Changes in this PR
1. Adds a space before colon in parameters and returns
  `solar_azimuth: numeric` -> `solar_azimuth : numeric`
1. Changes excessive use of parentheses in defaults
  `return_components : bool (optional, default=False)` -> `return_components : bool, default False`
1. Removes colon when default is to be specified
  `logical_records : list or tuple, default: ('0100',)` -> `logical_records : list or tuple, default ('0100',)`
1. default None -> optional (#1574)
2. `See also` -> `See Also`