### PR TITLE
changed colorbar for plots in plot_sunpath_diagrams.py

### DIFF
--- a/docs/examples/solar-position/plot_sunpath_diagrams.py
+++ b/docs/examples/solar-position/plot_sunpath_diagrams.py
@@ -31,9 +31,16 @@ solpos = solpos.loc[solpos['apparent_elevation'] > 0, :]
 
 ax = plt.subplot(1, 1, 1, projection='polar')
 # draw the analemma loops
-points = ax.scatter(np.radians(solpos.azimuth), solpos.apparent_zenith,
-                    s=2, label=None, c=solpos.index.dayofyear)
-ax.figure.colorbar(points)
+points = ax.scatter(np.radians(solpos.azimuth), solpos.apparent_zenith, s=2, label=None, c=solpos.index.dayofyear)
+# Create colorbar
+cbar = ax.figure.colorbar(points)
+# Define ticks for the middle of each month (assuming non-leap year for simplicity)
+month_ticks = [pd.Timestamp(f'2023-{month}-15').dayofyear for month in range(1, 13)]
+# Set colorbar ticks
+cbar.set_ticks(month_ticks) 
+# Set colorbar tick labels to short month names
+month_names = [pd.Timestamp(f'2023-{month}-15').strftime('%b') for month in range(1, 13)]
+cbar.set_ticklabels(month_names)
 
 # draw hour labels
 for hour in np.unique(solpos.index.hour):
@@ -111,9 +118,16 @@ solpos = solarposition.get_solarposition(times, lat, lon)
 solpos = solpos.loc[solpos['apparent_elevation'] > 0, :]
 
 fig, ax = plt.subplots()
-points = ax.scatter(solpos.azimuth, solpos.apparent_elevation, s=2,
-                    c=solpos.index.dayofyear, label=None)
-fig.colorbar(points)
+points = ax.scatter(np.radians(solpos.azimuth), solpos.apparent_zenith, s=2, label=None, c=solpos.index.dayofyear)
+# Create colorbar
+cbar = ax.figure.colorbar(points)
+# Define ticks for the middle of each month (assuming non-leap year for simplicity)
+month_ticks = [pd.Timestamp(f'2023-{month}-15').dayofyear for month in range(1, 13)]
+# Set colorbar ticks
+cbar.set_ticks(month_ticks) 
+# Set colorbar tick labels to short month names
+month_names = [pd.Timestamp(f'2023-{month}-15').strftime('%b') for month in range(1, 13)]
+cbar.set_ticklabels(month_names)
 
 for hour in np.unique(solpos.index.hour):
     # choose label position by the largest elevation for each hour


### PR DESCRIPTION
The scale for the colorbar was numerical from 0-365. The monthly scale in Short month names is much more intuitive for me.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
