### PR TITLE
Set `map_variables=True` by default in PSM3 iotools functions

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.0.rst
@@ -16,6 +16,9 @@ Breaking changes
   (:pull:`1779`, :pull:`1989`)
 * The `leap_day` parameter in :py:func:`~pvlib.iotools.get_psm3`
   now defaults to True instead of False. (:issue:`1481`, :pull:`1991`)
+* :py:func:`~pvlib.iotools.get_psm3`, :py:func:`~pvlib.iotools.read_psm3`, and
+  :py:func:`~pvlib.iotools.parse_psm3` all now have ``map_variables=True`` by
+  default. (:issue:`1425`, :pull:`2094`)
 
 
 Deprecations

--- a/pvlib/iotools/psm3.py
+++ b/pvlib/iotools/psm3.py
@@ -63,7 +63,7 @@ REQUEST_VARIABLE_MAP = {
 
 def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
              attributes=ATTRIBUTES, leap_day=True, full_name=PVLIB_PYTHON,
-             affiliation=PVLIB_PYTHON, map_variables=None, url=None,
+             affiliation=PVLIB_PYTHON, map_variables=True, url=None,
              timeout=30):
     """
     Retrieve NSRDB PSM3 timeseries weather data from the PSM3 API. The NSRDB
@@ -105,14 +105,14 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
         for lists of available fields. Alternatively, pvlib names may also be
         used (e.g. 'ghi' rather than 'GHI'); see :const:`REQUEST_VARIABLE_MAP`.
         To retrieve all available fields, set ``attributes=[]``.
-    leap_day : boolean, default : True
+    leap_day : bool, default : True
         include leap day in the results. Only used for single-year requests
         (i.e., it is ignored for tmy/tgy/tdy requests).
     full_name : str, default 'pvlib python'
         optional
     affiliation : str, default 'pvlib python'
         optional
-    map_variables : boolean, optional
+    map_variables : bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
     url : str, optional
@@ -219,7 +219,7 @@ def get_psm3(latitude, longitude, api_key, email, names='tmy', interval=60,
     return parse_psm3(fbuf, map_variables)
 
 
-def parse_psm3(fbuf, map_variables=None):
+def parse_psm3(fbuf, map_variables=True):
     """
     Parse an NSRDB PSM3 weather file (formatted as SAM CSV). The NSRDB
     is described in [1]_ and the SAM CSV format is described in [2]_.
@@ -233,9 +233,9 @@ def parse_psm3(fbuf, map_variables=None):
     ----------
     fbuf: file-like object
         File-like object containing data to read.
-    map_variables: bool
+    map_variables: bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
-        where applicable. See variable VARIABLE_MAP.
+        where applicable. See variable :const:`VARIABLE_MAP`.
 
     Returns
     -------
@@ -348,13 +348,6 @@ def parse_psm3(fbuf, map_variables=None):
     tz = 'Etc/GMT%+d' % -metadata['Time Zone']
     data.index = pd.DatetimeIndex(dtidx).tz_localize(tz)
 
-    if map_variables is None:
-        warnings.warn(
-            'PSM3 variable names will be renamed to pvlib conventions by '
-            'default starting in pvlib 0.11.0. Specify map_variables=True '
-            'to enable that behavior now, or specify map_variables=False '
-            'to hide this warning.', pvlibDeprecationWarning)
-        map_variables = False
     if map_variables:
         data = data.rename(columns=VARIABLE_MAP)
         metadata['latitude'] = metadata.pop('Latitude')
@@ -364,7 +357,7 @@ def parse_psm3(fbuf, map_variables=None):
     return data, metadata
 
 
-def read_psm3(filename, map_variables=None):
+def read_psm3(filename, map_variables=True):
     """
     Read an NSRDB PSM3 weather file (formatted as SAM CSV). The NSRDB
     is described in [1]_ and the SAM CSV format is described in [2]_.
@@ -378,9 +371,9 @@ def read_psm3(filename, map_variables=None):
     ----------
     filename: str
         Filename of a file containing data to read.
-    map_variables: bool
+    map_variables: bool, default True
         When true, renames columns of the Dataframe to pvlib variable names
-        where applicable. See variable VARIABLE_MAP.
+        where applicable. See variable :const:`VARIABLE_MAP`.
 
     Returns
     -------

--- a/pvlib/tests/iotools/test_psm3.py
+++ b/pvlib/tests/iotools/test_psm3.py
@@ -196,10 +196,3 @@ def test_get_psm3_attribute_mapping(nrel_api_key):
     assert 'latitude' in meta.keys()
     assert 'longitude' in meta.keys()
     assert 'altitude' in meta.keys()
-
-
-@pytest.mark.remote_data
-@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-def test_psm3_variable_map_deprecation_warning(nrel_api_key):
-    with pytest.warns(pvlibDeprecationWarning, match='names will be renamed'):
-        _ = psm3.read_psm3(MANUAL_TEST_DATA)


### PR DESCRIPTION
 - [x] Closes #1425
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR changes `map_variables` to default to True in the PSM3 iotools functions.  It has defaulted to False (with a deprecation warning) since v0.9.1 when the option was originally introduced. 