### PR TITLE
Add configuration options for math mode

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -56,8 +56,8 @@ extensions = [
     'sphinx_toggleprompt',
 ]
 
-mathjax_config = {'chtml': {'displayAlign': 'left',
-                            'displayIndent': '2em'}}
+mathjax3_config = {'chtml': {'displayAlign': 'left',
+                             'displayIndent': '2em'}}
 
 napoleon_use_rtype = False  # group rtype on same line together with return
 

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -56,6 +56,9 @@ extensions = [
     'sphinx_toggleprompt',
 ]
 
+mathjax_config = {'chtml': {'displayAlign': 'left',
+                            'displayIndent': '2em'}}
+
 napoleon_use_rtype = False  # group rtype on same line together with return
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/sphinx/source/whatsnew/v0.10.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.5.rst
@@ -23,7 +23,7 @@ Documentation
 * Fix variable name typo at
   ``docs\examples\system-models\plot_oedi_9068.py``. (:pull:`1996`)
 * Remove "Comparison with PVLib for Matlab" page from the User Guide. (:issue:`2010`, :pull:`2012`)
-* Configure mathjax to left-align and indent equations in docstrings. (:pull:`2056`)
+
 
 Requirements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.10.5.rst
+++ b/docs/sphinx/source/whatsnew/v0.10.5.rst
@@ -23,7 +23,7 @@ Documentation
 * Fix variable name typo at
   ``docs\examples\system-models\plot_oedi_9068.py``. (:pull:`1996`)
 * Remove "Comparison with PVLib for Matlab" page from the User Guide. (:issue:`2010`, :pull:`2012`)
-
+* Configure mathjax to left-align and indent equations in docstrings. (:pull:`2056`)
 
 Requirements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.11.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.0.rst
@@ -27,7 +27,7 @@ Testing
 
 Documentation
 ~~~~~~~~~~~~~
-
+* Configure mathjax to left-align and indent equations in docstrings. (:pull:`2056`)
 
 Requirements
 ~~~~~~~~~~~~
@@ -35,3 +35,4 @@ Requirements
 
 Contributors
 ~~~~~~~~~~~~
+* Cliff Hansen (:ghuser:`cwhanse`)


### PR DESCRIPTION
 - ~~[ ] Closes #xxxx~~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Left-align and indent equations in docstrings. Default is centered which makes a series of equations visually unattractive.

[Before](https://pvlib-python.readthedocs.io/en/v0.10.5/reference/generated/pvlib.temperature.sapm_cell.html) and [after](https://pvlib-python--2056.org.readthedocs.build/en/2056/reference/generated/pvlib.temperature.sapm_cell.html).


