### PR TITLE
Skip failing SRML tests

### DIFF
--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -14,6 +14,7 @@ def test_read_srml():
     srml.read_srml(srml_testfile)
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_remote():
@@ -46,6 +47,7 @@ def test_read_srml_nans_exist():
     assert data['dni_0_flag'].iloc[1119] == 99
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.parametrize('url,year,month', [
     ('http://solardat.uoregon.edu/download/Archive/EUPO1801.txt',
      2018, 1),
@@ -76,6 +78,7 @@ def test__map_columns(column, expected):
     assert srml._map_columns(column) == expected
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml():
@@ -86,6 +89,7 @@ def test_get_srml():
     assert_frame_equal(file_data, requested)
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
@@ -97,6 +101,7 @@ def test_read_srml_month_from_solardat():
     assert file_data.equals(requested)
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
@@ -112,6 +117,7 @@ def test_15_minute_dt_index():
     assert (data.index[3::4].minute == 45).all()
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
@@ -127,6 +133,7 @@ def test_hourly_dt_index():
     assert (data.index.minute == 0).all()
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_hourly():
@@ -137,6 +144,7 @@ def test_get_srml_hourly():
     assert_index_equal(data.index, expected_index)
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_minute():
@@ -154,6 +162,7 @@ def test_get_srml_minute():
     assert meta['filenames'] == ['EUPO1801.txt']
 
 
+@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_nonexisting_month_warning():


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The remote data tests in iotools/test_srml.py have been failing for a while. However, the tests first fail after running for a very long time (hours?) which makes testing difficult. The reason is that the SRML website is currently undergoing maintenance - it's unknown when it will be back up and running.

Thus, as a temporary solution, I suggest we mark the remote data SRML tests with ``@pytest.mark.skip`` and create an issue as a reminder to re-enable these tests when the SRML website comes back online.