### PR TITLE
Update SRML test url and re-enable tests

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.4.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.4.rst
@@ -37,6 +37,8 @@ Bug fixes
 * Fixed incorrect unit conversion of precipitable water used for the Solcast iotools functions.
 * :py:class:`~pvlib.modelchain.ModelChain.infer_temperature_model` now raises a more useful error when
   the temperature model cannot be inferred (:issue:`1946`)
+* The default URL for retrieving irradiance data from the SRML network was updated in
+  :py:func:`~pvlib.iotools.get_srml` (:pull:`1957`, :issue:`1922`)
 
 Testing
 ~~~~~~~

--- a/pvlib/tests/iotools/test_srml.py
+++ b/pvlib/tests/iotools/test_srml.py
@@ -14,11 +14,12 @@ def test_read_srml():
     srml.read_srml(srml_testfile)
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_remote():
-    srml.read_srml('http://solardat.uoregon.edu/download/Archive/EUPO1801.txt')
+    srml.read_srml(
+        'http://solardata.uoregon.edu/download/Archive/EUPO1801.txt'
+    )
 
 
 def test_read_srml_columns_exist():
@@ -47,11 +48,10 @@ def test_read_srml_nans_exist():
     assert data['dni_0_flag'].iloc[1119] == 99
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.parametrize('url,year,month', [
-    ('http://solardat.uoregon.edu/download/Archive/EUPO1801.txt',
+    ('http://solardata.uoregon.edu/download/Archive/EUPO1801.txt',
      2018, 1),
-    ('http://solardat.uoregon.edu/download/Archive/EUPO1612.txt',
+    ('http://solardata.uoregon.edu/download/Archive/EUPO1612.txt',
      2016, 12),
 ])
 @pytest.mark.remote_data
@@ -78,30 +78,27 @@ def test__map_columns(column, expected):
     assert srml._map_columns(column) == expected
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml():
-    url = 'http://solardat.uoregon.edu/download/Archive/EUPO1801.txt'
+    url = 'http://solardata.uoregon.edu/download/Archive/EUPO1801.txt'
     file_data = srml.read_srml(url)
     requested, _ = srml.get_srml(station='EU', start='2018-01-01',
                                  end='2018-01-31')
     assert_frame_equal(file_data, requested)
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_read_srml_month_from_solardat():
-    url = 'http://solardat.uoregon.edu/download/Archive/EUPO1801.txt'
+    url = 'http://solardata.uoregon.edu/download/Archive/EUPO1801.txt'
     file_data = srml.read_srml(url)
     with pytest.warns(pvlibDeprecationWarning, match='get_srml instead'):
         requested = srml.read_srml_month_from_solardat('EU', 2018, 1)
     assert file_data.equals(requested)
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
@@ -117,7 +114,6 @@ def test_15_minute_dt_index():
     assert (data.index[3::4].minute == 45).all()
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @fail_on_pvlib_version('0.11')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
@@ -133,7 +129,6 @@ def test_hourly_dt_index():
     assert (data.index.minute == 0).all()
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_hourly():
@@ -144,7 +139,6 @@ def test_get_srml_hourly():
     assert_index_equal(data.index, expected_index)
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_minute():
@@ -162,7 +156,6 @@ def test_get_srml_minute():
     assert meta['filenames'] == ['EUPO1801.txt']
 
 
-@pytest.mark.skip(reason="SRML server is undergoing maintenance as of 12-2023")
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_srml_nonexisting_month_warning():


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #1922
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - ~~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The SRML data is now again available following the original structure, but the URL has changed. Note, the URL in the ``get_srml`` function has already been updated previously, so this PR is only related to tests (hence no whatsnew entry).

The SRML tests were disabled in #1921.