### PR TITLE
Include pvarray in `__init__.py`

### DIFF
--- a/pvlib/__init__.py
+++ b/pvlib/__init__.py
@@ -14,6 +14,7 @@ from pvlib import (  # noqa: F401
     ivtools,
     location,
     modelchain,
+    pvarray,
     pvsystem,
     scaling,
     shading,


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

`pvlib.pvarray` doesn't behave as you might expect:

```python
In [1]: import pvlib

In [2]: pvlib.pvsystem.sapm
Out[2]: <function pvlib.pvsystem.sapm(effective_irradiance, temp_cell, module)>

In [3]: pvlib.pvarray.pvefficiency_adr
Traceback (most recent call last):

  Cell In[3], line 1
    pvlib.pvarray.pvefficiency_adr

AttributeError: module 'pvlib' has no attribute 'pvarray'
```

This is because it was not listed in the `__init__.py` file.  This one-line PR lists it there so that the behavior becomes:

```python
In [1]: import pvlib

In [2]: pvlib.pvarray.pvefficiency_adr
Out[2]: <function pvlib.pvarray.pvefficiency_adr(effective_irradiance, temp_cell, k_a, k_d, tc_d, k_rs, k_rsh)>
```
