### PR TITLE
Fix silently ignoring file path in `pvsystem.retrieve_sam` when `name` is provided

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.10.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.5.rst
@@ -38,3 +38,5 @@ Requirements
 Contributors
 ~~~~~~~~~~~~
 * Cliff Hansen (:ghuser:`cwhanse`)
+* :ghuser:`apct69`
+* Mark Mikofski (:ghuser:`mikofski`)

--- a/docs/sphinx/source/whatsnew/v0.10.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.5.rst
@@ -15,6 +15,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+* Fixed :py:func:`pvlib.pvsystem.retrieve_sam` silently ignoring the `path` parameter
+  when `name` was provided. Now an exception is raised requesting to only provide one
+  of the two parameters. (:issue:`2018`, :pull:`2020`)
 
 
 Testing

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2060,7 +2060,8 @@ def retrieve_sam(name=None, path=None):
             )
         except KeyError:
             raise KeyError(
-                f"Invalid name {name}. Provide one of {internal_dbs.keys()}."
+                f"Invalid name {name}. "
+                + f"Provide one of {list(internal_dbs.keys())}."
             ) from None
     else:  # path is not None
         if path.lower().startswith("http"):  # URL check is not case-sensitive

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1979,6 +1979,7 @@ def retrieve_sam(name=None, path=None):
     name : string, optional
         Use one of the following strings to retrieve a database bundled with
         pvlib:
+
         * 'CECMod' - returns the CEC module database
         * 'CECInverter' - returns the CEC Inverter database
         * 'SandiaInverter' - returns the CEC Inverter database

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1957,7 +1957,7 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
     return tuple(pd.Series(a, index=index).rename(None) for a in out)
 
 
-def retrieve_sam(name_or_path):
+def retrieve_sam(name_or_path=None, name=None, path=None):
     """
     Retrieve latest module and inverter info from a file bundled with pvlib,
     a path or an URL (like SAM's website).
@@ -1985,6 +1985,16 @@ def retrieve_sam(name_or_path):
         * 'ADRInverter' - returns the ADR Inverter database
 
         Additionally, a path to a CSV file or a URL can be provided.
+
+    name : string, optional
+        Name of the database to use.
+        .. deprecated:: 0.10.5
+            Use ``name_or_path`` instead.
+
+    path : string, optional
+        Path to a CSV file or a URL.
+        .. deprecated:: 0.10.5
+            Use ``name_or_path`` instead.
 
     Returns
     -------
@@ -2030,6 +2040,22 @@ def retrieve_sam(name_or_path):
     CEC_Type     Utility Interactive
     Name: AE_Solar_Energy__AE6_0__277V_, dtype: object
     """
+    # error: path was previously silently ignored if name was given GH#2018
+    if name is not None and path is not None:
+        raise ValueError("Please only provide 'name_or_path', not both.")
+    # deprecation warning for name and path if given GH#2018
+    if name is not None or path is not None:
+        warn_deprecated(
+            since="0.10.5",
+            removal="0.11.0",
+            message=(
+                "'name' and 'path' parameters have been deprecated in "
+                + "favor of 'name_or_path' parameter."
+            ),
+            name="pvlib.pvsystem.retrieve_sam",
+            obj_type="parameters 'name' and 'path'",
+        )
+        name_or_path = name or path
     internal_dbs = {
         "cecmod": "sam-library-cec-modules-2019-03-05.csv",
         "sandiamod": "sam-library-sandia-modules-2015-6-30.csv",

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2004,10 +2004,8 @@ def retrieve_sam(name=None, path=None):
         If no ``name`` or ``path`` is provided.
     ValueError
         If both ``name`` and ``path`` are provided.
-    ValueError
-        If the provided ``name`` is not valid.
-    ValueError
-        If the provided ``path`` does not exist.
+    KeyError
+        If the provided ``name`` is not a valid database name.
 
     Notes
     -----
@@ -2056,23 +2054,20 @@ def retrieve_sam(name=None, path=None):
             "cecinverter": "sam-library-cec-inverters-2019-03-05.csv",
             "sandiainverter": "sam-library-cec-inverters-2019-03-05.csv",
         }
-        name_lwr = name.lower()
-        if name_lwr in internal_dbs.keys():  # input is a database name
+        try:
             csvdata_path = Path(__file__).parent.joinpath(
-                "data", internal_dbs[name_lwr]
+                "data", internal_dbs[name.lower()]
             )
-        else:
-            raise ValueError(
+        except KeyError:
+            raise KeyError(
                 f"Invalid name {name}. Provide one of {internal_dbs.keys()}."
-            )
+            ) from None
     else:  # path is not None
         if path.lower().startswith("http"):  # URL check is not case-sensitive
             response = urlopen(path)  # URL is case-sensitive
             csvdata_path = io.StringIO(response.read().decode(errors="ignore"))
-        elif Path(path).exists():
-            csvdata_path = path
         else:
-            raise ValueError(f"Invalid path {path}: does not exist.")
+            csvdata_path = path
     return _parse_raw_sam_df(csvdata_path)
 
 

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -117,7 +117,7 @@ def test_retrieve_sam_raises_exceptions():
         pvsystem.retrieve_sam(path="this_surely_wont_work.csv")
 
 
-def test_retrieve_sam_cecinverter():
+def test_retrieve_sam_databases():
     """Test the expected keys are retrieved from each database."""
     keys_per_database = {
         "cecmod": {'Technology', 'Bifacial', 'STC', 'PTC', 'A_c', 'Length',
@@ -140,7 +140,7 @@ def test_retrieve_sam_cecinverter():
                         'C3', 'Pnt', 'Vdcmax', 'Idcmax', 'Mppt_low',
                         'Mppt_high', 'CEC_Date', 'CEC_Type'}
     }  # fmt: skip
-    module_per_database = {
+    item_per_database = {
         "cecmod": "Itek_Energy_LLC_iT_300_HE",
         "sandiamod": "Canadian_Solar_CS6X_300M__2013_",
         "adrinverter": "Sainty_Solar__SSI_4K4U_240V__CEC_2011_",
@@ -148,12 +148,12 @@ def test_retrieve_sam_cecinverter():
     }
     # duplicate the cecinverter items for sandiainverter, for backwards compat
     keys_per_database["sandiainverter"] = keys_per_database["cecinverter"]
-    module_per_database["sandiainverter"] = module_per_database["cecinverter"]
+    item_per_database["sandiainverter"] = item_per_database["cecinverter"]
 
     for database in keys_per_database.keys():
         data = pvsystem.retrieve_sam(database)
         assert set(data.index) == keys_per_database[database]
-        assert module_per_database[database] in data.columns
+        assert item_per_database[database] in data.columns
 
 
 def test_sapm(sapm_module_params):

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -111,9 +111,9 @@ def test_retrieve_sam_raises_exceptions():
         pvsystem.retrieve_sam()
     with pytest.raises(ValueError, match="Please provide either.*, not both."):
         pvsystem.retrieve_sam(name="this_surely_wont_work", path="wont_work")
-    with pytest.raises(ValueError, match="Invalid name"):
+    with pytest.raises(KeyError, match="Invalid name"):
         pvsystem.retrieve_sam(name="this_surely_wont_work")
-    with pytest.raises(ValueError, match="Invalid path"):
+    with pytest.raises(FileNotFoundError):
         pvsystem.retrieve_sam(path="this_surely_wont_work.csv")
 
 
@@ -140,14 +140,15 @@ def test_retrieve_sam_cecinverter():
                         'C3', 'Pnt', 'Vdcmax', 'Idcmax', 'Mppt_low',
                         'Mppt_high', 'CEC_Date', 'CEC_Type'}
     }  # fmt: skip
-    keys_per_database["sandiainverter"] = keys_per_database["cecinverter"]
     module_per_database = {
         "cecmod": "Itek_Energy_LLC_iT_300_HE",
         "sandiamod": "Canadian_Solar_CS6X_300M__2013_",
         "adrinverter": "Sainty_Solar__SSI_4K4U_240V__CEC_2011_",
         "cecinverter": "ABB__PVI_3_0_OUTD_S_US__208V_",
-        "sandiainverter": "ABB__PVI_3_0_OUTD_S_US__208V_"
     }
+    # duplicate the cecinverter items for sandiainverter, for backwards compat
+    keys_per_database["sandiainverter"] = keys_per_database["cecinverter"]
+    module_per_database["sandiainverter"] = module_per_database["cecinverter"]
 
     for database in keys_per_database.keys():
         data = pvsystem.retrieve_sam(database)

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -103,12 +103,18 @@ def test_PVSystem_get_iam_invalid(sapm_module_params, mocker):
         system.get_iam(45, iam_model='not_a_model')
 
 
-def test_retrieve_sam_raise_no_parameters():
+def test_retrieve_sam_raises_exceptions():
     """
     Raise an exception if an invalid parameter is provided to `retrieve_sam()`.
     """
+    with pytest.raises(ValueError, match="Please provide either"):
+        pvsystem.retrieve_sam()
+    with pytest.raises(ValueError, match="Please provide either.*, not both."):
+        pvsystem.retrieve_sam(name="this_surely_wont_work", path="wont_work")
     with pytest.raises(ValueError, match="Invalid name"):
-        pvsystem.retrieve_sam(name_or_path="this_surely_wont_work.csv")
+        pvsystem.retrieve_sam(name="this_surely_wont_work")
+    with pytest.raises(ValueError, match="Invalid path"):
+        pvsystem.retrieve_sam(path="this_surely_wont_work.csv")
 
 
 def test_retrieve_sam_cecinverter():

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -105,80 +105,48 @@ def test_PVSystem_get_iam_invalid(sapm_module_params, mocker):
 
 def test_retrieve_sam_raise_no_parameters():
     """
-    Raise an exception if no parameters are provided to `retrieve_sam()`.
+    Raise an exception if an invalid parameter is provided to `retrieve_sam()`.
     """
-    with pytest.raises(ValueError) as error:
-        pvsystem.retrieve_sam()
-    assert 'A name or path must be provided!' == str(error.value)
-
-
-def test_retrieve_sam_cecmod():
-    """
-    Test the expected data is retrieved from the CEC module database. In
-    particular, check for a known module in the database and check for the
-    expected keys for that module.
-    """
-    data = pvsystem.retrieve_sam('cecmod')
-    keys = [
-        'BIPV',
-        'Date',
-        'T_NOCT',
-        'A_c',
-        'N_s',
-        'I_sc_ref',
-        'V_oc_ref',
-        'I_mp_ref',
-        'V_mp_ref',
-        'alpha_sc',
-        'beta_oc',
-        'a_ref',
-        'I_L_ref',
-        'I_o_ref',
-        'R_s',
-        'R_sh_ref',
-        'Adjust',
-        'gamma_r',
-        'Version',
-        'STC',
-        'PTC',
-        'Technology',
-        'Bifacial',
-        'Length',
-        'Width',
-    ]
-    module = 'Itek_Energy_LLC_iT_300_HE'
-    assert module in data
-    assert set(data[module].keys()) == set(keys)
+    with pytest.raises(ValueError, match="Invalid name"):
+        pvsystem.retrieve_sam(name_or_path="this_surely_wont_work.csv")
 
 
 def test_retrieve_sam_cecinverter():
-    """
-    Test the expected data is retrieved from the CEC inverter database. In
-    particular, check for a known inverter in the database and check for the
-    expected keys for that inverter.
-    """
-    data = pvsystem.retrieve_sam('cecinverter')
-    keys = [
-        'Vac',
-        'Paco',
-        'Pdco',
-        'Vdco',
-        'Pso',
-        'C0',
-        'C1',
-        'C2',
-        'C3',
-        'Pnt',
-        'Vdcmax',
-        'Idcmax',
-        'Mppt_low',
-        'Mppt_high',
-        'CEC_Date',
-        'CEC_Type',
-    ]
-    inverter = 'Yaskawa_Solectria_Solar__PVI_5300_208__208V_'
-    assert inverter in data
-    assert set(data[inverter].keys()) == set(keys)
+    """Test the expected keys are retrieved from each database."""
+    keys_per_database = {
+        "cecmod": {'Technology', 'Bifacial', 'STC', 'PTC', 'A_c', 'Length',
+                   'Width', 'N_s', 'I_sc_ref', 'V_oc_ref', 'I_mp_ref',
+                   'V_mp_ref', 'alpha_sc', 'beta_oc', 'T_NOCT', 'a_ref',
+                   'I_L_ref', 'I_o_ref', 'R_s', 'R_sh_ref', 'Adjust',
+                   'gamma_r', 'BIPV', 'Version', 'Date'},
+        "sandiamod": {'Vintage', 'Area', 'Material', 'Cells_in_Series',
+                      'Parallel_Strings', 'Isco', 'Voco', 'Impo', 'Vmpo',
+                      'Aisc', 'Aimp', 'C0', 'C1', 'Bvoco', 'Mbvoc', 'Bvmpo',
+                      'Mbvmp', 'N', 'C2', 'C3', 'A0', 'A1', 'A2', 'A3', 'A4',
+                      'B0', 'B1', 'B2', 'B3', 'B4', 'B5', 'DTC', 'FD', 'A',
+                      'B', 'C4', 'C5', 'IXO', 'IXXO', 'C6', 'C7', 'Notes'},
+        "adrinverter": {'Manufacturer', 'Model', 'Source', 'Vac', 'Vintage',
+                        'Pacmax', 'Pnom', 'Vnom', 'Vmin', 'Vmax',
+                        'ADRCoefficients', 'Pnt', 'Vdcmax', 'Idcmax',
+                        'MPPTLow', 'MPPTHi', 'TambLow', 'TambHi', 'Weight',
+                        'PacFitErrMax', 'YearOfData'},
+        "cecinverter": {'Vac', 'Paco', 'Pdco', 'Vdco', 'Pso', 'C0', 'C1', 'C2',
+                        'C3', 'Pnt', 'Vdcmax', 'Idcmax', 'Mppt_low',
+                        'Mppt_high', 'CEC_Date', 'CEC_Type'}
+    }  # fmt: skip
+    keys_per_database["sandiainverter"] = keys_per_database["cecinverter"]
+    module_per_database = {
+        "cecmod": "Itek_Energy_LLC_iT_300_HE",
+        "sandiamod": "Canadian_Solar_CS6X_300M__2013_",
+        "adrinverter": "Sainty_Solar__SSI_4K4U_240V__CEC_2011_",
+        "cecinverter": "ABB__PVI_3_0_OUTD_S_US__208V_",
+        "sandiainverter": "ABB__PVI_3_0_OUTD_S_US__208V_"
+    }
+
+    for database in keys_per_database.keys():
+        data = pvsystem.retrieve_sam(database)
+        assert set(data.index) == keys_per_database[database]
+        assert module_per_database[database] in data.columns
 
 
 def test_sapm(sapm_module_params):


### PR DESCRIPTION
 - [x] Closes #2018 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

(EDIT: at first I did a crazy proposal of merging the two parameters, with deprecations and so on, but that's too much hassle for this issue)

Fixes ignoring `path` silently when `name` was provided.

I added a few more checks, and reworked the code. I think it is now clearer. And extended tests.

#### Docs links
* https://pvlib-python--2020.org.readthedocs.build/en/2020/reference/generated/pvlib.pvsystem.retrieve_sam.html