### PR TITLE
Correct usage of `xtol` in `ghi_from_poa_driesse_2023`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.4.rst
@@ -14,6 +14,8 @@ Bug fixes
 ~~~~~~~~~
 * :py:class:`~pvlib.modelchain.ModelChain` now raises a more useful error when
   ``temperature_model_parameters`` are specified on the passed ``system`` instead of on its ``arrays``. (:issue:`1759`).
+* :py:func:`pvlib.irradiance.ghi_from_poa_driesse_2023` now correctly makes use
+  of the ``xtol`` argument. Previously, it was ignored. (:issue:`1970`, :pull:`1971`)
 
 Testing
 ~~~~~~~

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1513,15 +1513,11 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
                         full_output=True,
                         disp=False,
                         )
-    except ValueError as e:
-        if "f(a) and f(b) must have different signs" in e.args:
-            # this occurs when poa_error has the same sign at both end points
-            ghi = np.nan
-            conv = False
-            niter = -1
-        else:
-            # propagate other ValueError's, like a non-positive xtol
-            raise e
+    except ValueError:
+        # this occurs when poa_error has the same sign at both end points
+        ghi = np.nan
+        conv = False
+        niter = -1
     else:
         ghi = result[0]
         conv = result[1].converged
@@ -1596,6 +1592,9 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
     gti_dirint
     '''
     # Contributed by Anton Driesse (@adriesse), PV Performance Labs. Nov., 2023
+
+    if xtol <= 0:
+        raise ValueError(f"xtol too small ({xtol:g} <= 0)")
 
     ghi_from_poa_array = np.vectorize(_ghi_from_poa)
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1599,7 +1599,7 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
                                           solar_zenith, solar_azimuth,
                                           poa_global,
                                           dni_extra, airmass, albedo,
-                                          xtol=0.01)
+                                          xtol=xtol)
 
     if isinstance(poa_global, pd.Series):
         ghi = pd.Series(ghi, poa_global.index)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1514,12 +1514,13 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
                         disp=False,
                         )
     except ValueError as e:
-        # this may occur because poa_error has the same sign at both end points
         if "f(a) and f(b) must have different signs" in e.args:
+            # this occurs when poa_error has the same sign at both end points
             ghi = np.nan
             conv = False
             niter = -1
         else:
+            # propagate other ValueError's, like a non-positive xtol
             raise e
     else:
         ghi = result[0]
@@ -1560,8 +1561,8 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
     albedo : numeric, default 0.25
         Ground surface albedo. [unitless]
     xtol : numeric, default 0.01
-        Convergence criterion.  The estimated GHI will be within xtol of the
-        true value. [W/m^2]
+        Convergence criterion. The estimated GHI will be within xtol of the
+        true value. Must be positive. [W/m^2]
     full_output : boolean, default False
         If full_output is False, only ghi is returned, otherwise the return
         value is (ghi, converged, niter). (see Returns section for details).

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1513,11 +1513,14 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
                         full_output=True,
                         disp=False,
                         )
-    except ValueError:
-        # this occurs when poa_error has the same sign at both end points
-        ghi = np.nan
-        conv = False
-        niter = -1
+    except ValueError as e:
+        # this may occur because poa_error has the same sign at both end points
+        if "f(a) and f(b) must have different signs" in e.args:
+            ghi = np.nan
+            conv = False
+            niter = -1
+        else:
+            raise e
     else:
         ghi = result[0]
         conv = result[1].converged

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -828,7 +828,7 @@ def test_ghi_from_poa_driesse():
     # test xtol propagation by producing an exception
     poa_global = pd.Series([20, 300, 1000], index=times)
     xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
-    with pytest.raises(ValueError, match="xtol too small \(%g <= 0\)" % xtol):
+    with pytest.raises(ValueError, match=r"xtol too small \(%g <= 0\)" % xtol):
         output = irradiance.ghi_from_poa_driesse_2023(
             surface_tilt, surface_azimuth, zenith, azimuth,
             poa_global, dni_extra=1366.1, xtol=xtol)

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -1,6 +1,7 @@
 import datetime
 from collections import OrderedDict
 import warnings
+import re
 
 import numpy as np
 from numpy import array, nan
@@ -824,6 +825,16 @@ def test_ghi_from_poa_driesse():
 
     expected = [0, -1, 0]
     assert_allclose(expected, niter)
+
+    # test xtol propagation by producing an exception
+    poa_global = pd.Series([20, 300, 1000], index=times)
+    xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
+    with pytest.raises(
+        ValueError,
+        match=re.escape("xtol too small (%g <= 0)" % xtol)):
+        output = irradiance.ghi_from_poa_driesse_2023(
+            surface_tilt, surface_azimuth, zenith, azimuth,
+            poa_global, dni_extra=1366.1, xtol=xtol)
 
 
 def test_gti_dirint():

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -1,7 +1,6 @@
 import datetime
 from collections import OrderedDict
 import warnings
-import re
 
 import numpy as np
 from numpy import array, nan

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -829,10 +829,7 @@ def test_ghi_from_poa_driesse():
     # test xtol propagation by producing an exception
     poa_global = pd.Series([20, 300, 1000], index=times)
     xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
-    with pytest.raises(
-        ValueError,
-        match=re.escape("xtol too small (%g <= 0)" % xtol)
-    ):
+    with pytest.raises(ValueError, match="xtol too small \(%g <= 0\)" % xtol):
         output = irradiance.ghi_from_poa_driesse_2023(
             surface_tilt, surface_azimuth, zenith, azimuth,
             poa_global, dni_extra=1366.1, xtol=xtol)

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -831,7 +831,8 @@ def test_ghi_from_poa_driesse():
     xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
     with pytest.raises(
         ValueError,
-        match=re.escape("xtol too small (%g <= 0)" % xtol)):
+        match=re.escape("xtol too small (%g <= 0)" % xtol)
+    ):
         output = irradiance.ghi_from_poa_driesse_2023(
             surface_tilt, surface_azimuth, zenith, azimuth,
             poa_global, dni_extra=1366.1, xtol=xtol)


### PR DESCRIPTION
 - [x] Closes #1970 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I believe linked issue gives enough context.
