### PR TITLE
Fix port of old-precision-decimal to present-atol in tests

### DIFF
--- a/pvlib/tests/test_inverter.py
+++ b/pvlib/tests/test_inverter.py
@@ -61,13 +61,13 @@ def test_sandia_float(cec_inverter_parameters):
     idcs = 5.5
     pdcs = idcs * vdcs
     pacs = inverter.sandia(vdcs, pdcs, cec_inverter_parameters)
-    assert_allclose(pacs, 132.004278, 5)
+    assert_allclose(pacs, 132.004278, 1e-5)
     # test at low power condition
     vdcs = 25.
     idcs = 0
     pdcs = idcs * vdcs
     pacs = inverter.sandia(vdcs, pdcs, cec_inverter_parameters)
-    assert_allclose(pacs, -1. * cec_inverter_parameters['Pnt'], 5)
+    assert_allclose(pacs, -1. * cec_inverter_parameters['Pnt'], 1e-5)
 
 
 def test_sandia_Pnt_micro():

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -94,7 +94,7 @@ value = 1383.636203
     'asce', 'spencer', 'nrel', pytest.param('pyephem', marks=requires_ephem)])
 def test_get_extra_radiation(testval, expected, method):
     out = irradiance.get_extra_radiation(testval, method=method)
-    assert_allclose(out, expected, atol=10)
+    assert_allclose(out, expected, atol=1e-10)
 
 
 def test_get_extra_radiation_epoch_year():
@@ -1053,7 +1053,7 @@ def test_erbs_all_scalar():
     out = irradiance.erbs(ghi, zenith, doy)
 
     for k, v in out.items():
-        assert_allclose(v, expected[k], 5)
+        assert_allclose(v, expected[k], 1e-2)
 
 
 def test_dirindex(times):

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -94,7 +94,7 @@ value = 1383.636203
     'asce', 'spencer', 'nrel', pytest.param('pyephem', marks=requires_ephem)])
 def test_get_extra_radiation(testval, expected, method):
     out = irradiance.get_extra_radiation(testval, method=method)
-    assert_allclose(out, expected, atol=1e-10)
+    assert_allclose(out, expected, atol=10)
 
 
 def test_get_extra_radiation_epoch_year():

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -206,7 +206,7 @@ def test_PVSystem_sapm(sapm_module_params, mocker):
     out = system.sapm(effective_irradiance, temp_cell)
     pvsystem.sapm.assert_called_once_with(effective_irradiance, temp_cell,
                                           sapm_module_params)
-    assert_allclose(out['p_mp'], 100, atol=100)
+    assert_allclose(out['p_mp'], 100, 10)
 
 
 def test_PVSystem_multi_array_sapm(sapm_module_params):
@@ -434,7 +434,7 @@ def test_PVSystem_sapm_celltemp_kwargs(mocker):
                                                   temp_model_params['a'],
                                                   temp_model_params['b'],
                                                   temp_model_params['deltaT'])
-    assert_allclose(out, 57, atol=1)
+    assert_allclose(out, 57, atol=1e-1)
 
 
 def test_PVSystem_multi_array_sapm_celltemp_different_arrays():
@@ -487,7 +487,7 @@ def test_PVSystem_faiman_celltemp(mocker):
     winds = 1
     out = system.get_cell_temperature(irrads, temps, winds, model='faiman')
     temperature.faiman.assert_called_once_with(irrads, temps, winds, u0, u1)
-    assert_allclose(out, 56.4, atol=1)
+    assert_allclose(out, 56.4, atol=1e-1)
 
 
 def test_PVSystem_noct_celltemp(mocker):
@@ -1062,7 +1062,7 @@ def test_PVSystem_calcparams_desoto(cec_module_params, mocker):
         dEgdT=module_parameters['dEgdT']
     )
 
-    assert_allclose(IL, np.array([0.0, 6.036]), atol=1)
+    assert_allclose(IL, np.array([0.0, 6.036]), atol=1e-1)
     assert_allclose(I0, np.array([2.0e-9, 2.0e-9]), atol=1.0e-9)
     assert_allclose(Rs, np.array([0.1, 0.1]), atol=0.1)
     assert_allclose(Rsh, np.array([np.inf, 20]), atol=1)

--- a/pvlib/tests/test_pvsystem.py
+++ b/pvlib/tests/test_pvsystem.py
@@ -434,7 +434,7 @@ def test_PVSystem_sapm_celltemp_kwargs(mocker):
                                                   temp_model_params['a'],
                                                   temp_model_params['b'],
                                                   temp_model_params['deltaT'])
-    assert_allclose(out, 57, atol=1e-1)
+    assert_allclose(out, 57, atol=1)
 
 
 def test_PVSystem_multi_array_sapm_celltemp_different_arrays():

--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -20,13 +20,13 @@ def sapm_default():
 def test_sapm_cell(sapm_default):
     default = temperature.sapm_cell(900, 20, 5, sapm_default['a'],
                                     sapm_default['b'], sapm_default['deltaT'])
-    assert_allclose(default, 43.509, 3)
+    assert_allclose(default, 43.509, 1e-3)
 
 
 def test_sapm_module(sapm_default):
     default = temperature.sapm_module(900, 20, 5, sapm_default['a'],
                                       sapm_default['b'])
-    assert_allclose(default, 40.809, 3)
+    assert_allclose(default, 40.809, 1e-3)
 
 
 def test_sapm_cell_from_module(sapm_default):
@@ -47,8 +47,8 @@ def test_sapm_ndarray(sapm_default):
                                            sapm_default['b'])
     expected_cell = np.array([0., 23.06066166, 5.])
     expected_module = np.array([0., 21.56066166, 5.])
-    assert_allclose(expected_cell, cell_temps, 3)
-    assert_allclose(expected_module, module_temps, 3)
+    assert_allclose(expected_cell, cell_temps, 1e-3)
+    assert_allclose(expected_module, module_temps, 1e-3)
 
 
 def test_sapm_series(sapm_default):
@@ -85,7 +85,7 @@ def test_pvsyst_cell_ndarray():
     winds = np.array([10, 5, 0])
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
     expected = np.array([0.0, 23.96551, 5.0])
-    assert_allclose(expected, result, 3)
+    assert_allclose(expected, result, 1e-3)
 
 
 def test_pvsyst_cell_series():

--- a/pvlib/tests/test_temperature.py
+++ b/pvlib/tests/test_temperature.py
@@ -85,7 +85,7 @@ def test_pvsyst_cell_ndarray():
     winds = np.array([10, 5, 0])
     result = temperature.pvsyst_cell(irrads, temps, wind_speed=winds)
     expected = np.array([0.0, 23.96551, 5.0])
-    assert_allclose(expected, result, 1e-3)
+    assert_allclose(expected, result, 3)
 
 
 def test_pvsyst_cell_series():


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes comment https://github.com/pvlib/pvlib-python/pull/2080#issuecomment-2152762811
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Some tests were using a tolerance higher than expected.

Feel free to find other occurrences with `(assert_allclose)\((.*), ?(.*), ?([a-zA-Z0-9=]*)?(\d)\)`

These are the left integer tolerances:
![image](https://github.com/pvlib/pvlib-python/assets/80125792/820ee661-ff68-4dfc-bec8-58391d22cb00)
But I have played a bit with some of em and didn't think they are a misunderstood decimal position.