### PR TITLE
`fit_pvefficiency_adr` compatibility with scipy 1.11.2

### DIFF
--- a/pvlib/pvarray.py
+++ b/pvlib/pvarray.py
@@ -192,9 +192,9 @@ def fit_pvefficiency_adr(effective_irradiance, temp_cell, eta,
 
     P_NAMES = ['k_a', 'k_d', 'tc_d', 'k_rs', 'k_rsh']
     P_MAX   = [+np.inf,   0, +0.1, 1, 1]                           # noQA: E221
-    P_MIN   = [0,       -12, -0.1, 0, 0]                           # noQA: E221
-    P0      = [eta_max,  -6,  0.0, 0, 0]                           # noQA: E221
-    P_SCALE = [eta_max,  10,  0.1, 1, 1]
+    P_MIN   = [0,       -12, -0.1,  0.0,  0.0]                     # noQA: E221
+    P0      = [eta_max,  -6,  0.0, 1e-3, 1e-3]                     # noQA: E221
+    P_SCALE = [eta_max,  10,  0.1,  1.0,  1.0]
 
     SIGMA = 1 / np.sqrt(irradiance / 1000)
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I am tired of waiting for the next scipy release to come out (with a fix for https://github.com/scipy/scipy/issues/19103) and resolve our failing CI tests, so here is a fix on our end instead.  I guess it is best to include a fix in pvlib anyway.

The problem is that the starting point for a call to `curve_fit` was on the boundary of the acceptable region, so I moved the initial point just inside the bounded region.  

@adriesse could you please take a look and confirm the new starting point is appropriate?  
