### PR TITLE
Enable numba and nrel-pysam in py3.12 anaconda environments

### DIFF
--- a/ci/requirements-py3.12.yml
+++ b/ci/requirements-py3.12.yml
@@ -7,7 +7,7 @@ dependencies:
     - cython
     - ephem
     - h5py
-    # - numba  # not available for 3.12 as of 2023-12-12
+    - numba
     - numpy >= 1.16.0
     - pandas >= 0.25.0
     - pip
@@ -23,6 +23,6 @@ dependencies:
     - requests
     - scipy >= 1.5.0
     - statsmodels
-    # - pip:
-        # - nrel-pysam>=2.0  # not available for 3.12 as of 2023-12-12
+    - pip:
+        - nrel-pysam>=2.0
         # - solarfactors  # required shapely<2 isn't available for 3.12


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Python 3.12 wheels weren't available for Numba and PySAM when we started testing on 3.12 in #1886.  Now they are!  This PR adds them to the anaconda environment spec so that the relevant tests will now run in the python 3.12 jobs.