### PR TITLE
Change accuracy of `pvsyst_cell` test function

### DIFF
--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -84,7 +84,7 @@ def test_pvsyst_cell_ndarray():
     irrads = np.array([0, 500, 0])
     winds = np.array([10, 5, 0])
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
-    expected = np.array([0.0, 23.96551, 5.0])
+    expected = np.array([0.0, 23.965517, 5.0])
     assert_allclose(expected, result)
 
 
@@ -95,7 +95,7 @@ def test_pvsyst_cell_series():
     winds = pd.Series([10, 5, 0], index=times)
 
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
-    expected = pd.Series([0.0, 23.96551, 5.0], index=times)
+    expected = pd.Series([0.0, 23.965517, 5.0], index=times)
     assert_series_equal(expected, result)
 
 

--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -84,7 +84,7 @@ def test_pvsyst_cell_ndarray():
     irrads = np.array([0, 500, 0])
     winds = np.array([10, 5, 0])
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
-    expected = np.array([0.0, 23.965517, 5.0])
+    expected = np.array([0.0, 23.96551, 5.0])
     assert_allclose(expected, result)
 
 

--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -84,8 +84,8 @@ def test_pvsyst_cell_ndarray():
     irrads = np.array([0, 500, 0])
     winds = np.array([10, 5, 0])
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
-    expected = np.array([0.0, 23.96551, 5.0])
-    assert_allclose(expected, result, 3)
+    expected = np.array([0.0, 23.965517, 5.0])
+    assert_allclose(expected, result)
 
 
 def test_pvsyst_cell_series():


### PR DESCRIPTION
I noticed that for the `test_pvsyst_cell_ndarray`, the tolerance for the test is `3`, which I think is too high. Thus, I changed it to the default value. 