### PR TITLE
fix invalid escape sequence '\c'

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.3.rst
@@ -23,4 +23,4 @@ Documentation
 
 Contributors
 ~~~~~~~~~~~~
-
+* Arjan Keeman (:ghuser:`akeeman`)

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -840,7 +840,7 @@ def schlick(aoi):
 
 
 def schlick_diffuse(surface_tilt):
-    """
+    r"""
     Determine the incidence angle modifiers (IAM) for diffuse sky and
     ground-reflected irradiance on a tilted surface using the Schlick
     incident angle model.


### PR DESCRIPTION
pvlib/iam.py:843: DeprecationWarning: invalid escape sequence '\c'

Occurence is actually in line 854: `IAM = 1 - (1 - \cos(aoi))^5`

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
