### PR TITLE
Minor documentation rendering improvements

### DIFF
--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -592,10 +592,10 @@ def marion_diffuse(model, surface_tilt, **kwargs):
     iam : dict
         IAM values for each type of diffuse irradiance:
 
-            * 'sky': radiation from the sky dome (zenith <= 90)
-            * 'horizon': radiation from the region of the sky near the horizon
-              (89.5 <= zenith <= 90)
-            * 'ground': radiation reflected from the ground (zenith >= 90)
+        * 'sky': radiation from the sky dome (zenith <= 90)
+        * 'horizon': radiation from the region of the sky near the horizon
+          (89.5 <= zenith <= 90)
+        * 'ground': radiation reflected from the ground (zenith >= 90)
 
         See [1]_ for a detailed description of each class.
 
@@ -667,10 +667,10 @@ def marion_integrate(function, surface_tilt, region, num=None):
     region : {'sky', 'horizon', 'ground'}
         The region to integrate over. Must be one of:
 
-            * 'sky': radiation from the sky dome (zenith <= 90)
-            * 'horizon': radiation from the region of the sky near the horizon
-              (89.5 <= zenith <= 90)
-            * 'ground': radiation reflected from the ground (zenith >= 90)
+        * 'sky': radiation from the sky dome (zenith <= 90)
+        * 'horizon': radiation from the region of the sky near the horizon
+          (89.5 <= zenith <= 90)
+        * 'ground': radiation reflected from the ground (zenith >= 90)
 
         See [1]_ for a detailed description of each class.
 
@@ -678,8 +678,8 @@ def marion_integrate(function, surface_tilt, region, num=None):
         The number of increments in the zenith integration.
         If not specified, N will follow the values used in [1]_:
 
-            * 'sky' or 'ground': num = 180
-            * 'horizon': num = 1800
+        * 'sky' or 'ground': num = 180
+        * 'horizon': num = 1800
 
     Returns
     -------
@@ -1107,14 +1107,14 @@ def convert(source_name, source_params, target_name, weight=_sin_weight,
     source_params : dict
         A dictionary of parameters for the source model.
 
-            If source model is ``'ashrae'``, the dictionary must contain
-            the key ``'b'``.
+        If source model is ``'ashrae'``, the dictionary must contain
+        the key ``'b'``.
 
-            If source model is ``'martin_ruiz'``, the dictionary must
-            contain the key ``'a_r'``.
+        If source model is ``'martin_ruiz'``, the dictionary must
+        contain the key ``'a_r'``.
 
-            If source model is ``'physical'``, the dictionary must
-            contain the keys ``'n'``, ``'K'``, and ``'L'``.
+        If source model is ``'physical'``, the dictionary must
+        contain the keys ``'n'``, ``'K'``, and ``'L'``.
 
     target_name : str
         Name of the target model. Must be ``'ashrae'``, ``'martin_ruiz'``, or
@@ -1146,14 +1146,14 @@ def convert(source_name, source_params, target_name, weight=_sin_weight,
     dict
         Parameters for the target model.
 
-            If target model is ``'ashrae'``, the dictionary will contain
-            the key ``'b'``.
+        If target model is ``'ashrae'``, the dictionary will contain
+        the key ``'b'``.
 
-            If target model is ``'martin_ruiz'``, the dictionary will
-            contain the key ``'a_r'``.
+        If target model is ``'martin_ruiz'``, the dictionary will
+        contain the key ``'a_r'``.
 
-            If target model is ``'physical'``, the dictionary will
-            contain the keys ``'n'``, ``'K'``, and ``'L'``.
+        If target model is ``'physical'``, the dictionary will
+        contain the keys ``'n'``, ``'K'``, and ``'L'``.
 
     Note
     ----
@@ -1243,14 +1243,14 @@ def fit(measured_aoi, measured_iam, model_name, weight=_sin_weight, xtol=None):
     dict
         Parameters for target model.
 
-            If target model is ``'ashrae'``, the dictionary will contain
-            the key ``'b'``.
+        If target model is ``'ashrae'``, the dictionary will contain
+        the key ``'b'``.
 
-            If target model is ``'martin_ruiz'``, the dictionary will
-            contain the key ``'a_r'``.
+        If target model is ``'martin_ruiz'``, the dictionary will
+        contain the key ``'a_r'``.
 
-            If target model is ``'physical'``, the dictionary will
-            contain the keys ``'n'``, ``'K'``, and ``'L'``.
+        If target model is ``'physical'``, the dictionary will
+        contain the keys ``'n'``, ``'K'``, and ``'L'``.
 
     References
     ----------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2334,10 +2334,10 @@ def gti_dirint(poa_global, aoi, solar_zenith, solar_azimuth, times,
     data : DataFrame
         Contains the following keys/columns:
 
-            * ``ghi``: the modeled global horizontal irradiance in W/m^2.
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
+        * ``ghi``: the modeled global horizontal irradiance in W/m^2.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
 
     References
     ----------
@@ -2618,11 +2618,11 @@ def erbs(ghi, zenith, datetime_or_doy, min_cos_zenith=0.065, max_zenith=87):
     data : OrderedDict or DataFrame
         Contains the following keys/columns:
 
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
-            * ``kt``: Ratio of global to extraterrestrial irradiance
-              on a horizontal plane.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
+        * ``kt``: Ratio of global to extraterrestrial irradiance
+          on a horizontal plane.
 
     References
     ----------
@@ -2721,11 +2721,11 @@ def erbs_driesse(ghi, zenith, datetime_or_doy=None, dni_extra=None,
     data : OrderedDict or DataFrame
         Contains the following keys/columns:
 
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
-            * ``kt``: Ratio of global to extraterrestrial irradiance
-              on a horizontal plane.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
+        * ``kt``: Ratio of global to extraterrestrial irradiance
+          on a horizontal plane.
 
     Raises
     ------
@@ -2839,11 +2839,11 @@ def orgill_hollands(ghi, zenith, datetime_or_doy, dni_extra=None,
     data : OrderedDict or DataFrame
         Contains the following keys/columns:
 
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
-            * ``kt``: Ratio of global to extraterrestrial irradiance
-              on a horizontal plane.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
+        * ``kt``: Ratio of global to extraterrestrial irradiance
+          on a horizontal plane.
 
     References
     ----------
@@ -2934,11 +2934,11 @@ def boland(ghi, solar_zenith, datetime_or_doy, a_coeff=8.645, b_coeff=0.613,
     data : OrderedDict or DataFrame
         Contains the following keys/columns:
 
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
-            * ``kt``: Ratio of global to extraterrestrial irradiance
-              on a horizontal plane.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
+        * ``kt``: Ratio of global to extraterrestrial irradiance
+          on a horizontal plane.
 
     References
     ----------
@@ -3771,11 +3771,11 @@ def louche(ghi, solar_zenith, datetime_or_doy, max_zenith=90):
     data: OrderedDict or DataFrame
         Contains the following keys/columns:
 
-            * ``dni``: the modeled direct normal irradiance in W/m^2.
-            * ``dhi``: the modeled diffuse horizontal irradiance in
-              W/m^2.
-            * ``kt``: Ratio of global to extraterrestrial irradiance
-              on a horizontal plane.
+        * ``dni``: the modeled direct normal irradiance in W/m^2.
+        * ``dhi``: the modeled diffuse horizontal irradiance in
+          W/m^2.
+        * ``kt``: Ratio of global to extraterrestrial irradiance
+          on a horizontal plane.
 
     References
     -------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -896,8 +896,8 @@ def reindl(surface_tilt, surface_azimuth, dhi, dni, ghi, dni_extra,
 
     .. math::
 
-       I_{d} = DHI (A R_b + (1 - A) (\frac{1 + \cos\beta}{2})
-       (1 + \sqrt{\frac{I_{hb}}{I_h}} \sin^3(\beta/2)) )
+       I_{d} = DHI \left(A R_b + (1 - A) \left(\frac{1 + \cos\beta}{2}\right)
+       \left(1 + \sqrt{\frac{I_{hb}}{I_h}} \sin^3(\beta/2)\right) \right)
 
     Reindl's 1990 model determines the diffuse irradiance from the sky
     (ground reflected irradiance is not included in this algorithm) on a

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2318,9 +2318,10 @@ def sapm_effective_irradiance(poa_direct, poa_diffuse, airmass_absolute, aoi,
     a module's cells.
 
     The model is
+
     .. math::
 
-        `Ee = f_1(AM_a) (E_b f_2(AOI) + f_d E_d)`
+        Ee = f_1(AM_a) (E_b f_2(AOI) + f_d E_d)
 
     where :math:`Ee` is effective irradiance (W/m2), :math:`f_1` is a fourth
     degree polynomial in air mass :math:`AM_a`, :math:`E_b` is beam (direct)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2420,20 +2420,20 @@ def singlediode(photocurrent, saturation_current, resistance_series,
     dict or pandas.DataFrame
         The returned dict-like object always contains the keys/columns:
 
-            * i_sc - short circuit current in amperes.
-            * v_oc - open circuit voltage in volts.
-            * i_mp - current at maximum power point in amperes.
-            * v_mp - voltage at maximum power point in volts.
-            * p_mp - power at maximum power point in watts.
-            * i_x - current, in amperes, at ``v = 0.5*v_oc``.
-            * i_xx - current, in amperes, at ``v = 0.5*(v_oc+v_mp)``.
+        * i_sc - short circuit current in amperes.
+        * v_oc - open circuit voltage in volts.
+        * i_mp - current at maximum power point in amperes.
+        * v_mp - voltage at maximum power point in volts.
+        * p_mp - power at maximum power point in watts.
+        * i_x - current, in amperes, at ``v = 0.5*v_oc``.
+        * i_xx - current, in amperes, at ``v = 0.5*(v_oc+v_mp)``.
 
         A dict is returned when the input parameters are scalars or
         ``ivcurve_pnts > 0``. If ``ivcurve_pnts > 0``, the output dictionary
         will also include the keys:
 
-            * i - IV curve current in amperes.
-            * v - IV curve voltage in volts.
+        * i - IV curve current in amperes.
+        * v - IV curve voltage in volts.
 
     See also
     --------

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -265,11 +265,11 @@ def spectral_factor_firstsolar(precipitable_water, airmass_absolute,
     SMARTS, spectrums are simulated with all combinations of AMa and
     Pw where:
 
-       * :math:`0.5 \textrm{cm} <= Pw <= 5 \textrm{cm}`
-       * :math:`1.0 <= AM_a <= 5.0`
-       * Spectral range is limited to that of CMP11 (280 nm to 2800 nm)
-       * spectrum simulated on a plane normal to the sun
-       * All other parameters fixed at G173 standard
+    * :math:`0.5 \textrm{cm} <= Pw <= 5 \textrm{cm}`
+    * :math:`1.0 <= AM_a <= 5.0`
+    * Spectral range is limited to that of CMP11 (280 nm to 2800 nm)
+    * spectrum simulated on a plane normal to the sun
+    * All other parameters fixed at G173 standard
 
     From these simulated spectra, M is calculated using the known
     quantum efficiency curves. Multiple linear regression is then
@@ -291,11 +291,11 @@ def spectral_factor_firstsolar(precipitable_water, airmass_absolute,
         'multisi', and 'polysi' (can be lower or upper case). If provided,
         module_type selects default coefficients for the following modules:
 
-            * 'cdte' - First Solar Series 4-2 CdTe module.
-            * 'monosi', 'xsi' - First Solar TetraSun module.
-            * 'multisi', 'polysi' - anonymous multi-crystalline silicon module.
-            * 'cigs' - anonymous copper indium gallium selenide module.
-            * 'asi' - anonymous amorphous silicon module.
+        * 'cdte' - First Solar Series 4-2 CdTe module.
+        * 'monosi', 'xsi' - First Solar TetraSun module.
+        * 'multisi', 'polysi' - anonymous multi-crystalline silicon module.
+        * 'cigs' - anonymous copper indium gallium selenide module.
+        * 'asi' - anonymous amorphous silicon module.
 
         The module used to calculate the spectral correction
         coefficients corresponds to the Multi-crystalline silicon

--- a/pvlib/spectrum/spectrl2.py
+++ b/pvlib/spectrum/spectrl2.py
@@ -233,14 +233,14 @@ def spectrl2(apparent_zenith, aoi, surface_tilt, ground_albedo,
         input ``apparent_zenith``.  All values are spectral irradiance
         with units W/m^2/nm except for `wavelength`, which is in nanometers.
 
-            * wavelength
-            * dni_extra
-            * dhi
-            * dni
-            * poa_sky_diffuse
-            * poa_ground_diffuse
-            * poa_direct
-            * poa_global
+        * wavelength
+        * dni_extra
+        * dhi
+        * dni
+        * poa_sky_diffuse
+        * poa_ground_diffuse
+        * poa_direct
+        * poa_global
 
     Notes
     -----


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR fixes a handful of instances like this, where a bulleted list is rendered with quotation formatting:

![image](https://github.com/pvlib/pvlib-python/assets/57452607/2fb80398-20da-4b7a-aed7-385f254f4ac1)

After fixing the indentation, it renders better:

![image](https://github.com/pvlib/pvlib-python/assets/57452607/e848d146-7563-4140-9803-734ea2082cf0)

It also improves the rendering of a couple of equations I noticed along the way.

Here is a table of the changed docstrings:

|Function|Stable|PR|
|--|--|--|
|pvlib.irradiance.reindl|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.reindl.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.reindl.html)|
|pvlib.irradiance.erbs|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.erbs.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.erbs.html)|
|pvlib.irradiance.erbs_driesse|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.erbs_driesse.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.erbs_driesse.html)|
|pvlib.irradiance.orgill_hollands|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.orgill_hollands.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.orgill_hollands.html)|
|pvlib.irradiance.boland|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.boland.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.boland.html)|
|pvlib.irradiance.gti_dirint|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.gti_dirint.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.gti_dirint.html)|
|pvlib.irradiance.louche|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.louche.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.irradiance.louche.html)|
|pvlib.iam.marion_diffuse|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.iam.marion_diffuse.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.iam.marion_diffuse.html)|
|pvlib.iam.marion_integrate|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.iam.marion_integrate.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.iam.marion_integrate.html)|
|pvlib.iam.convert|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.iam.convert.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.iam.convert.html)|
|pvlib.iam.fit|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.iam.fit.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.iam.fit.html)|
|pvlib.pvsystem.sapm_effective_irradiance|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.pvsystem.sapm_effective_irradiance.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.pvsystem.sapm_effective_irradiance.html)|
|pvlib.pvsystem.singlediode|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.pvsystem.singlediode.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.pvsystem.singlediode.html)|
|pvlib.spectrum.spectrl2|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.spectrum.spectrl2.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.spectrum.spectrl2.html)|
|pvlib.spectrum.spectral_factor_firstsolar|[link](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.spectrum.spectral_factor_firstsolar.html)|[link](https://pvlib-python--2058.org.readthedocs.build/en/2058/reference/generated/pvlib.spectrum.spectral_factor_firstsolar.html)|

