### PR TITLE
Add doc notes about using quote marks on Mac when installing `optional` et al

### DIFF
--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -261,7 +261,7 @@ First, install the ``doc`` dependencies specified in the
 `setup.py <https://github.com/pvlib/pvlib-python/blob/main/setup.py>`_.
 An easy way to do this is with::
 
-    pip install pvlib[doc]
+    pip install pvlib[doc]    # on Mac:  pip install "pvlib[doc]"
 
 Note: Anaconda users may have trouble using the above command to update an
 older version of docutils. If that happens, you can update it with ``conda``

--- a/docs/sphinx/source/user_guide/installation.rst
+++ b/docs/sphinx/source/user_guide/installation.rst
@@ -71,7 +71,7 @@ non-editable way, use one of the following commands to install pvlib-python::
 
     # get pvlib and optional dependencies from the Python Package Index
     # another option if you know what you are doing
-    pip install pvlib[optional]
+    pip install pvlib[optional]  # on Mac:  pip install "pvlib[optional]"
 
 .. note::
 
@@ -239,7 +239,7 @@ The Anaconda distribution includes most of the above packages.
 
 Alternatively, users may install all optional dependencies using
 
-    pip install pvlib[optional]
+    pip install pvlib[optional]  # on Mac:  pip install "pvlib[optional]"
 
 
 .. _nrelspa:


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

pvlib defines a few sets of optional dependencies that can be installed with `pip install pvlib[optional]`, `pip install pvlib[test]`, etc.  On zsh, the default shell on Mac, the brackets syntax is interpreted by the shell instead of being passed through to `pip`, so they must be escaped or wrapped in quotation marks like `pip install "pvlib[optional]"`.

In #1167 we decided against documenting this since it's not specific to pvlib, but since it has come up again in the JOSS review (https://github.com/openjournals/joss-reviews/issues/5994#issuecomment-1820067837) I think it's worth a small note in our docs.

This PR edits the `installation` and `contributing` docs pages to mention the correct command for Mac users. 
