### PR TITLE
Fix example in docstring pvsystem.py

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -35,6 +35,8 @@ Documentation
   (:issue:`1811`, :pull:`1812`)
 * Removed Stickler-CI integration as the service has ceased June 2023.
   (:issue:`1722`, :pull:`1723`)
+* Fix and update example in :py:func:`pvlib.pvsystem.retrieve_sam`.
+  (:issue:`1741`, :pull:`1833`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -45,3 +47,4 @@ Contributors
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
 * Abigail Jones (:ghuser:`ajonesr`)
 * Taos Transue (:ghuser:`reepoi`)
+* NativeSci (:ghuser:`nativesci`)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2001,23 +2001,25 @@ def retrieve_sam(name=None, path=None):
 
     >>> from pvlib import pvsystem
     >>> invdb = pvsystem.retrieve_sam('CECInverter')
-    >>> inverter = invdb.AE_Solar_Energy__AE6_0__277V__277V__CEC_2012_
+    >>> inverter = invdb.AE_Solar_Energy__AE6_0__277V_
     >>> inverter
-    Vac           277.000000
-    Paco         6000.000000
-    Pdco         6165.670000
-    Vdco          361.123000
-    Pso            36.792300
-    C0             -0.000002
-    C1             -0.000047
-    C2             -0.001861
-    C3              0.000721
-    Pnt             0.070000
-    Vdcmax        600.000000
-    Idcmax         32.000000
-    Mppt_low      200.000000
-    Mppt_high     500.000000
-    Name: AE_Solar_Energy__AE6_0__277V__277V__CEC_2012_, dtype: float64
+    Vac                          277
+    Pso                    36.197575
+    Paco                      6000.0
+    Pdco                 6158.746094
+    Vdco                       360.0
+    C0                     -0.000002
+    C1                     -0.000026
+    C2                     -0.001253
+    C3                       0.00021
+    Pnt                          1.8
+    Vdcmax                     450.0
+    Idcmax                 17.107628
+    Mppt_low                   100.0
+    Mppt_high                  450.0
+    CEC_Date                     NaN
+    CEC_Type     Utility Interactive
+    Name: AE_Solar_Energy__AE6_0__277V_, dtype: object
     '''
 
     if name is not None:


### PR DESCRIPTION
 - [x] Closes #1741
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

See linked issue.
