### PR TITLE
Remove dhi_clear in SolarAnywhere variable mapping

### DIFF
--- a/pvlib/iotools/solaranywhere.py
+++ b/pvlib/iotools/solaranywhere.py
@@ -28,8 +28,6 @@ VARIABLE_MAP = {
     'ClearSkyGHI_WattsPerMeterSquared': 'ghi_clear',
     'Clear Sky DNI': 'dni_clear',
     'ClearSkyDNI_WattsPerMeterSquared': 'dni_clear',
-    'Clear Sky DHI': 'dhi_clear',
-    'ClearSkyDHI_WattsPerMeterSquared': 'dhi_clear',
     'Albedo': 'albedo',
     'Albedo_Unitless': 'albedo',
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
@williamhobbs noted that `dhi_clear` is included in the SolarAnywhere `VARIABLE_MAP`. However, according to the SolarAnywhere API there is no such variable as clear sky DHI, thus it serves no purpose.

Given that this has never been in use, as it doesn't exist, I have refrained from making a whatsnew entry.


