### PR TITLE
Fix Windows/Conda CI error in test_singlediode.py

### DIFF
--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -175,7 +175,7 @@ def test_singlediode_lambert_negative_voc():
     assert_approx_equal(outs['v_oc'], 0)
 
     # Testing for an array
-    x  = np.array([x, x]).T
+    x = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method='lambertw')
     assert_approx_equal(outs['v_oc'], [0, 0])
 

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -177,15 +177,15 @@ def test_singlediode_lambert_negative_voc(mocker):
     # mock it. It depends on the platform and Python distro. See issue #2000.
     patcher = mocker.patch("pvlib.singlediode._lambertw_v_from_i")
     x = np.array([0.0, 1.480501e-11, 0.178, 8000.0, 1.797559])
-    patcher.return_value=-9.999e-13
+    patcher.return_value = -9.999e-13
     outs = pvsystem.singlediode(*x, method="lambertw")
     assert outs["v_oc"] == 0
 
     # Testing for an array
-    patcher.return_value=np.array([-9.999e-13, -1.001e-13])
+    patcher.return_value = np.array([-9.999e-13, -1.001e-13])
     x = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method="lambertw")
-    assert_array_equal(outs['v_oc'], [0, 0])
+    assert_array_equal(outs["v_oc"], [0, 0])
 
 
 @pytest.mark.parametrize('method', ['lambertw'])

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -10,7 +10,7 @@ from pvlib.singlediode import (bishop88_mpp, estimate_voc, VOLTAGE_BUILTIN,
                                bishop88, bishop88_i_from_v, bishop88_v_from_i)
 from pvlib._deprecation import pvlibDeprecationWarning
 import pytest
-from numpy.testing import assert_approx_equal
+from numpy.testing import assert_allclose
 from .conftest import DATA_DIR
 
 POA = 888
@@ -172,12 +172,12 @@ def test_singlediode_lambert_negative_voc():
     # Those values result in a negative v_oc out of `_lambertw_v_from_i`
     x = np.array([0., 1.480501e-11, 0.178, 8000., 1.797559])
     outs = pvsystem.singlediode(*x, method='lambertw')
-    assert_approx_equal(outs['v_oc'], 0)
+    assert_allclose(outs['v_oc'], 0)
 
     # Testing for an array
     x = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method='lambertw')
-    assert_approx_equal(outs['v_oc'], [0, 0])
+    assert_allclose(outs['v_oc'].values, [0, 0])
 
 
 @pytest.mark.parametrize('method', ['lambertw'])

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -10,6 +10,7 @@ from pvlib.singlediode import (bishop88_mpp, estimate_voc, VOLTAGE_BUILTIN,
                                bishop88, bishop88_i_from_v, bishop88_v_from_i)
 from pvlib._deprecation import pvlibDeprecationWarning
 import pytest
+from numpy.testing import assert_approx_equal
 from .conftest import DATA_DIR
 
 POA = 888
@@ -168,16 +169,15 @@ def test_singlediode_precision(method, precise_iv_curves):
 
 
 def test_singlediode_lambert_negative_voc():
-
     # Those values result in a negative v_oc out of `_lambertw_v_from_i`
     x = np.array([0., 1.480501e-11, 0.178, 8000., 1.797559])
     outs = pvsystem.singlediode(*x, method='lambertw')
-    assert outs['v_oc'] == 0
+    assert_approx_equal(outs['v_oc'], 0)
 
     # Testing for an array
     x  = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method='lambertw')
-    assert np.array_equal(outs['v_oc'], [0, 0])
+    assert_approx_equal(outs['v_oc'], [0, 0])
 
 
 @pytest.mark.parametrize('method', ['lambertw'])


### PR DESCRIPTION
 - [x] Closes #2000
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fixes the Windows-conda error by mocking the platform-variadic `_lambert_v_from_i` .

No need for a whatsnew entry I believe.