### PR TITLE
Remove download badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
     <a href="https://pypi.org/project/pvlib/">
     <img src="https://img.shields.io/pypi/v/pvlib.svg" alt="latest release" />
     </a>
-    <a href="https://anaconda.org/conda-forge/pvlib-python">
-    <img src="https://anaconda.org/conda-forge/pvlib-python/badges/version.svg" />
+    <a href="https://anaconda.org/conda-forge/pvlib">
+    <img src="https://anaconda.org/conda-forge/pvlib/badges/version.svg" />
     </a>
-    <a href="https://anaconda.org/conda-forge/pvlib-python">
-    <img src="https://anaconda.org/conda-forge/pvlib-python/badges/latest_release_date.svg" />
+    <a href="https://anaconda.org/conda-forge/pvlib">
+    <img src="https://anaconda.org/conda-forge/pvlib/badges/latest_release_date.svg" />
     </a>
 </tr>
 <tr>

--- a/README.md
+++ b/README.md
@@ -55,17 +55,6 @@
     </a>
   </td>
 </tr>
-<tr>
-  <td>Downloads</td>
-  <td>
-    <a href="https://pypi.org/project/pvlib/">
-    <img src="https://img.shields.io/pypi/dm/pvlib" alt="PyPI downloads" />
-    </a>
-    <a href="https://anaconda.org/conda-forge/pvlib-python">
-    <img src="https://anaconda.org/conda-forge/pvlib-python/badges/downloads.svg" alt="conda-forge downloads" />
-    </a>
-  </td>
-</tr>
 </table>
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
There are currently two download badges on the pvlib python README page:
![image](https://github.com/pvlib/pvlib-python/assets/39184289/a18623af-cbea-4b96-a792-5fba0386c9b3)

The first badge is from PyPi and the second from conda forge. Both badges show approximately the same number of downloads, but the first is per month and the second is totals - that seems inconsistent although I realize that they're different sources. I simply suggest to declutter the badge section and remove this downloads as they are dominated by automated tests downloading the packages and doesn't add any meaningful information/value (i.e., they say nothing about our actual user base).

There are already badges for both PyPi and conda forge at the top of the bad section in the "Latest release" section.