### PR TITLE
Fix temp_dew mapping in get_psm3

### DIFF
--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -30,7 +30,7 @@ VARIABLE_MAP = {
     'Clearsky DNI': 'dni_clear',
     'Solar Zenith Angle': 'solar_zenith',
     'Temperature': 'temp_air',
-    'Dew point': 'temp_dew',
+    'Dew Point': 'temp_dew',
     'Relative Humidity': 'relative_humidity',
     'Pressure': 'pressure',
     'Wind Speed': 'wind_speed',

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -172,7 +172,7 @@ def test_read_psm3_map_variables():
     data, metadata = psm3.read_psm3(MANUAL_TEST_DATA, map_variables=True)
     columns_mapped = ['Year', 'Month', 'Day', 'Hour', 'Minute', 'dhi', 'ghi',
                       'dni', 'ghi_clear', 'dhi_clear', 'dni_clear',
-                      'Cloud Type', 'Dew Point', 'solar_zenith',
+                      'Cloud Type', 'temp_dew', 'solar_zenith',
                       'Fill Flag', 'albedo', 'wind_speed',
                       'wind_direction', 'precipitable_water',
                       'relative_humidity', 'temp_air', 'pressure']


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The dew point column name is currently no mapping correctly when using ``map_variables=True`` in ``get_psm3``. The reason is that both words should start with an upper case letter, i.e., "Dew Point" whereas it is currently incorrectly listed as "Dew point" in the VARIABLE_MAP.