### PR TITLE
Make interp IAM method available for modelchain

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -31,6 +31,8 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
+* Added docstring detail for :py:func:`pvlib.iam.schlick_diffuse`.
+  (:issue:`1811`, :pull:`1812`)
 * Removed Stickler-CI integration as the service has ceased June 2023.
   (:issue:`1722`, :pull:`1723`)
 

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -27,6 +27,9 @@ Bug fixes
 ~~~~~~~~~
 * :py:func:`~pvlib.iotools.get_psm3` no longer incorrectly returns clear-sky
   DHI instead of clear-sky GHI when requesting ``ghi_clear``. (:pull:`1819`)
+* :py:class:`pvlib.pvsystem.PVSystem` now correctly passes ``n_ar`` module
+   parameter to :py:func:`pvlib.iam.physical` when this IAM model is specified
+   or inferred. (:pull:`1832`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -48,3 +48,4 @@ Contributors
 * Abigail Jones (:ghuser:`ajonesr`)
 * Taos Transue (:ghuser:`reepoi`)
 * Echedey Luis (:ghuser:`echedey-ls`)
+* Todd Karin (:ghuser:`toddkarin`)

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -17,7 +17,9 @@ Enhancements
   (:pull:`1800`)
 * Added option to infer threshold values for 
   :py:func:`pvlib.clearsky.detect_clearsky` (:issue:`1808`, :pull:`1784`)
-
+* Added :py:func:`~pvlib.iam.interp` option as AOI losses model in
+  :py:class:`pvlib.modelchain.ModelChain` and
+  :py:class:`pvlib.pvsystem.PVSystem`. (:issue:`1742`, :pull:`1832`)
 
 Bug fixes
 ~~~~~~~~~
@@ -45,3 +47,4 @@ Contributors
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
 * Abigail Jones (:ghuser:`ajonesr`)
 * Taos Transue (:ghuser:`reepoi`)
+* Echedey Luis (:ghuser:`echedey-ls`)

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -20,7 +20,7 @@ _IAM_MODEL_PARAMS = {
     'physical': {'n', 'K', 'L'},
     'martin_ruiz': {'a_r'},
     'sapm': {'B0', 'B1', 'B2', 'B3', 'B4', 'B5'},
-    'interp': set()
+    'interp': {'theta_ref', 'iam_ref'}
 }
 
 

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -800,7 +800,7 @@ def schlick(aoi):
 
     In PV contexts, the Schlick approximation has been used as an analytically
     integrable alternative to the Fresnel equations for estimating IAM
-    for diffuse irradiance [2]_.
+    for diffuse irradiance [2]_ (see :py:func:`schlick_diffuse`).
 
     Parameters
     ----------
@@ -813,6 +813,10 @@ def schlick(aoi):
     iam : numeric
         The incident angle modifier.
 
+    See Also
+    --------
+    pvlib.iam.schlick_diffuse
+
     References
     ----------
     .. [1] Schlick, C. An inexpensive BRDF model for physically-based
@@ -822,10 +826,6 @@ def schlick(aoi):
        for Diffuse radiation on Inclined photovoltaic Surfaces (FEDIS)",
        Renewable and Sustainable Energy Reviews, vol. 161, 112362. June 2022.
        :doi:`10.1016/j.rser.2022.112362`
-
-    See Also
-    --------
-    pvlib.iam.schlick_diffuse
     """
     iam = 1 - (1 - cosd(aoi)) ** 5
     iam = np.where(np.abs(aoi) >= 90.0, 0.0, iam)
@@ -845,9 +845,20 @@ def schlick_diffuse(surface_tilt):
     ground-reflected irradiance on a tilted surface using the Schlick
     incident angle model.
 
-    The diffuse iam values are calculated using an analytical integration
-    of the Schlick equation [1]_ over the portion of an isotropic sky and
-    isotropic foreground that is visible from the tilted surface [2]_.
+    The Schlick equation (or "Schlick's approximation") [1]_ is an
+    approximation to the Fresnel reflection factor which can be recast as
+    a simple photovoltaic IAM model like so:
+
+    .. math::
+
+        IAM = 1 - (1 - \cos(aoi))^5
+
+    Unlike the Fresnel reflection factor itself, Schlick's approximation can
+    be integrated analytically to derive a closed-form equation for diffuse
+    IAM factors for the portions of the sky and ground visible
+    from a tilted surface if isotropic distributions are assumed.  
+    This function implements the integration of the
+    Schlick approximation provided by Xie et al. [2]_.
 
     Parameters
     ----------
@@ -863,6 +874,35 @@ def schlick_diffuse(surface_tilt):
     iam_ground : numeric
         The incident angle modifier for ground-reflected diffuse.
 
+    See Also
+    --------
+    pvlib.iam.schlick
+
+    Notes
+    -----
+    The analytical integration of the Schlick approximation was derived
+    as part of the FEDIS diffuse IAM model [2]_.  Compared with the model
+    implemented in this function, the FEDIS model includes an additional term
+    to account for reflection off a pyranometer's glass dome.  Because that
+    reflection should already be accounted for in the instrument's calibration,
+    the pvlib authors believe it is inappropriate to account for pyranometer
+    reflection again in an IAM model.  Thus, this function omits that term and
+    implements only the integrated Schlick approximation.
+
+    Note also that the output of this function (which is an exact integration)
+    can be compared with the output of :py:func:`marion_diffuse` which numerically
+    integrates the Schlick approximation:
+
+    .. code::
+
+        >>> pvlib.iam.marion_diffuse('schlick', surface_tilt=20)
+        {'sky': 0.9625000227247358,
+         'horizon': 0.7688174948510073,
+         'ground': 0.6267861879241405}
+
+        >>> pvlib.iam.schlick_diffuse(surface_tilt=20)
+        (0.9624993421569652, 0.6269387554469255)
+
     References
     ----------
     .. [1] Schlick, C. An inexpensive BRDF model for physically-based
@@ -872,10 +912,6 @@ def schlick_diffuse(surface_tilt):
        for Diffuse radiation on Inclined photovoltaic Surfaces (FEDIS)",
        Renewable and Sustainable Energy Reviews, vol. 161, 112362. June 2022.
        :doi:`10.1016/j.rser.2022.112362`
-
-    See Also
-    --------
-    pvlib.iam.schlick
     """
     # these calculations are as in [2]_, but with the refractive index
     # weighting coefficient w set to 1.0 (so it is omitted)

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -944,9 +944,9 @@ class ModelChain:
                              'system.arrays[i].module_parameters. Check that '
                              'the module_parameters for all Arrays in '
                              'system.arrays contain parameters for '
-                             'the physical, aoi, ashrae or martin_ruiz model; '
-                             'explicitly set the model with the aoi_model '
-                             'kwarg; or set aoi_model="no_loss".')
+                             'the physical, aoi, ashrae, martin_ruiz or interp'
+                             'model; explicitly set the model with the'
+                             'aoi_model kwarg; or set aoi_model="no_loss".')
 
     def ashrae_aoi_loss(self):
         self.results.aoi_modifier = self.system.get_iam(

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -943,8 +943,8 @@ class ModelChain:
             raise ValueError('could not infer AOI model from '
                              'system.arrays[i].module_parameters. Check that '
                              'the module_parameters for all Arrays in '
-                             'system.arrays contain parameters for '
-                             'the physical, aoi, ashrae, martin_ruiz or interp '
+                             'system.arrays contain parameters for the '
+                             'physical, aoi, ashrae, martin_ruiz or interp '
                              'model; explicitly set the model with the '
                              'aoi_model kwarg; or set aoi_model="no_loss".')
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -14,10 +14,9 @@ from dataclasses import dataclass, field
 from typing import Union, Tuple, Optional, TypeVar
 
 from pvlib import (atmosphere, clearsky, inverter, pvsystem, solarposition,
-                   temperature)
+                   temperature, iam)
 import pvlib.irradiance  # avoid name conflict with full import
 from pvlib.pvsystem import _DC_MODEL_PARAMS
-from pvlib._deprecation import pvlibDeprecationWarning
 from pvlib.tools import _build_kwargs
 
 from pvlib._deprecation import deprecated
@@ -279,7 +278,7 @@ def _mcr_repr(obj):
     # scalar, None, other?
     return repr(obj)
 
-    
+
 # Type for fields that vary between arrays
 T = TypeVar('T')
 
@@ -490,7 +489,7 @@ class ModelChain:
         If None, the model will be inferred from the parameters that
         are common to all of system.arrays[i].module_parameters.
         Valid strings are 'physical', 'ashrae', 'sapm', 'martin_ruiz',
-        'no_loss'. The ModelChain instance will be passed as the
+        'interp' and 'no_loss'. The ModelChain instance will be passed as the
         first argument to a user-defined function.
 
     spectral_model: None, str, or function, default None
@@ -917,6 +916,8 @@ class ModelChain:
                 self._aoi_model = self.sapm_aoi_loss
             elif model == 'martin_ruiz':
                 self._aoi_model = self.martin_ruiz_aoi_loss
+            elif model == 'interp':
+                self._aoi_model = self.interp_aoi_loss
             elif model == 'no_loss':
                 self._aoi_model = self.no_aoi_loss
             else:
@@ -928,14 +929,16 @@ class ModelChain:
         module_parameters = tuple(
             array.module_parameters for array in self.system.arrays)
         params = _common_keys(module_parameters)
-        if {'K', 'L', 'n'} <= params:
+        if iam._IAM_MODEL_PARAMS['physical'] <= params:
             return self.physical_aoi_loss
-        elif {'B5', 'B4', 'B3', 'B2', 'B1', 'B0'} <= params:
+        elif iam._IAM_MODEL_PARAMS['sapm'] <= params:
             return self.sapm_aoi_loss
-        elif {'b'} <= params:
+        elif iam._IAM_MODEL_PARAMS['ashrae'] <= params:
             return self.ashrae_aoi_loss
-        elif {'a_r'} <= params:
+        elif iam._IAM_MODEL_PARAMS['martin_ruiz'] <= params:
             return self.martin_ruiz_aoi_loss
+        elif iam._IAM_MODEL_PARAMS['interp'] <= params:
+            return self.interp_aoi_loss
         else:
             raise ValueError('could not infer AOI model from '
                              'system.arrays[i].module_parameters. Check that '
@@ -969,6 +972,13 @@ class ModelChain:
     def martin_ruiz_aoi_loss(self):
         self.results.aoi_modifier = self.system.get_iam(
             self.results.aoi, iam_model='martin_ruiz'
+        )
+        return self
+
+    def interp_aoi_loss(self):
+        self.results.aoi_modifier = self.system.get_iam(
+            self.results.aoi,
+            iam_model='interp'
         )
         return self
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -388,7 +388,7 @@ class PVSystem:
 
         aoi_model : string, default 'physical'
             The IAM model to be used. Valid strings are 'physical', 'ashrae',
-            'martin_ruiz' and 'sapm'.
+            'martin_ruiz', 'sapm' and 'interp'.
         Returns
         -------
         iam : numeric or tuple of numeric
@@ -1151,7 +1151,7 @@ class Array:
 
         aoi_model : string, default 'physical'
             The IAM model to be used. Valid strings are 'physical', 'ashrae',
-            'martin_ruiz' and 'sapm'.
+            'martin_ruiz', 'sapm' and 'interp'.
 
         Returns
         -------
@@ -1164,16 +1164,13 @@ class Array:
             if `iam_model` is not a valid model name.
         """
         model = iam_model.lower()
-        if model in ['ashrae', 'physical', 'martin_ruiz']:
+        if model in ['ashrae', 'physical', 'martin_ruiz', 'interp']:
             param_names = iam._IAM_MODEL_PARAMS[model]
             kwargs = _build_kwargs(param_names, self.module_parameters)
             func = getattr(iam, model)
             return func(aoi, **kwargs)
         elif model == 'sapm':
             return iam.sapm(aoi, self.module_parameters)
-        elif model == 'interp':
-            raise ValueError(model + ' is not implemented as an IAM model '
-                             'option for Array')
         else:
             raise ValueError(model + ' is not a valid IAM model')
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -8,6 +8,7 @@ import functools
 import io
 import itertools
 import os
+import inspect
 from urllib.request import urlopen
 import numpy as np
 from scipy import constants
@@ -1165,9 +1166,12 @@ class Array:
         """
         model = iam_model.lower()
         if model in ['ashrae', 'physical', 'martin_ruiz', 'interp']:
-            param_names = iam._IAM_MODEL_PARAMS[model]
-            kwargs = _build_kwargs(param_names, self.module_parameters)
-            func = getattr(iam, model)
+            func = getattr(iam, model)  # get function at pvlib.iam
+            # get all parameters from function signature to retrieve them from
+            # module_parameters if present
+            params = set(inspect.signature(func).parameters.keys())
+            params.discard('aoi')  # exclude aoi so it can't be repeated
+            kwargs = _build_kwargs(params, self.module_parameters)
             return func(aoi, **kwargs)
         elif model == 'sapm':
             return iam.sapm(aoi, self.module_parameters)

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1458,14 +1458,16 @@ def test_aoi_model_no_loss(sapm_dc_snl_ac_system, location, weather):
 def test_aoi_model_interp(sapm_dc_snl_ac_system, location, weather, mocker):
     # similar to test_aoi_models but requires arguments to work, so we
     # add 'interp' aoi losses model arguments to module
-    sapm_dc_snl_ac_system.arrays[0].module_parameters['iam_ref'] = (1., 0.85)
-    sapm_dc_snl_ac_system.arrays[0].module_parameters['theta_ref'] = (0., 80.)
+    iam_ref = (1., 0.85)
+    theta_ref = (0., 80.)
+    sapm_dc_snl_ac_system.arrays[0].module_parameters['iam_ref'] = iam_ref
+    sapm_dc_snl_ac_system.arrays[0].module_parameters['theta_ref'] = theta_ref
     mc = ModelChain(sapm_dc_snl_ac_system, location,
                     dc_model='sapm', aoi_model='interp',
                     spectral_model='no_loss')
-    m = mocker.spy(sapm_dc_snl_ac_system, 'get_iam')
+    m = mocker.spy(iam, 'interp')
     mc.run_model(weather=weather)
-    assert m.call_count == 1
+    assert m.call_args.kwargs == {'iam_ref': iam_ref, 'theta_ref': theta_ref}
     assert isinstance(mc.results.ac, pd.Series)
     assert not mc.results.ac.empty
     assert mc.results.ac[0] > 150 and mc.results.ac[0] < 200

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1455,6 +1455,23 @@ def test_aoi_model_no_loss(sapm_dc_snl_ac_system, location, weather):
     assert mc.results.ac[1] < 1
 
 
+def test_aoi_model_interp(sapm_dc_snl_ac_system, location, weather, mocker):
+    # similar to test_aoi_models but requires arguments to work, so we
+    # add 'interp' aoi losses model arguments to module
+    sapm_dc_snl_ac_system.arrays[0].module_parameters['iam_ref'] = (1., 0.85)
+    sapm_dc_snl_ac_system.arrays[0].module_parameters['theta_ref'] = (0., 80.)
+    mc = ModelChain(sapm_dc_snl_ac_system, location,
+                    dc_model='sapm', aoi_model='interp',
+                    spectral_model='no_loss')
+    m = mocker.spy(sapm_dc_snl_ac_system, 'get_iam')
+    mc.run_model(weather=weather)
+    assert m.call_count == 1
+    assert isinstance(mc.results.ac, pd.Series)
+    assert not mc.results.ac.empty
+    assert mc.results.ac[0] > 150 and mc.results.ac[0] < 200
+    assert mc.results.ac[1] < 1
+
+
 def test_aoi_model_user_func(sapm_dc_snl_ac_system, location, weather, mocker):
     m = mocker.spy(sys.modules[__name__], 'constant_aoi_loss')
     mc = ModelChain(sapm_dc_snl_ac_system, location, dc_model='sapm',
@@ -1468,7 +1485,7 @@ def test_aoi_model_user_func(sapm_dc_snl_ac_system, location, weather, mocker):
 
 
 @pytest.mark.parametrize('aoi_model', [
-    'sapm', 'ashrae', 'physical', 'martin_ruiz'
+    'sapm', 'ashrae', 'physical', 'martin_ruiz', 'interp'
 ])
 def test_infer_aoi_model(location, system_no_aoi, aoi_model):
     for k in iam._IAM_MODEL_PARAMS[aoi_model]:

--- a/pvlib/tests/test_modelchain.py
+++ b/pvlib/tests/test_modelchain.py
@@ -1467,7 +1467,9 @@ def test_aoi_model_interp(sapm_dc_snl_ac_system, location, weather, mocker):
                     spectral_model='no_loss')
     m = mocker.spy(iam, 'interp')
     mc.run_model(weather=weather)
-    assert m.call_args.kwargs == {'iam_ref': iam_ref, 'theta_ref': theta_ref}
+    # only test kwargs
+    assert m.call_args[1]['iam_ref'] == iam_ref
+    assert m.call_args[1]['theta_ref'] == theta_ref
     assert isinstance(mc.results.ac, pd.Series)
     assert not mc.results.ac.empty
     assert mc.results.ac[0] > 150 and mc.results.ac[0] < 200

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -64,13 +64,15 @@ def test_PVSystem_get_iam_sapm(sapm_module_params, mocker):
     assert_allclose(out, 1.0, atol=0.01)
 
 
-def test_PVSystem_get_iam_interp():
-    custom_module_params = {'iam_ref': (1., 0.8), 'theta_ref': (0., 80.)}
-    system = pvsystem.PVSystem(module_parameters=custom_module_params)
+def test_PVSystem_get_iam_interp(mocker):
+    interp_module_params = {'iam_ref': (1., 0.8), 'theta_ref': (0., 80.)}
+    system = pvsystem.PVSystem(module_parameters=interp_module_params)
+    spy = mocker.spy(_iam, 'interp')
     aoi = ((0., 40., 80.),)
     expected = (1., 0.9, 0.8)
     out = system.get_iam(aoi, iam_model='interp')
     assert_allclose(out, expected)
+    spy.assert_called_once_with(aoi[0], **interp_module_params)
 
 
 def test__normalize_sam_product_names():

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -64,10 +64,13 @@ def test_PVSystem_get_iam_sapm(sapm_module_params, mocker):
     assert_allclose(out, 1.0, atol=0.01)
 
 
-def test_PVSystem_get_iam_interp(sapm_module_params, mocker):
-    system = pvsystem.PVSystem(module_parameters=sapm_module_params)
-    with pytest.raises(ValueError):
-        system.get_iam(45, iam_model='interp')
+def test_PVSystem_get_iam_interp():
+    custom_module_params = {'iam_ref': (1., 0.8), 'theta_ref': (0., 80.)}
+    system = pvsystem.PVSystem(module_parameters=custom_module_params)
+    aoi = ((0., 40., 80.),)
+    expected = (1., 0.9, 0.8)
+    out = system.get_iam(aoi, iam_model='interp')
+    assert_allclose(out, expected)
 
 
 def test__normalize_sam_product_names():


### PR DESCRIPTION
 - [x] Closes #1742
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Have a look at #1742 

I have some doubts about tests, there are many of them testing aoi losses models, but `'interp'` requires some arguments (it does not have defaults to run without args like the other ones in `test_aoi_models` among other tests). I ended up creating a new one.
In this specific test, I've modified the fixture to add the required args `iam_ref` and `theta_ref` to the module in the PVSystem.