### PR TITLE
Get the asv benchmarking job working again

### DIFF
--- a/.github/workflows/asv_check.yml
+++ b/.github/workflows/asv_check.yml
@@ -28,6 +28,18 @@ jobs:
       - name: Install asv
         run: pip install asv==0.4.2
 
+      # asv 0.4.2 (and more recent versions as well) creates conda envs
+      # using the --force option, which was removed in conda 24.3.
+      # Since ubuntu-latest now comes with conda 24.3 pre-installed,
+      # using the system's conda will result in error.
+      # To prevent that, we install an older version.
+      # TODO: remove this when we eventually upgrade our asv version.
+      # https://github.com/airspeed-velocity/asv/issues/1396
+      - name: Install Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          conda-version: 24.1.2
+
       - name: Run asv benchmarks
         run: |
           cd benchmarks


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Continuing my push to get the CI back to all green checkmarks.  The ASV job has been failing for a few weeks because the latest versions of conda renamed a certain option that asv uses to create the benchmarking environments.  This PR ensures that a compatible version of conda is installed and available for asv's use.  It's not really ideal to pin an older version of conda, but I don't see any real harm given that we're already pinning an older version of asv.  We can just remove it when we eventually update to a newer version of asv.