### PR TITLE
Replace `pvfactors` with `solarfactors`

### DIFF
--- a/ci/requirements-py3.10.yml
+++ b/ci/requirements-py3.10.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        - pvfactors==1.5.2
+        - solarfactors

--- a/ci/requirements-py3.11.yml
+++ b/ci/requirements-py3.11.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        - pvfactors==1.5.2
+        - solarfactors

--- a/ci/requirements-py3.7.yml
+++ b/ci/requirements-py3.7.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        - pvfactors==1.5.2
+        - solarfactors

--- a/ci/requirements-py3.8.yml
+++ b/ci/requirements-py3.8.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        - pvfactors==1.5.2
+        - solarfactors

--- a/ci/requirements-py3.9.yml
+++ b/ci/requirements-py3.9.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        - pvfactors==1.5.2
+        - solarfactors

--- a/docs/examples/bifacial/plot_bifi_model_mc.py
+++ b/docs/examples/bifacial/plot_bifi_model_mc.py
@@ -18,6 +18,13 @@ Example of bifacial modeling using pvfactors and ModelChain
 #
 # Future versions of pvlib may make it easier to do bifacial modeling
 # with ``ModelChain``.
+#
+# .. attention::
+#    To run this example, the ``solarfactors`` package (an implementation
+#    of the pvfactors model) must be installed.  It can be installed with
+#    either ``pip install solarfactors`` or ``pip install pvlib[optional]``,
+#    which installs all of pvlib's optional dependencies.
+
 
 import pandas as pd
 from pvlib import pvsystem

--- a/docs/examples/bifacial/plot_bifi_model_pvwatts.py
+++ b/docs/examples/bifacial/plot_bifi_model_pvwatts.py
@@ -10,6 +10,12 @@ Example of bifacial modeling using pvfactors and procedural method
 # :py:func:`pvlib.pvsystem.pvwatts_dc` with the
 # :py:func:`pvlib.bifacial.pvfactors.pvfactors_timeseries` function to
 # transpose GHI data to both front and rear Plane of Array (POA) irradiance.
+#
+# .. attention::
+#    To run this example, the ``solarfactors`` package (an implementation
+#    of the pvfactors model) must be installed.  It can be installed with
+#    either ``pip install solarfactors`` or ``pip install pvlib[optional]``,
+#    which installs all of pvlib's optional dependencies.
 
 import pandas as pd
 from pvlib import location

--- a/docs/examples/bifacial/plot_pvfactors_fixed_tilt.py
+++ b/docs/examples/bifacial/plot_pvfactors_fixed_tilt.py
@@ -11,6 +11,12 @@ Modeling the irradiance on the rear side of a fixed-tilt array.
 # fixed-tilt systems correctly.
 # This example shows how to model rear-side irradiance on a fixed-tilt
 # array using :py:func:`pvlib.bifacial.pvfactors.pvfactors_timeseries`.
+#
+# .. attention::
+#    To run this example, the ``solarfactors`` package (an implementation
+#    of the pvfactors model) must be installed.  It can be installed with
+#    either ``pip install solarfactors`` or ``pip install pvlib[optional]``,
+#    which installs all of pvlib's optional dependencies.
 
 import pandas as pd
 from pvlib import location

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -297,7 +297,8 @@ extlinks = {
     'pull': ('https://github.com/pvlib/pvlib-python/pull/%s', 'GH'),
     'wiki': ('https://github.com/pvlib/pvlib-python/wiki/%s', 'wiki '),
     'doi': ('http://dx.doi.org/%s', 'DOI: '),
-    'ghuser': ('https://github.com/%s', '@')
+    'ghuser': ('https://github.com/%s', '@'),
+    'discuss': ('https://github.com/pvlib/pvlib-python/discussions/%s', 'GH'),
 }
 
 # -- Options for manual page output ---------------------------------------

--- a/docs/sphinx/source/user_guide/bifacial.rst
+++ b/docs/sphinx/source/user_guide/bifacial.rst
@@ -15,7 +15,7 @@ surfaces.
 pvlib-python provides two groups of functions for estimating front and back
 irradiance:
 
-1. a wrapper for convenient use of the pvfactors package:
+1. a wrapper for convenient use of the pvfactors model:
 :py:func:`~pvlib.bifacial.pvfactors.pvfactors_timeseries`
 
 2. the infinite sheds bifacial model:
@@ -26,12 +26,22 @@ irradiance:
 pvfactors
 ---------
 
-The `pvfactors <https://sunpower.github.io/pvfactors/>`_ package calculates
+The pvfactors model calculates
 incident irradiance on the front and back surfaces of an array. pvfactors uses
 a 2D geometry which assumes that the array is made up of long, regular rows.
 Irradiance is calculated in the middle of a row; end-of-row effects are not
 included. pvfactors can model arrays in fixed racking or on single-axis
-trackers.
+trackers with a user-configurable number of rows.
+
+Prior to pvlib version 0.10.1, pvlib used the original SunPower implementation
+of the model via the `pvfactors <https://github.com/sunpower/pvfactors>`_
+package.  Starting in version 0.10.1, pvlib instead uses
+`solarfactors <https://github.com/pvlib/solarfactors>`_, a drop-in
+replacement for ``pvfactors`` maintained by the pvlib community.
+``solarfactors`` implements the same model as ``pvfactors`` and is kept
+up to date and working over time.  Note that for backwards compatibility,
+``pip install solarfactors`` installs a package that is still accessed in code
+with the original ``import pvfactors``.
 
 
 Infinite Sheds

--- a/docs/sphinx/source/user_guide/bifacial.rst
+++ b/docs/sphinx/source/user_guide/bifacial.rst
@@ -37,11 +37,14 @@ Prior to pvlib version 0.10.1, pvlib used the original SunPower implementation
 of the model via the `pvfactors <https://github.com/sunpower/pvfactors>`_
 package.  Starting in version 0.10.1, pvlib instead uses
 `solarfactors <https://github.com/pvlib/solarfactors>`_, a drop-in
-replacement for ``pvfactors`` maintained by the pvlib community.
+replacement implementation maintained by the pvlib community.
+This switch was made when the original ``pvfactors`` package became
+difficult to install in modern python environments.
 ``solarfactors`` implements the same model as ``pvfactors`` and is kept
-up to date and working over time.  Note that for backwards compatibility,
-``pip install solarfactors`` installs a package that is still accessed in code
-with the original ``import pvfactors``.
+up to date and working over time.  Note that "solarfactors" is only the name
+on PyPI (meaning it is installed via ``pip install solarfactors``);
+after installation, Python code still accesses it as "pvfactors"
+(e.g. ``import pvfactors``).
 
 
 Infinite Sheds

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.10.1.rst
 .. include:: whatsnew/v0.10.0.rst
 .. include:: whatsnew/v0.9.5.rst
 .. include:: whatsnew/v0.9.4.rst

--- a/docs/sphinx/source/whatsnew/v0.10.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.1.rst
@@ -1,34 +1,12 @@
 .. _whatsnew_01010:
 
 
-v0.10.1 (Anticipated September, 2023)
--------------------------------------
+v0.10.1 (July 3, 2023)
+----------------------
 
-
-Deprecations
-~~~~~~~~~~~~
-
-
-Enhancements
-~~~~~~~~~~~~
-
-
-Bug fixes
-~~~~~~~~~
-
-
-Testing
-~~~~~~~
-
-
-Documentation
-~~~~~~~~~~~~~
-
-
-Requirements
-~~~~~~~~~~~~
-
-
-Contributors
-~~~~~~~~~~~~
+To resolve an installation issue with ``pvfactors`` and ``shapely``,
+this release drops the optional ``pvfactors`` dependency and replaces
+it with ``solarfactors``, a fork of ``pvfactors`` maintained by the
+pvlib community.  This change should not affect any user code.
+(:issue:`1796`, :pull:`1797`, :discuss:`1657`)
 

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -1,0 +1,34 @@
+.. _whatsnew_01020:
+
+
+v0.10.2 (Anticipated September, 2023)
+-------------------------------------
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+

--- a/pvlib/bifacial/pvfactors.py
+++ b/pvlib/bifacial/pvfactors.py
@@ -1,6 +1,7 @@
 """
 The ``bifacial.pvfactors`` module contains functions for modeling back surface
-plane-of-array irradiance using the pvfactors package.
+plane-of-array irradiance using an external implementaton of the pvfactors
+model (either ``solarfactors`` or the original ``pvfactors``).
 """
 
 import pandas as pd
@@ -15,11 +16,10 @@ def pvfactors_timeseries(
         horizon_band_angle=15.):
     """
     Calculate front and back surface plane-of-array irradiance on
-    a fixed tilt or single-axis tracker PV array configuration, and using
-    the open-source "pvfactors" package.  pvfactors implements the model
-    described in [1]_.
-    Please refer to pvfactors online documentation for more details:
-    https://sunpower.github.io/pvfactors/
+    a fixed tilt or single-axis tracker PV array configuration using
+    the pvfactors model.
+
+    The pvfactors bifacial irradiance model is described in [1]_.
 
     .. versionchanged:: 0.10.1
        It is now recommended to install the ``solarfactors`` package

--- a/pvlib/bifacial/pvfactors.py
+++ b/pvlib/bifacial/pvfactors.py
@@ -21,6 +21,11 @@ def pvfactors_timeseries(
     Please refer to pvfactors online documentation for more details:
     https://sunpower.github.io/pvfactors/
 
+    .. versionchanged:: 0.10.1
+       It is now recommended to install the ``solarfactors`` package
+       (``pip install solarfactors``) instead of ``pvfactors`` for this
+       function.  For more information, see :ref:`bifacial`.
+
     Parameters
     ----------
     solar_azimuth: numeric

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ TESTS_REQUIRE = ['pytest', 'pytest-cov', 'pytest-mock',
                  'pytest-remotedata']
 EXTRAS_REQUIRE = {
     'optional': ['cython', 'ephem', 'nrel-pysam', 'numba',
-                 'pvfactors', 'statsmodels'],
+                 'solarfactors', 'statsmodels'],
     'doc': ['ipython', 'matplotlib', 'sphinx == 4.5.0',
             'pydata-sphinx-theme == 0.8.1', 'sphinx-gallery',
             'docutils == 0.15.2', 'pillow',
-            'sphinx-toggleprompt >= 0.0.5', 'pvfactors'],
+            'sphinx-toggleprompt >= 0.0.5', 'solarfactors'],
     'test': TESTS_REQUIRE
 }
 EXTRAS_REQUIRE['all'] = sorted(set(sum(EXTRAS_REQUIRE.values(), [])))


### PR DESCRIPTION
 - [x] Closes #1796
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.
 - [x] TODO: update `pvfactors_timeseries` docstring

I've got a first release of [solarfactors](https://github.com/pvlib/solarfactors) up on PyPI, with the important feature of not requiring `pvlib<0.10`.  Other than `pip install`ing a different name, it should be a transparent replacement for pvfactors as far as pvlib is concerned.  So hopefully just by changing the dependency name, the tests and docs build should pass without any other changes being needed.

If so, I think we could proceed with making a v0.10.1 release with this update.