### PR TITLE
Add loss input to example in modelchain.with_pvwatts docs

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -582,17 +582,27 @@ class ModelChain:
             constructor and take precedence over the default
             configuration.
 
+        .. warning::
+            The PVWatts model assumes 14% total system losses. The loss assumptions
+            can be modified as shown in the example below.
+
         Examples
         --------
+        >>> from pvlib import temperature, pvsystem, location, modelchain
         >>> module_parameters = dict(gamma_pdc=-0.003, pdc0=4500)
         >>> inverter_parameters = dict(pdc0=4000)
-        >>> tparams = TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
-        >>> system = PVSystem(surface_tilt=30, surface_azimuth=180,
-        ...     module_parameters=module_parameters,
-        ...     inverter_parameters=inverter_parameters,
-        ...     temperature_model_parameters=tparams)
-        >>> location = Location(32.2, -110.9)
-        >>> ModelChain.with_pvwatts(system, location)
+        >>> tparams = temperature.TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
+        >>> pvwatts_losses = {'soiling': 2, 'shading': 3, 'snow': 0, 'mismatch': 2,
+        >>>                   'wiring': 2, 'connections': 0.5, 'lid': 1.5,
+        >>>                   'nameplate_rating': 1, 'age': 0, 'availability': 30}
+        >>> system = pvsystem.PVSystem(
+        >>>     surface_tilt=30, surface_azimuth=180,
+        >>>     module_parameters=module_parameters,
+        >>>     inverter_parameters=inverter_parameters,
+        >>>     temperature_model_parameters=tparams,
+        >>>     losses_parameters=pvwatts_losses)
+        >>> loc = location.Location(32.2, -110.9)
+        >>> modelchain.ModelChain.with_pvwatts(system, loc)
         ModelChain:
           name: None
           clearsky_model: ineichen

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -584,8 +584,9 @@ class ModelChain:
 
         Warning
         -------
-        The PVWatts model defaults to 14 % total system losses. The loss
-        assumptions can be modified as shown in the example below.
+        The PVWatts model defaults to 14 % total system losses. The PVWatts
+        losses are fractions of DC power and can be modified, as shown in the
+        example below.
 
         Examples
         --------

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -603,6 +603,7 @@ class ModelChain:
 
         The following example is a modification of the example above but where
         custom losses have been specified.
+
         >>> pvwatts_losses = {'soiling': 2, 'shading': 3, 'snow': 0, 'mismatch': 2,
         >>>                   'wiring': 2, 'connections': 0.5, 'lid': 1.5,
         >>>                   'nameplate_rating': 1, 'age': 0, 'availability': 30}

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -593,17 +593,26 @@ class ModelChain:
         >>> module_parameters = dict(gamma_pdc=-0.003, pdc0=4500)
         >>> inverter_parameters = dict(pdc0=4000)
         >>> tparams = temperature.TEMPERATURE_MODEL_PARAMETERS['sapm']['open_rack_glass_glass']
+        >>> system = pvsystem.PVSystem(
+        >>>     surface_tilt=30, surface_azimuth=180,
+        >>>     module_parameters=module_parameters,
+        >>>     inverter_parameters=inverter_parameters,
+        >>>     temperature_model_parameters=tparams)
+        >>> loc = location.Location(32.2, -110.9)
+        >>> modelchain.ModelChain.with_pvwatts(system, loc)
+
+        The following example is a modification of the example above but where
+        custom losses have been specified.
         >>> pvwatts_losses = {'soiling': 2, 'shading': 3, 'snow': 0, 'mismatch': 2,
         >>>                   'wiring': 2, 'connections': 0.5, 'lid': 1.5,
         >>>                   'nameplate_rating': 1, 'age': 0, 'availability': 30}
-        >>> system = pvsystem.PVSystem(
+        >>> system_with_custom_losses = pvsystem.PVSystem(
         >>>     surface_tilt=30, surface_azimuth=180,
         >>>     module_parameters=module_parameters,
         >>>     inverter_parameters=inverter_parameters,
         >>>     temperature_model_parameters=tparams,
         >>>     losses_parameters=pvwatts_losses)
-        >>> loc = location.Location(32.2, -110.9)
-        >>> modelchain.ModelChain.with_pvwatts(system, loc)
+        >>> modelchain.ModelChain.with_pvwatts(system_with_custom_losses, loc)
         ModelChain:
           name: None
           clearsky_model: ineichen

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -584,8 +584,8 @@ class ModelChain:
 
         Warning
         -------
-        The PVWatts model assumes 14% total system losses. The loss assumptions
-        can be modified as shown in the example below.
+        The PVWatts model defaults to 14 % total system losses. The loss
+        assumptions can be modified as shown in the example below.
 
         Examples
         --------

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -582,9 +582,10 @@ class ModelChain:
             constructor and take precedence over the default
             configuration.
 
-        .. warning::
-            The PVWatts model assumes 14% total system losses. The loss assumptions
-            can be modified as shown in the example below.
+        Warning
+        -------
+        The PVWatts model assumes 14% total system losses. The loss assumptions
+        can be modified as shown in the example below.
 
         Examples
         --------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
I had some difficulties figuring out what losses were used in the ``modelchain.with_pvwatts``, I am making this PR to make it clearer and demonstrate how to change the loss factors.

My motivation for this PR is that I think it's important to encourage users to consider what loss assumptions are made and make it easier to modify them.

Also, it's typically new users who would use the ``modelchain.with_pvwatts`` model, which is why I have added the necessary imports such that the example can be run exactly as copied without having users to figure out where the different modules are imported from (something that would be difficult for a new user).