### PR TITLE
Fix incorrect `ghi_clear` PSM3 request mapping

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -19,7 +19,8 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
-
+* :py:func:`~pvlib.iotools.get_psm3` no longer incorrectly returns clear-sky
+  DHI instead of clear-sky GHI when requesting ``ghi_clear``. (:pull:`1819`)
 
 Testing
 ~~~~~~~

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -46,7 +46,7 @@ REQUEST_VARIABLE_MAP = {
     'ghi': 'ghi',
     'dhi': 'dhi',
     'dni': 'dni',
-    'ghi_clear': 'clearsky_dhi',
+    'ghi_clear': 'clearsky_ghi',
     'dhi_clear': 'clearsky_dhi',
     'dni_clear': 'clearsky_dni',
     'zenith': 'solar_zenith_angle',


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The PSM3 request-side variable map incorrectly translates pvlib's `ghi_clear` to PSM3's `clearsky_dhi` instead of `clearsky_ghi`.  Simple fix.