### PR TITLE
`pvlib.pvsystem.singlediode`: remove deprecated `ivcurve_pnts` parameter

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.0.rst
@@ -19,6 +19,9 @@ Breaking changes
 * :py:func:`~pvlib.iotools.get_psm3`, :py:func:`~pvlib.iotools.read_psm3`, and
   :py:func:`~pvlib.iotools.parse_psm3` all now have ``map_variables=True`` by
   default. (:issue:`1425`, :pull:`2094`)
+* The deprecated ``ivcurve_pnts`` parameter of :py:func:`pvlib.pvsystem.singlediode`
+  is removed. Use :py:func:`pvlib.pvsystem.v_from_i` and
+  :py:func:`pvlib.pvsystem.i_from_v` instead. (:pull:`2101`)
 
 
 Deprecations

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -722,15 +722,13 @@ class PVSystem:
         )
 
     def singlediode(self, photocurrent, saturation_current,
-                    resistance_series, resistance_shunt, nNsVth,
-                    ivcurve_pnts=None):
+                    resistance_series, resistance_shunt, nNsVth):
         """Wrapper around the :py:func:`pvlib.pvsystem.singlediode` function.
 
         See :py:func:`pvsystem.singlediode` for details
         """
         return singlediode(photocurrent, saturation_current,
-                           resistance_series, resistance_shunt, nNsVth,
-                           ivcurve_pnts=ivcurve_pnts)
+                           resistance_series, resistance_shunt, nNsVth)
 
     def i_from_v(self, voltage, photocurrent, saturation_current,
                  resistance_series, resistance_shunt, nNsVth):
@@ -2352,8 +2350,7 @@ def sapm_effective_irradiance(poa_direct, poa_diffuse, airmass_absolute, aoi,
 
 
 def singlediode(photocurrent, saturation_current, resistance_series,
-                resistance_shunt, nNsVth, ivcurve_pnts=None,
-                method='lambertw'):
+                resistance_shunt, nNsVth, method='lambertw'):
     r"""
     Solve the single diode equation to obtain a photovoltaic IV curve.
 
@@ -2405,14 +2402,6 @@ def singlediode(photocurrent, saturation_current, resistance_series,
         junction in Kelvin, and :math:`q` is the charge of an electron
         (coulombs). ``0 < nNsVth``.  [V]
 
-    ivcurve_pnts : int, optional
-        Number of points in the desired IV curve. If not specified or 0, no
-        points on the IV curves will be produced.
-
-        .. deprecated:: 0.10.0
-           Use :py:func:`pvlib.pvsystem.v_from_i` and
-           :py:func:`pvlib.pvsystem.i_from_v` instead.
-
     method : str, default 'lambertw'
         Determines the method used to calculate points on the IV curve. The
         options are ``'lambertw'``, ``'newton'``, or ``'brentq'``.
@@ -2430,12 +2419,7 @@ def singlediode(photocurrent, saturation_current, resistance_series,
         * i_x - current, in amperes, at ``v = 0.5*v_oc``.
         * i_xx - current, in amperes, at ``v = 0.5*(v_oc+v_mp)``.
 
-        A dict is returned when the input parameters are scalars or
-        ``ivcurve_pnts > 0``. If ``ivcurve_pnts > 0``, the output dictionary
-        will also include the keys:
-
-        * i - IV curve current in amperes.
-        * v - IV curve voltage in volts.
+        A dict is returned when the input parameters are scalars.
 
     See also
     --------
@@ -2459,13 +2443,6 @@ def singlediode(photocurrent, saturation_current, resistance_series,
     that guarantees convergence by bounding the voltage between zero and
     open-circuit.
 
-    If the method is either ``'newton'`` or ``'brentq'`` and ``ivcurve_pnts``
-    are indicated, then :func:`pvlib.singlediode.bishop88` [4]_ is used to
-    calculate the points on the IV curve points at diode voltages from zero to
-    open-circuit voltage with a log spacing that gets closer as voltage
-    increases. If the method is ``'lambertw'`` then the calculated points on
-    the IV curve are linearly spaced.
-
     References
     ----------
     .. [1] S.R. Wenham, M.A. Green, M.E. Watt, "Applied Photovoltaics" ISBN
@@ -2482,21 +2459,13 @@ def singlediode(photocurrent, saturation_current, resistance_series,
        photovoltaic cell interconnection circuits" JW Bishop, Solar Cell (1988)
        https://doi.org/10.1016/0379-6787(88)90059-2
     """
-    if ivcurve_pnts:
-        warn_deprecated('0.10.0', name='pvlib.pvsystem.singlediode',
-                        alternative=('pvlib.pvsystem.v_from_i and '
-                                     'pvlib.pvsystem.i_from_v'),
-                        obj_type='parameter ivcurve_pnts',
-                        removal='0.11.0')
     args = (photocurrent, saturation_current, resistance_series,
             resistance_shunt, nNsVth)  # collect args
     # Calculate points on the IV curve using the LambertW solution to the
     # single diode equation
     if method.lower() == 'lambertw':
-        out = _singlediode._lambertw(*args, ivcurve_pnts)
+        out = _singlediode._lambertw(*args)
         points = out[:7]
-        if ivcurve_pnts:
-            ivcurve_i, ivcurve_v = out[7:]
     else:
         # Calculate points on the IV curve using either 'newton' or 'brentq'
         # methods. Voltages are determined by first solving the single diode
@@ -2518,21 +2487,10 @@ def singlediode(photocurrent, saturation_current, resistance_series,
         )
         points = i_sc, v_oc, i_mp, v_mp, p_mp, i_x, i_xx
 
-        # calculate the IV curve if requested using bishop88
-        if ivcurve_pnts:
-            vd = v_oc * (
-                (11.0 - np.logspace(np.log10(11.0), 0.0, ivcurve_pnts)) / 10.0
-            )
-            ivcurve_i, ivcurve_v, _ = _singlediode.bishop88(vd, *args)
-
     columns = ('i_sc', 'v_oc', 'i_mp', 'v_mp', 'p_mp', 'i_x', 'i_xx')
 
-    if all(map(np.isscalar, args)) or ivcurve_pnts:
+    if all(map(np.isscalar, args)):
         out = {c: p for c, p in zip(columns, points)}
-
-        if ivcurve_pnts:
-            out.update(i=ivcurve_i, v=ivcurve_v)
-
         return out
 
     points = np.atleast_1d(*points)  # convert scalars to 1d-arrays

--- a/pvlib/tests/test_singlediode.py
+++ b/pvlib/tests/test_singlediode.py
@@ -8,7 +8,6 @@ import scipy
 from pvlib import pvsystem
 from pvlib.singlediode import (bishop88_mpp, estimate_voc, VOLTAGE_BUILTIN,
                                bishop88, bishop88_i_from_v, bishop88_v_from_i)
-from pvlib._deprecation import pvlibDeprecationWarning
 import pytest
 from numpy.testing import assert_array_equal
 from .conftest import DATA_DIR
@@ -186,24 +185,6 @@ def test_singlediode_lambert_negative_voc(mocker):
     x = np.array([x, x]).T
     outs = pvsystem.singlediode(*x, method="lambertw")
     assert_array_equal(outs["v_oc"], [0, 0])
-
-
-@pytest.mark.parametrize('method', ['lambertw'])
-def test_ivcurve_pnts_precision(method, precise_iv_curves):
-    """
-    Tests the accuracy of the IV curve points calcuated by singlediode. Only
-    methods of singlediode that linearly spaced points are tested.
-    """
-    x, pc = precise_iv_curves
-    pc_i, pc_v = np.stack(pc['Currents']), np.stack(pc['Voltages'])
-    ivcurve_pnts = len(pc['Currents'][0])
-
-    with pytest.warns(pvlibDeprecationWarning, match='ivcurve_pnts'):
-        outs = pvsystem.singlediode(method=method, ivcurve_pnts=ivcurve_pnts,
-                                    **x)
-
-    assert np.allclose(pc_i, outs['i'], atol=1e-10, rtol=0)
-    assert np.allclose(pc_v, outs['v'], atol=1e-10, rtol=0)
 
 
 @pytest.mark.parametrize('method', ['lambertw', 'brentq', 'newton'])


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Follow-up to #1743.  `ivcurve_pnts` was deprecated in 0.10.0 and scheduled for removal in 0.11.0.
