### PR TITLE
Update asv.conf.json

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -113,15 +113,15 @@
     "include": [
         // minimum supported versions
         {
-            "python": "3.7",
+            "python": "3.12.1",
             "build": "",
-            "numpy": "1.16.5",
-            "pandas": "0.25.0",
-            "scipy": "1.5.0",
+            "numpy": "1.26.4",
+            "pandas": "2.2.0",
+            "scipy": "1.12.0",
             // Note: these don't have a minimum in setup.py
-            "h5py": "3.1.0",
-            "ephem": "3.7.6.0",
-            "numba": "0.40.0"
+            "h5py": "3.10.0",
+            "ephem": "4.1.5",
+            "numba": "0.59.0"
         },
         // latest versions available
         {

--- a/docs/sphinx/source/whatsnew/v0.9.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.5.rst
@@ -52,6 +52,8 @@ Bug fixes
   and ``after`` for consistency with ``cftime>=1.6.0``. (:issue:`1609`, :pull:`1656`)
 * :py:func:`~pvlib.ivtools.sdm.pvsyst_temperature_coeff` no longer raises
   a scipy deprecation warning (and is slightly more accurate). (:issue:`1644`, :pull:`1674`)
+* changed versions of ephem,numba,numpa,pandas,python,scipy as mentioned in default anaconda channel conda-forge in asv.conf.json file so that asv run successfully.
+
 
 Testing
 ~~~~~~~


### PR DESCRIPTION
while trying to bench mark some pvlib functions i got some error and sorted it out by changing versions of python,numpy,pandas,scipy,h5py,ephem and numba as mentioned in anaconda default channel conda-forge

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1972 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 -

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
