### PR TITLE
Add hint about Perez discontinuities

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -407,7 +407,7 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
     The ``'Perez'`` transposition model features discontinuities in the
     predicted tilted diffuse irradiance due to relying on discrete input
     values. For applications that benefit from continuous output, consider
-    using the :py:func:`~pvlib.irradiance.perez-driesse`.
+    using :py:func:`~pvlib.irradiance.perez-driesse`.
 
     The ``'perez'`` and ``'perez-driesse'`` models require relative airmass
     (``airmass``) as input. If ``airmass`` is not provided, it is calculated
@@ -1014,7 +1014,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     The Perez transposition model features discontinuities in the
     predicted tilted diffuse irradiance due to relying on discrete input
     values. For applications that benefit from continuous output, consider
-    using the :py:func:`~pvlib.irradiance.perez-driesse`.
+    using :py:func:`~pvlib.irradiance.perez-driesse`.
 
     Parameters
     ----------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -407,7 +407,7 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
     The ``'Perez'`` transposition model features discontinuities in the
     predicted tilted diffuse irradiance due to relying on discrete input
     values. For applications that benefit from continuous output, consider
-    using :py:func:`~pvlib.irradiance.perez-driesse`.
+    using :py:func:`~pvlib.irradiance.perez_driesse`.
 
     The ``'perez'`` and ``'perez-driesse'`` models require relative airmass
     (``airmass``) as input. If ``airmass`` is not provided, it is calculated
@@ -1014,7 +1014,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     The Perez transposition model features discontinuities in the
     predicted tilted diffuse irradiance due to relying on discrete input
     values. For applications that benefit from continuous output, consider
-    using :py:func:`~pvlib.irradiance.perez-driesse`.
+    using :py:func:`~pvlib.irradiance.perez_driesse`.
 
     Parameters
     ----------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -360,6 +360,13 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
         * perez
         * perez-driesse
 
+    Hint
+    ----
+    The Perez transposition model feature discontinuities in the
+    predicted tilted diffuse irradiance due to relying discrete input values.
+    For applications that benefit from continuous output, consider using the
+    :py:func:`~pvlib.irradiance.perez-driesse`.
+
     Parameters
     ----------
     surface_tilt : numeric

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -360,13 +360,6 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
         * perez
         * perez-driesse
 
-    Hint
-    ----
-    The Perez transposition model feature discontinuities in the
-    predicted tilted diffuse irradiance due to relying discrete input values.
-    For applications that benefit from continuous output, consider using the
-    :py:func:`~pvlib.irradiance.perez-driesse`.
-
     Parameters
     ----------
     surface_tilt : numeric
@@ -410,6 +403,11 @@ def get_sky_diffuse(surface_tilt, surface_azimuth,
     Models ``'haydavies'``, ``'reindl'``, ``'perez'`` and ``'perez-driesse'``
     require ``'dni_extra'``. Values can be calculated using
     :py:func:`~pvlib.irradiance.get_extra_radiation`.
+
+    The ``'Perez'`` transposition model features discontinuities in the
+    predicted tilted diffuse irradiance due to relying on discrete input
+    values. For applications that benefit from continuous output, consider
+    using the :py:func:`~pvlib.irradiance.perez-driesse`.
 
     The ``'perez'`` and ``'perez-driesse'`` models require relative airmass
     (``airmass``) as input. If ``airmass`` is not provided, it is calculated
@@ -1010,6 +1008,13 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     irradiance, sun zenith angle, sun azimuth angle, and relative (not
     pressure-corrected) airmass. Optionally a selector may be used to
     use any of Perez's model coefficient sets.
+
+    Warning
+    -------
+    The Perez transposition model features discontinuities in the
+    predicted tilted diffuse irradiance due to relying on discrete input
+    values. For applications that benefit from continuous output, consider
+    using the :py:func:`~pvlib.irradiance.perez-driesse`.
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2043
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR adds a Hint section to the ``irradiance.get_sky_diffuse`` function stating that the Perez model output is discontinuous and suggests using the Perez-Driesse model for applications where this may be an issue.