### PR TITLE
Allow dates to be strings in iotools get functions

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.1.rst
@@ -11,6 +11,10 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
+* Added support for dates to specified as strings in the iotools get functions:
+  :py:func:`pvlib.iotools.get_pvgis_hourly`, :py:func:`pvlib.iotools.get_cams`,
+  and :py:func:`pvlib.iotools.read_midc_raw_data_from_nrel`.
+  (:pull:`1800`)
 
 
 Bug fixes

--- a/docs/sphinx/source/whatsnew/v0.10.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.1.rst
@@ -4,37 +4,6 @@
 v0.10.1 (July 3, 2023)
 ----------------------
 
-
-Deprecations
-~~~~~~~~~~~~
-
-
-Enhancements
-~~~~~~~~~~~~
-* Added support for dates to specified as strings in the iotools get functions:
-  :py:func:`pvlib.iotools.get_pvgis_hourly`, :py:func:`pvlib.iotools.get_cams`,
-  and :py:func:`pvlib.iotools.read_midc_raw_data_from_nrel`.
-  (:pull:`1800`)
-
-
-Bug fixes
-~~~~~~~~~
-
-
-Testing
-~~~~~~~
-
-
-Documentation
-~~~~~~~~~~~~~
-
-
-Requirements
-~~~~~~~~~~~~
-
-
-Contributors
-~~~~~~~~~~~~
 To resolve an installation issue with ``pvfactors`` and ``shapely``,
 this release drops the optional ``pvfactors`` dependency and replaces
 it with ``solarfactors``, a fork of ``pvfactors`` maintained by the

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -11,6 +11,10 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
+* Added support for dates to specified as strings in the iotools get functions:
+  :py:func:`pvlib.iotools.get_pvgis_hourly`, :py:func:`pvlib.iotools.get_cams`,
+  and :py:func:`pvlib.iotools.read_midc_raw_data_from_nrel`.
+  (:pull:`1800`)
 
 
 Bug fixes
@@ -31,4 +35,4 @@ Requirements
 
 Contributors
 ~~~~~~~~~~~~
-
+* Adam R. Jensen (:ghuser:`AdamRJensen`)

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -11,9 +11,9 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
-* Added support for dates to specified as strings in the iotools get functions:
+* Added support for dates to be specified as strings in the iotools get functions:
   :py:func:`pvlib.iotools.get_pvgis_hourly`, :py:func:`pvlib.iotools.get_cams`,
-  and :py:func:`pvlib.iotools.read_midc_raw_data_from_nrel`.
+  :py:func:`pvlib.iotools.get_bsrn`, and :py:func:`pvlib.iotools.read_midc_raw_data_from_nrel`.
   (:pull:`1800`)
 
 

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -154,6 +154,10 @@ def get_bsrn(station, start, end, username, password,
     # The FTP server uses lowercase station abbreviations
     station = station.lower()
 
+    # Use pd.to_datetime so that strings (e.g. '2021-01-01') are accepted
+    start = pd.to_datetime(start)
+    end = pd.to_datetime(end)
+
     # Generate list files to download based on start/end (SSSMMYY.dat.gz)
     filenames = pd.date_range(
         start, end.replace(day=1) + pd.DateOffset(months=1), freq='1M')\

--- a/pvlib/iotools/midc.py
+++ b/pvlib/iotools/midc.py
@@ -215,9 +215,9 @@ def read_midc_raw_data_from_nrel(site, start, end, variable_map={},
     ----------
     site: string
         The MIDC station id.
-    start: datetime
+    start: datetime-like
         Start date for requested data.
-    end: datetime
+    end: datetime-like
         End date for requested data.
     variable_map: dict
         A dictionary mapping MIDC field names to pvlib names. Used to
@@ -247,8 +247,8 @@ def read_midc_raw_data_from_nrel(site, start, end, variable_map={},
     for more details and considerations.
     """
     args = {'site': site,
-            'begin': start.strftime('%Y%m%d'),
-            'end': end.strftime('%Y%m%d')}
+            'begin': pd.to_datetime(start).strftime('%Y%m%d'),
+            'end': pd.to_datetime(end).strftime('%Y%m%d')}
     url = 'https://midcdmz.nrel.gov/apps/data_api.pl'
     # NOTE: just use requests.get(url, params=args) to build querystring
     # number of header columns and data columns do not always match,

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -219,7 +219,7 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
     if start is not None:
         params['startyear'] = start if isinstance(start, int) else pd.to_datetime(start).year  # noqa: E501
     if end is not None:
-        params['endyear'] = end if isinstance(end, int) else pd.to_datetime(start).year  # noqa: E501
+        params['endyear'] = end if isinstance(end, int) else pd.to_datetime(end).year  # noqa: E501
     if peakpower is not None:
         params['peakpower'] = peakpower
 

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -217,9 +217,9 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
     if raddatabase is not None:
         params['raddatabase'] = raddatabase
     if start is not None:
-        params['startyear'] = start if isinstance(start, int) else start.year
+        params['startyear'] = start if isinstance(start, int) else pd.to_datetime(start).year  # noqa: E501
     if end is not None:
-        params['endyear'] = end if isinstance(end, int) else end.year
+        params['endyear'] = end if isinstance(end, int) else pd.to_datetime(start).year  # noqa: E501
     if peakpower is not None:
         params['peakpower'] = peakpower
 

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -178,8 +178,8 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
         altitude = -999
 
     # Start and end date should be in the format: yyyy-mm-dd
-    start = start.strftime('%Y-%m-%d')
-    end = end.strftime('%Y-%m-%d')
+    start = pd.to_datetime(start).strftime('%Y-%m-%d')
+    end = pd.to_datetime(end).strftime('%Y-%m-%d')
 
     email = email.replace('@', '%2540')  # Format email address
     identifier = 'get_{}'.format(identifier.lower())  # Format identifier str

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -47,8 +47,9 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
              altitude=None, time_step='1h', time_ref='UT', verbose=False,
              integrated=False, label=None, map_variables=True,
              server=URL, timeout=30):
-    """
-    Retrieve time-series of radiation and/or clear-sky global, beam, and
+    """Retrieve irradiance and clear-sky time series from CAMS.
+
+    Time-series of radiation and/or clear-sky global, beam, and
     diffuse radiation from CAMS (see [1]_). Data is retrieved from SoDa [2]_.
 
     Time coverage: 2004-01-01 to two days ago
@@ -65,9 +66,9 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
         in decimal degrees, between -90 and 90, north is positive (ISO 19115)
     longitude : float
         in decimal degrees, between -180 and 180, east is positive (ISO 19115)
-    start: datetime like
+    start: datetime-like
         First day of the requested period
-    end: datetime like
+    end: datetime-like
         Last day of the requested period
     email: str
         Email address linked to a SoDa account

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -243,9 +243,9 @@ def get_srml(station, start, end, filetype='PO', map_variables=True,
     ----------
     station : str
         Two letter station abbreviation.
-    start : datetime like
+    start : datetime-like
         First day of the requested period
-    end : datetime like
+    end : datetime-like
         Last day of the requested period
     filetype : string, default: 'PO'
         SRML file type to gather. See notes for explanation.


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR allows for the `start`/`end` parameters in the iotools _get_ functions to be specified as strings.

