### PR TITLE
Remove link to outdated tutorials

### DIFF
--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -29,7 +29,7 @@ pvlib-python, git, or Python:
   `easy <https://github.com/pvlib/pvlib-python/labels/easy>`_,
   or `help wanted <https://github.com/pvlib/pvlib-python/labels/help%20wanted>`_.
 * Improve the documentation and the unit tests.
-* Improve the IPython/Jupyter Notebook tutorials or write new ones that
+* Improve the Example Gallery or add new examples that
   demonstrate how to use pvlib-python in your area of expertise.
 * If you have MATLAB experience, you can help us keep pvlib-python
   up to date with PVLIB_MATLAB or help us develop common unit tests.

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -15,8 +15,7 @@ The source code for pvlib python is hosted on `GitHub
 Please see the :ref:`installation` page for installation help.
 
 For examples of how to use pvlib python, please see
-:ref:`package_overview` and the `Example Gallery
-<https://pvlib-python.readthedocs.io/en/stable/gallery/index.html/>`_.
+:ref:`package_overview` and the :ref:`example_gallery`.
 The documentation assumes general familiarity with
 Python, NumPy, and Pandas. Google searches will yield many
 excellent tutorials for these packages.

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -10,14 +10,14 @@ energy systems and accomplishing related tasks.
 The core mission of pvlib python is to provide open,
 reliable, interoperable, and benchmark implementations of PV system models.
 
-The source code for pvlib python is hosted on `github
+The source code for pvlib python is hosted on `GitHub
 <https://github.com/pvlib/pvlib-python>`_.
 Please see the :ref:`installation` page for installation help.
 
 For examples of how to use pvlib python, please see
-:ref:`package_overview` and our `Jupyter Notebook tutorials
-<http://nbviewer.org/github/pvlib/pvlib-python/tree/main/docs/
-tutorials/>`_. The documentation assumes general familiarity with
+:ref:`package_overview` and the `Example Gallery
+<https://pvlib-python.readthedocs.io/en/stable/gallery/index.html/>`_.
+The documentation assumes general familiarity with
 Python, NumPy, and Pandas. Google searches will yield many
 excellent tutorials for these packages.
 

--- a/docs/sphinx/source/user_guide/installation.rst
+++ b/docs/sphinx/source/user_guide/installation.rst
@@ -83,15 +83,10 @@ for a password then you're probably trying to install pvlib into your
 system's Python distribution. This is usually a bad idea and you should
 follow the :ref:`nopython` instructions before installing pvlib.
 
-You may still want to download the Python source code so that you can
-easily get all of the Jupyter Notebook tutorials. Either clone the `git
+You may still want to download the Python source code. Either clone the `git
 repository <https://github.com/pvlib/pvlib-python>`_ or go to the
 `Releases page <https://github.com/pvlib/pvlib-python/releases>`_ to
-download the zip file of the most recent release. You can also use the
-nbviewer website to choose a tutorial to experiment with. Go to our
-`nbviewer tutorial page
-<http://nbviewer.jupyter.org/github/pvlib/pvlib-python/tree/main/docs/
-tutorials/>`_.
+download the zip file of the most recent release.
 
 
 .. _editablelibrary:

--- a/docs/sphinx/source/user_guide/installation.rst
+++ b/docs/sphinx/source/user_guide/installation.rst
@@ -220,7 +220,7 @@ pvlib-python is compatible with Python 3.
 
 pvlib-python requires Pandas, Numpy, and SciPy. The minimum version requirements
 are specified in
-`setup.py <https://github.com/pvlib/pvlib-python/blob/main/setup.py>`_.
+`pyproject.toml <https://github.com/pvlib/pvlib-python/blob/main/pyproject.toml>`_.
 They are typically releases from several years ago.
 
 A handful of pvlib-python features require additional packages that must

--- a/docs/sphinx/source/user_guide/package_overview.rst
+++ b/docs/sphinx/source/user_guide/package_overview.rst
@@ -12,7 +12,8 @@ interoperable, and benchmark implementations of PV system models.
 There are at least as many opinions about how to model PV systems as
 there are modelers of PV systems, so pvlib-python provides several
 modeling paradigms: functions, the Location/PVSystem classes, and the
-ModelChain class.
+ModelChain class. Read more about this in the :ref:`introtutorial`
+section.
 
 
 User extensions

--- a/docs/sphinx/source/user_guide/package_overview.rst
+++ b/docs/sphinx/source/user_guide/package_overview.rst
@@ -12,8 +12,7 @@ interoperable, and benchmark implementations of PV system models.
 There are at least as many opinions about how to model PV systems as
 there are modelers of PV systems, so pvlib-python provides several
 modeling paradigms: functions, the Location/PVSystem classes, and the
-ModelChain class. Read more about this in the :ref:`introtutorial`
-section.
+ModelChain class.
 
 
 User extensions


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The tutorials referenced have not been maintained for several years and should in my opinion not be referenced as a first place to start.