### PR TITLE
Minor improvements to "PV System Models" reference page

### DIFF
--- a/docs/sphinx/source/reference/pv_modeling/system_models.rst
+++ b/docs/sphinx/source/reference/pv_modeling/system_models.rst
@@ -13,10 +13,11 @@ Sandia array performance model (SAPM)
    pvsystem.sapm
    pvsystem.sapm_effective_irradiance
    pvsystem.sapm_spectral_loss
+   spectrum.spectral_factor_sapm
    inverter.sandia
    temperature.sapm_cell
 
-Pvsyst model
+PVsyst model
 ^^^^^^^^^^^^
 
 .. autosummary::


### PR DESCRIPTION
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.


#1628 deprecated `pvlib.pvsystem.sapm_spectral_loss`, replacing it with `pvlib.spectrum.spectral_factor_sapm`.  This adds an entry for the new name in the "SAPM" section of the Reference docs. 

It also corrects the capitalization of "Pvsyst" to "PVsyst".