### PR TITLE
Enhance description of unit_mass in prilliman temperature model

### DIFF
--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -962,7 +962,7 @@ def prilliman(temp_cell, wind_speed, unit_mass=11.1, coefficients=None):
 
     unit_mass : float, default 11.1
         Total mass of module divided by its one-sided surface area [kg/m^2]
-        One-sided surface area is equal to module height time width
+        One-sided surface area is equal to module height times width
 
     coefficients : 4-element list-like, optional
         Values for coefficients a_0 through a_3, see Eq. 9 of [1]_

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -962,6 +962,7 @@ def prilliman(temp_cell, wind_speed, unit_mass=11.1, coefficients=None):
 
     unit_mass : float, default 11.1
         Total mass of module divided by its one-sided surface area [kg/m^2]
+        One-sided surface area is equal to module height time width
 
     coefficients : 4-element list-like, optional
         Values for coefficients a_0 through a_3, see Eq. 9 of [1]_


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
I had initially understood the one-sided surface area as the "area of the side of the module", e.g., module width times module thickness, which of course is not correct. I think this added line makes it a bit clearer.