### PR TITLE
Fix CAMS message error handler

### DIFF
--- a/docs/examples/iv-modeling/plot_singlediode.py
+++ b/docs/examples/iv-modeling/plot_singlediode.py
@@ -118,7 +118,6 @@ plt.legend(loc=(1.0, 0))
 plt.xlabel('Module voltage [V]')
 plt.ylabel('Module current [A]')
 plt.title(parameters['Name'])
-plt.show()
 plt.gcf().set_tight_layout(True)
 
 
@@ -136,6 +135,7 @@ def draw_arrow(ax, label, x0, y0, rotation, size, direction):
 ax = plt.gca()
 draw_arrow(ax, 'Irradiance', 20, 2.5, 90, 15, 'r')
 draw_arrow(ax, 'Temperature', 35, 1, 0, 15, 'l')
+plt.show()
 
 print(pd.DataFrame({
     'i_sc': curve_info['i_sc'],

--- a/docs/sphinx/source/whatsnew/v0.10.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.3.rst
@@ -24,7 +24,7 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
-
+* Fixed a plotting issue in the IV curve gallery example (:pull:`1895`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.10.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.3.rst
@@ -15,7 +15,8 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
-
+* Fixed CAMS error message handler in
+  :py:func:`pvlib.iotools.sodapro.get_cams` (:issue:`1799`, :pull:`1905`)
 
 Testing
 ~~~~~~~
@@ -32,3 +33,4 @@ Contributors
 * Miguel Sánchez de León Peque (:ghuser:`Peque`)
 * Will Hobbs (:ghuser:`williamhobbs`)
 * Anton Driesse (:ghuser:`adriesse`)
+* Gilles Fischer (:ghuser: `GillesFischerV`)

--- a/docs/sphinx/source/whatsnew/v0.10.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.3.rst
@@ -33,5 +33,5 @@ Contributors
 * Miguel Sánchez de León Peque (:ghuser:`Peque`)
 * Will Hobbs (:ghuser:`williamhobbs`)
 * Anton Driesse (:ghuser:`adriesse`)
-* Gilles Fischer (:ghuser: `GillesFischerV`)
+* Gilles Fischer (:ghuser:`GillesFischerV`)
 * :ghuser:`matsuobasho`

--- a/docs/sphinx/source/whatsnew/v0.10.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.3.rst
@@ -16,7 +16,7 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 * Fixed CAMS error message handler in
-  :py:func:`pvlib.iotools.sodapro.get_cams` (:issue:`1799`, :pull:`1905`)
+  :py:func:`pvlib.iotools.get_cams` (:issue:`1799`, :pull:`1905`)
 
 Testing
 ~~~~~~~
@@ -34,4 +34,6 @@ Contributors
 * Will Hobbs (:ghuser:`williamhobbs`)
 * Anton Driesse (:ghuser:`adriesse`)
 * Gilles Fischer (:ghuser:`GillesFischerV`)
+* Adam R. Jensen (:ghusuer:`AdamRJensen`)
 * :ghuser:`matsuobasho`
+

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -59,7 +59,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     Requests: max. 100 per day
 
     Geographical coverage: worldwide for CAMS McClear and approximately -66° to
-    66° in latitude and -66° to 180° in longitude for CAMS Radiation. See [3]_
+    66° in latitude and -66° to 200° in longitude for CAMS Radiation. See [3]_
     for a map of the geographical coverage.
 
     Parameters

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -221,8 +221,8 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
                        timeout=timeout)
 
     # Response from CAMS follows the status and reason format of PyWPS4
-    # If an error occurs on the server side, it will return error 400 - bad request
-    # Additional information is available in the response text, so it is added 
+    # If an error occurs on server side, it will return error 400 - bad request
+    # Additional information is available in the response text, so it is added
     # to the error displayed to facilitate users effort to fix their request
     if not res.ok:
         errors = res.text.split('ows:ExceptionText')[1][1:-2]

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -57,8 +57,10 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     Access: free, but requires registration, see [2]_
 
     Requests: max. 100 per day
+
     Geographical coverage: worldwide for CAMS McClear and approximately -66° to
-    66° in both latitude and longitude for CAMS Radiation.
+    66° in latitude and -66° to 180° in longitude for CAMS Radiation. See [3]_
+    for a map of the geographical coverage.
 
     Parameters
     ----------
@@ -157,6 +159,9 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
        <https://atmosphere.copernicus.eu/solar-radiation>`_
     .. [2] `CAMS Radiation Automatic Access (SoDa)
        <https://www.soda-pro.com/help/cams-services/cams-radiation-service/automatic-access>`_
+    .. [3] A. R. Jensen et al., pvlib iotools — Open-source Python functions
+       for seamless access to solar irradiance data. Solar Energy. 2023. Vol
+       266, pp. 112092. :doi:`10.1016/j.solener.2023.112092`
     """
     try:
         time_step_str = TIME_STEPS_MAP[time_step]

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -221,9 +221,8 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
                        timeout=timeout)
 
     # Response from CAMS follows the status and reason format of PyWPS4
-    # If an error occurs on our side, we will return error 400 - bad request
-    # Additional information is available in the response text so
-    # we add it here
+    # If an error occurs on the server side, it will return error 400 - bad request
+    # Additional information is available in the response text, so it is added 
     # to the error displayed to facilitate users effort to fix their request
     if not res.ok:
         errors = res.text.split('ows:ExceptionText')[1][1:-2]

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -59,7 +59,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     Requests: max. 100 per day
 
     Geographical coverage: worldwide for CAMS McClear and approximately -66° to
-    66° in latitude and -66° to 200° in longitude for CAMS Radiation. See [3]_
+    66° in latitude and -66° to 180° in longitude for CAMS Radiation. See [3]_
     for a map of the geographical coverage.
 
     Parameters

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -217,11 +217,12 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
 
     # Response from CAMS follows the status and reason format of PyWPS4
     # If an error occurs on our side, we will return error 400 - bad request
-    # Additional information is available in the response text so we add it here 
+    # Additional information is available in the response text so
+    # we add it here
     # to the error displayed to facilitate users effort to fix their request
     if not res.ok:
         errors = res.text.split('ows:ExceptionText')[1][1:-2]
-        res.reason = "%s: <%s>"%(res.reason, errors)
+        res.reason = "%s: <%s>" % (res.reason, errors)
         res.raise_for_status()
     # Successful requests returns a csv data file
     elif res.headers['Content-Type'] == 'application/csv':

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -225,7 +225,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
         res.reason = "%s: <%s>" % (res.reason, errors)
         res.raise_for_status()
     # Successful requests returns a csv data file
-    elif res.headers['Content-Type'] == 'application/csv':
+    else:
         fbuf = io.StringIO(res.content.decode('utf-8'))
         data, metadata = parse_cams(fbuf, integrated=integrated, label=label,
                                     map_variables=map_variables)

--- a/pvlib/tests/iotools/test_sodapro.py
+++ b/pvlib/tests/iotools/test_sodapro.py
@@ -248,7 +248,7 @@ def test_get_cams_bad_request(requests_mock):
     requests inputs. Also tests if the specified server url gets used"""
 
     # Subset of an xml file returned for errornous requests
-    mock_response_bad = """<?xml version="1.0" encoding="utf-8"?>
+    mock_response_bad_text = """<?xml version="1.0" encoding="utf-8"?>
     <ows:Exception exceptionCode="NoApplicableCode" locator="None">
     <ows:ExceptionText>Failed to execute WPS process [get_mcclear]:
         Please, register yourself at www.soda-pro.com
@@ -256,12 +256,12 @@ def test_get_cams_bad_request(requests_mock):
 
     url_cams_bad_request = 'https://pro.soda-is.com/service/wps?DataInputs=latitude=55.7906;longitude=12.5251;altitude=-999;date_begin=2020-01-01;date_end=2020-05-04;time_ref=TST;summarization=PT01H;username=test%2540test.com;verbose=false&Service=WPS&Request=Execute&Identifier=get_mcclear&version=1.0.0&RawDataOutput=irradiation'  # noqa: E501
 
-    requests_mock.get(url_cams_bad_request, text=mock_response_bad,
-                      headers={'Content-Type': 'application/xml'})
+    requests_mock.get(url_cams_bad_request, status_code=400,
+                      text=mock_response_bad_text)
 
     # Test if HTTPError is raised if incorrect input is specified
     # In the below example a non-registrered email is specified
-    with pytest.raises(requests.HTTPError, match='Failed to execute WPS'):
+    with pytest.raises(requests.exceptions.HTTPError, match='Failed to execute WPS process'):
         _ = sodapro.get_cams(
             start=pd.Timestamp('2020-01-01'),
             end=pd.Timestamp('2020-05-04'),

--- a/pvlib/tests/iotools/test_sodapro.py
+++ b/pvlib/tests/iotools/test_sodapro.py
@@ -261,7 +261,8 @@ def test_get_cams_bad_request(requests_mock):
 
     # Test if HTTPError is raised if incorrect input is specified
     # In the below example a non-registrered email is specified
-    with pytest.raises(requests.exceptions.HTTPError, match='Failed to execute WPS process'):
+    with pytest.raises(requests.exceptions.HTTPError,
+                       match='Failed to execute WPS process'):
         _ = sodapro.get_cams(
             start=pd.Timestamp('2020-01-01'),
             end=pd.Timestamp('2020-05-04'),


### PR DESCRIPTION
 - [x] Closes #1799
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Hi! I am Gilles Fischer, a new member of SoDa team working on CAMS project.

With this commit, I suggest a fix to the message error handler for cams request.
If an error occurs on our side, we will return status 400 - Bad request. As it lacks any details, I  suggest to use the error details also available in our response to facilitate the user experience.
It is the default behavior in my PR but I could be only available as a verbose option in get_cams. 

It is my first time working on a open source project so hopefully my contribution will meet your expectation and needs. 

Let me know if anything required more details or work!