### PR TITLE
Add "logwright" SDE solver functions

### DIFF
--- a/docs/sphinx/source/user_guide/singlediode.rst
+++ b/docs/sphinx/source/user_guide/singlediode.rst
@@ -49,6 +49,8 @@ Then the module current can be solved using the Lambert W-function,
        - \frac{n Ns V_{th}}{R_s} W \left(z \right)
 
 
+TODO
+
 Bishop's Algorithm
 ------------------
 The function :func:`pvlib.singlediode.bishop88` uses an explicit solution [4]

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2405,7 +2405,8 @@ def singlediode(photocurrent, saturation_current, resistance_series,
 
     method : str, default 'lambertw'
         Determines the method used to calculate points on the IV curve. The
-        options are ``'lambertw'``, ``'newton'``, or ``'brentq'``.
+        options are ``'lambertw'``, ``'logwright'``, ``'newton'``, or
+        ``'brentq'``.
 
     Returns
     -------
@@ -2440,6 +2441,8 @@ def singlediode(photocurrent, saturation_current, resistance_series,
     If the method is ``'lambertw'`` then the solution employed to solve the
     implicit diode equation utilizes the Lambert W function to obtain an
     explicit function of :math:`V=f(I)` and :math:`I=f(V)` as shown in [2]_.
+
+    If the method is ``'logwright'`` TODO
 
     If the method is ``'newton'`` then the root-finding Newton-Raphson method
     is used. It should be safe for well behaved IV-curves, but the ``'brentq'``
@@ -2482,8 +2485,8 @@ def singlediode(photocurrent, saturation_current, resistance_series,
             resistance_shunt, nNsVth)  # collect args
     # Calculate points on the IV curve using the LambertW solution to the
     # single diode equation
-    if method.lower() == 'lambertw':
-        out = _singlediode._lambertw(*args, ivcurve_pnts)
+    if method.lower() in ['lambertw', 'logwright']:
+        out = _singlediode._lambertw(*args, ivcurve_pnts, how=method)
         points = out[:7]
         if ivcurve_pnts:
             ivcurve_i, ivcurve_v = out[7:]
@@ -2651,8 +2654,8 @@ def v_from_i(current, photocurrent, saturation_current, resistance_series,
         0 < nNsVth
 
     method : str
-        Method to use: ``'lambertw'``, ``'newton'``, or ``'brentq'``. *Note*:
-        ``'brentq'`` is limited to 1st quadrant only.
+        Method to use: ``'lambertw'``, ``'logwright'``, ``'newton'``,
+        or ``'brentq'``. *Note*: ``'brentq'`` is limited to 1st quadrant only.
 
     Returns
     -------
@@ -2668,6 +2671,8 @@ def v_from_i(current, photocurrent, saturation_current, resistance_series,
             resistance_series, resistance_shunt, nNsVth)
     if method.lower() == 'lambertw':
         return _singlediode._lambertw_v_from_i(*args)
+    elif method.lower() == 'logwright':
+        return _singlediode._logwright_v_from_i(*args)
     else:
         # Calculate points on the IV curve using either 'newton' or 'brentq'
         # methods. Voltages are determined by first solving the single diode
@@ -2733,8 +2738,8 @@ def i_from_v(voltage, photocurrent, saturation_current, resistance_series,
         0 < nNsVth
 
     method : str
-        Method to use: ``'lambertw'``, ``'newton'``, or ``'brentq'``. *Note*:
-        ``'brentq'`` is limited to 1st quadrant only.
+        Method to use: ``'lambertw'``, ``'logwright'``, ``'newton'``,
+        or ``'brentq'``. *Note*: ``'brentq'`` is limited to 1st quadrant only.
 
     Returns
     -------
@@ -2750,6 +2755,8 @@ def i_from_v(voltage, photocurrent, saturation_current, resistance_series,
             resistance_series, resistance_shunt, nNsVth)
     if method.lower() == 'lambertw':
         return _singlediode._lambertw_i_from_v(*args)
+    elif method.lower() == 'logwright':
+        return _singlediode._logwright_i_from_v(*args)
     else:
         # Calculate points on the IV curve using either 'newton' or 'brentq'
         # methods. Voltages are determined by first solving the single diode

--- a/pvlib/tests/test_tools.py
+++ b/pvlib/tests/test_tools.py
@@ -3,6 +3,7 @@ import pytest
 from pvlib import tools
 import numpy as np
 import pandas as pd
+import scipy
 
 
 @pytest.mark.parametrize('keys, input_dict, expected', [
@@ -120,3 +121,18 @@ def test_get_pandas_index(args, args_idx):
         assert index is None
     else:
         pd.testing.assert_index_equal(args[args_idx].index, index)
+
+
+def test__logwrightomega():
+    x = np.concatenate([-(10.**np.arange(100, -100, -0.1)),
+                        10.**np.arange(-100, 100, 0.1)])
+    with np.errstate(divide='ignore'):
+        expected = np.log(scipy.special.wrightomega(x))
+
+    expected[x < -750] = x[x < -750]
+
+    actual = tools._logwrightomega(x, n=2)
+    np.testing.assert_allclose(actual, expected, atol=2e-11, rtol=2e-11)
+
+    actual = tools._logwrightomega(x, n=3)
+    np.testing.assert_allclose(actual, expected, atol=2e-15, rtol=4e-16)

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -494,3 +494,24 @@ def get_pandas_index(*args):
         (a.index for a in args if isinstance(a, (pd.DataFrame, pd.Series))),
         None
     )
+
+
+def _logwrightomega(x, n=3):
+    # a faster alternative to np.log(scipy.special.wrightomega(x)).
+    # this calculation also more robust in that it avoids underflow
+    # problems that np.log(scipy.specia.wrightomega()) experiences
+    # for x < ~-745.
+
+    # TODO see ref X
+
+    y = np.where(x <= -np.e, x, 1)
+    y = np.where((-np.e < x) & (x < np.e), -np.e + (1 + np.e) * (x + np.e) / (2 * np.e), y)
+    np.log(x, out=y, where=x >= np.e)
+
+    for _ in range(n):
+        ey = np.exp(y)
+        ey_plus_one = 1 + ey
+        y_ey_x = y + ey - x
+        y = y - 2 * (y_ey_x) * (ey_plus_one) / ((2 * (ey_plus_one)**2 - (y_ey_x)*ey))
+
+    return y


### PR DESCRIPTION
 - [x] Closes #1856
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR implements two new functions in `pvlib.singlediode`: `_logwright_v_from_i` and `_logwright_i_from_v`.  The reference from #1856 ([link](https://arxiv.org/pdf/1601.02679.pdf)) provides the `v_from_i` equation.  I used the same technique to derive the `i_from_v` equation.  I plan to document the equations in our `singlediode.rst` page.

The new base functions are then integrated into the rest of the SDE solving machinery.  Here are some runtimes for the `pvsystem.i_from_v`, `v_from_i`, and `singlediode` functions comparing `method='lambertw'` with `method='logwright'`:

![image](https://github.com/pvlib/pvlib-python/assets/57452607/f645f319-6998-443a-897c-98197f332ee6)