### PR TITLE
Create and list whatsnew page for v0.11.1

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.11.1.rst
 .. include:: whatsnew/v0.11.0.rst
 .. include:: whatsnew/v0.10.5.rst
 .. include:: whatsnew/v0.10.4.rst

--- a/docs/sphinx/source/whatsnew/v0.11.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.1.rst
@@ -1,0 +1,33 @@
+.. _whatsnew_01110:
+
+
+v0.11.1 (Anticipated Sep, 2024)
+-------------------------------
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+


### PR DESCRIPTION
Per the new release procedure, this PR adds and lists a whatsnew page for the next release (v0.11.1).  This will make the whatsnew page viewable in the `latest` docs and in PR builds.