### PR TITLE
Codecov upload follow-up

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -109,3 +109,5 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           flags: remote-data  # flags are configured in codecov.yml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -88,3 +88,5 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           flags: core  # flags are configured in codecov.yml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

See #2008 and #2022.  This PR adds a missing piece of the puzzle: making the codecov upload token available to the codecov upload steps.  This is not necessary for PR uploads, but is needed for coverage to be uploaded correctly after merges to `main`.  

After verifying that this new commit doesn't change/break anything regarding the PR upload, I plan to merge and see if it gets uploads working on `main` as well.