### PR TITLE
Change read_tmy3 parameter input order

### DIFF
--- a/pvlib/iotools/tmy.py
+++ b/pvlib/iotools/tmy.py
@@ -24,8 +24,8 @@ VARIABLE_MAP = {
 }
 
 
-def read_tmy3(filename, coerce_year=None, map_variables=None, recolumn=None,
-              encoding=None):
+def read_tmy3(filename, coerce_year=None, recolumn=None, encoding=None,
+              map_variables=None):
     """Read a TMY3 file into a pandas dataframe.
 
     Note that values contained in the metadata dictionary are unchanged
@@ -44,9 +44,6 @@ def read_tmy3(filename, coerce_year=None, map_variables=None, recolumn=None,
         If supplied, the year of the index will be set to `coerce_year`, except
         for the last index value which will be set to the *next* year so that
         the index increases monotonically.
-    map_variables : bool, default None
-        When True, renames columns of the DataFrame to pvlib variable names
-        where applicable. See variable :const:`VARIABLE_MAP`.
     recolumn : bool (deprecated, use map_variables instead)
         If ``True``, apply standard names to TMY3 columns. Typically this
         results in stripping the units from the column name.
@@ -56,6 +53,9 @@ def read_tmy3(filename, coerce_year=None, map_variables=None, recolumn=None,
         be necessary to specify an alternative encoding, e.g., for
         SolarAnywhere TMY3 files the encoding should be 'iso-8859-1'. Users
         may also consider using the 'utf-8-sig' encoding.
+    map_variables : bool, default None
+        When True, renames columns of the DataFrame to pvlib variable names
+        where applicable. See variable :const:`VARIABLE_MAP`.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Based on this https://github.com/pvlib/pvlib-python/pull/1779#discussion_r1243756573, it seems there is consensus that the `map_variable` parameter should be the last or second to last input parameters. This PR updates this for the `read_tmy3` function (variable mapping of `read_tmy3` has yet to be officially released, hence this PR is not a breaking change).