### PR TITLE
Fix spurious test error with pandas 2.1

### DIFF
--- a/pvlib/tests/test_solarposition.py
+++ b/pvlib/tests/test_solarposition.py
@@ -310,7 +310,7 @@ def test_sun_rise_set_transit_ephem_horizon(golden):
     sunrise_delta = datetime.datetime(2016, 1, 3, 7, 17, 11) - \
         datetime.datetime(2016, 1, 3, 7, 21, 33)
     expected = pd.Series(index=times,
-                         data=sunrise_delta,
+                         data=[sunrise_delta],
                          name='sunrise').dt.round('min')
     assert_series_equal(expected, result_rounded)
 


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

As mentioned in https://github.com/pvlib/pvlib-python/pull/1827#issuecomment-1765380810, a pyephem test is failing due to a units difference in pandas datetimes ([example failure](https://github.com/pvlib/pvlib-python/actions/runs/6550206298/job/17788805035?pr=1827)):

```
___________________ test_sun_rise_set_transit_ephem_horizon ____________________

golden = Location: 
  name: None
  latitude: 39.742476
  longitude: -105.1786
  altitude: 1830.14
  tz: America/Denver

    @requires_ephem
    def test_sun_rise_set_transit_ephem_horizon(golden):
        times = pd.DatetimeIndex([datetime.datetime(2016, 1, 3, 0, 0, 0)
                                  ]).tz_localize('MST')
        # center of sun disk
        center = solarposition.sun_rise_set_transit_ephem(
            times,
            latitude=golden.latitude, longitude=golden.longitude)
        edge = solarposition.sun_rise_set_transit_ephem(
            times,
            latitude=golden.latitude, longitude=golden.longitude, horizon='-0:34')
        result_rounded = (edge['sunrise'] - center['sunrise']).dt.round('min')
    
        sunrise_delta = datetime.datetime(2016, 1, 3, 7, 17, 11) - \
            datetime.datetime(2016, 1, 3, 7, 21, 33)
        expected = pd.Series(index=times,
                             data=sunrise_delta,
                             name='sunrise').dt.round('min')
>       assert_series_equal(expected, result_rounded)

pvlib/tests/test_solarposition.py:315: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

left = 2016-01-03 00:00:00-07:00   -1 days +23:56:00
Name: sunrise, dtype: timedelta64[us]
right = 2016-01-03 00:00:00-07:00   -1 days +23:56:00
Name: sunrise, dtype: timedelta64[ns]
kwargs = {'atol': 1e-05, 'rtol': 1e-05}

    def assert_series_equal(left, right, **kwargs):
        kwargs = _check_pandas_assert_kwargs(kwargs)
>       pd.testing.assert_series_equal(left, right, **kwargs)
E       AssertionError: Attributes of Series are different
E       
E       Attribute "dtype" are different
E       [left]:  timedelta64[us]
E       [right]: timedelta64[ns]
```

I think this pandas issue describes the problem: https://github.com/pandas-dev/pandas/issues/55014

In short, the way we construct the expected value in the test results in different units for different pandas versions, and that causes the test to fail.  ~What I don't understand is why it only affects the `conda` CI jobs.~ ah of course, it's because pyephem is optional and not installed in the "bare" jobs.

Anyway I hope this change gets the tests passing again.