### PR TITLE
Fix incorrect description of surface_azimuth parameter in get_pvgis_hourly

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -37,6 +37,8 @@ Documentation
   (:issue:`1722`, :pull:`1723`)
 * Fix and update example in :py:func:`pvlib.pvsystem.retrieve_sam`.
   (:issue:`1741`, :pull:`1833`)
+* Fix error in :py:func:`pvlib.iotools.get_pvgis_hourly`.
+  (:issue:`1724`, :pull:`1838`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -48,3 +50,4 @@ Contributors
 * Abigail Jones (:ghuser:`ajonesr`)
 * Taos Transue (:ghuser:`reepoi`)
 * NativeSci (:ghuser:`nativesci`)
+* Lukas Grossar (:ghuser:`tongpu`)

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -37,7 +37,7 @@ Documentation
   (:issue:`1722`, :pull:`1723`)
 * Fix and update example in :py:func:`pvlib.pvsystem.retrieve_sam`.
   (:issue:`1741`, :pull:`1833`)
-* Fix error in :py:func:`pvlib.iotools.get_pvgis_hourly`.
+* Fix error in :py:func:`pvlib.iotools.get_pvgis_hourly` documentation of `surface_azimuth`.
   (:issue:`1724`, :pull:`1838`)
 
 Requirements

--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -77,14 +77,14 @@ def get_pvgis_hourly(latitude, longitude, start=None, end=None,
     surface_tilt: float, default: 0
         Tilt angle from horizontal plane. Ignored for two-axis tracking.
     surface_azimuth: float, default: 180
-        Orientation (azimuth angle) of the (fixed) plane. Counter-clockwise
-        from north (north=0, south=180). This is offset 180 degrees from
-        the convention used by PVGIS. Ignored for tracking systems.
+        Orientation (azimuth angle) of the (fixed) plane. Clockwise from north
+        (north=0, east=90, south=180, west=270). This is offset 180 degrees from the
+        convention used by PVGIS. Ignored for tracking systems.
 
         .. versionchanged:: 0.10.0
            The `surface_azimuth` parameter now follows the pvlib convention, which
-           is counterclockwise from north. However, the convention used by the
-           PVGIS website and pvlib<=0.9.5 is offset by 180 degrees.
+           is clockwise from north. However, the convention used by the PVGIS website
+           and pvlib<=0.9.5 is offset by 180 degrees.
     usehorizon: bool, default: True
         Include effects of horizon
     userhorizon: list of float, default: None


### PR DESCRIPTION
 - [x] Closes #1724
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fixes a documentation issue introduced with the change to align `surface_azimuth` in `pvgis_get_hourly`, where the implementation is clockwise from north, but the documentation strings mention counter-clockwise from north.