### PR TITLE
ASV: bump numpy and pandas versions to match new requirements

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -115,7 +115,7 @@
         {
             "python": "3.7",
             "build": "",
-            "numpy": "1.17.3",
+            "numpy": "1.17.5",
             "pandas": "1.3.0",
             "scipy": "1.5.0",
             // Note: these don't have a minimum in setup.py

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -115,8 +115,8 @@
         {
             "python": "3.7",
             "build": "",
-            "numpy": "1.16.5",
-            "pandas": "0.25.0",
+            "numpy": "1.17.3",
+            "pandas": "1.3.0",
             "scipy": "1.5.0",
             // Note: these don't have a minimum in setup.py
             "h5py": "3.1.0",


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - ~[ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.~

Follow-up to #1969; copying our new dependency minimum requirements to the asv benchmarks configuration.
