### PR TITLE
Update isotropic transposition references

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -614,10 +614,11 @@ def isotropic(surface_tilt, dhi):
        I_{d} = DHI \frac{1 + \cos\beta}{2}
 
     Hottel and Woertz's model treats the sky as a uniform source of
-    diffuse irradiance. Thus the diffuse irradiance from the sky (ground
+    diffuse irradiance. Thus, the diffuse irradiance from the sky (ground
     reflected irradiance is not included in this algorithm) on a tilted
     surface can be found from the diffuse horizontal irradiance and the
-    tilt angle of the surface.
+    tilt angle of the surface. A discussion of the origin of the
+    isotropic model can be found in [2]_.
 
     Parameters
     ----------
@@ -636,14 +637,16 @@ def isotropic(surface_tilt, dhi):
 
     References
     ----------
-    .. [1] Loutzenhiser P.G. et. al. "Empirical validation of models to
+    .. [1] Loutzenhiser P.G. et al. "Empirical validation of models to
        compute solar irradiance on inclined surfaces for building energy
        simulation" 2007, Solar Energy vol. 81. pp. 254-267
+       :doi:`10.1016/j.solener.2006.03.009`
 
-    .. [2] Hottel, H.C., Woertz, B.B., 1942. Evaluation of flat-plate solar
-       heat collector. Trans. ASME 64, 91.
+    .. [2] Kamphuis, N.R. et al. "Perspectives on the origin, derivation,
+       meaning, and significance of the isotropic sky model" 2020, Solar
+       Energy vol. 201. pp. 8-12
+       :doi:`10.1016/j.solener.2020.02.067`
     '''
-
     sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
 
     return sky_diffuse


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The reference in the isotropic transposition model seem not to be the original derivation of the model. Instead, I suggest referencing this very thorough [paper](https://doi.org/10.1016/j.solener.2020.02.067) for the model development. The paper states:
> Hottel (e.g., Hottel, 1940, 1941, 1951; Hottel and Woertz, 1942) had such a profound impact in the field of solar energy that some authors (e.g., Loutzenhiser et al., 2007) incorrectly cited Hottel and Woertz (1942) as the originators of the ISM [isotropic sky model]