### PR TITLE
Typo in plot_oedi_9068.py

### DIFF
--- a/docs/examples/system-models/plot_oedi_9068.py
+++ b/docs/examples/system-models/plot_oedi_9068.py
@@ -231,7 +231,7 @@ df_inverter_measured = df_inverter_measured.tz_localize('US/Mountain',
                                                         ambiguous='NaT',
                                                         nonexistent='NaT')
 # convert to standard time to match the NSRDB-based simulation
-df_inverter_measred = df_inverter_measured.tz_convert('Etc/GMT+7')
+df_inverter_measured = df_inverter_measured.tz_convert('Etc/GMT+7')
 
 # %%
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Solve a typo in said file. View [conversation](https://github.com/pvlib/pvlib-python/commit/c90cb4edb5aef6aea265d4ee5c32cafd3a4e7097#r139975961).
