### PR TITLE
Fix typo in docstring of pvlib.temperature.fuentes

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -62,6 +62,8 @@ Documentation
   (:issue:`1724`, :pull:`1838`)
 * Update definition of snow events parameter for :py:func:`pvlib.snow.loss_townsend`.
   (:issue:`1839`, :pull:`1840`)
+* Typo fix in :py:func:`pvlib.temperature.fuentes`, `wind_height` parameter description.
+  (:issue:`1814`, :pull:`1860`)
   
 Requirements
 ~~~~~~~~~~~~
@@ -81,3 +83,4 @@ Contributors
 * Lukas Grossar (:ghuser:`tongpu`)
 * Areeba Turabi (:ghuser:`aturabi`)
 * Miroslav Šedivý (:ghuser:`eumiro`)
+* kjsauer (:ghuser:`kjsauer`)

--- a/docs/sphinx/source/whatsnew/v0.10.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.2.rst
@@ -62,8 +62,6 @@ Documentation
   (:issue:`1724`, :pull:`1838`)
 * Update definition of snow events parameter for :py:func:`pvlib.snow.loss_townsend`.
   (:issue:`1839`, :pull:`1840`)
-* Typo fix in :py:func:`pvlib.temperature.fuentes`, `wind_height` parameter description.
-  (:issue:`1814`, :pull:`1860`)
   
 Requirements
 ~~~~~~~~~~~~

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -678,7 +678,7 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
 
     wind_height : float, default 9.144
         The height above ground at which ``wind_speed`` is measured. The
-        PVWatts defauls is 9.144 [m]
+        PVWatts default is 9.144 [m]
 
     emissivity : float, default 0.84
         The effectiveness of the module at radiating thermal energy. [unitless]


### PR DESCRIPTION
 - [x] Closes #1814
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)

 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).

 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

See linked issue.
