### PR TITLE
Add spectral factor gallery example

### DIFF
--- a/docs/examples/spectrum/spectral_factor.py
+++ b/docs/examples/spectrum/spectral_factor.py
@@ -1,0 +1,141 @@
+"""
+Spectral Mismatch Estimation
+============================
+Comparison of spectral factor calculation methods used to estimate the spectral
+mismatch factor from atmopsheric variable inputs.
+"""
+
+# %%
+# Introduction
+# ------------
+# This example demonstrates how to use different `spectrum.spectral_factor`
+# models in pvlib to calculate the spectral mismatch factor, :math:`M`. While
+# :math:`M` for a photovoltaic (PV) module can be calculated exactly using
+# spectral irradiance and module spectral response data, these data are not
+# always available. pvlib provides several functions to estimate the spectral
+# mismatch factor, :math:`M`, using proxies of the prevaiing spectral
+# irradiance conditions, such as air mass and clearsky index, which are easily
+# derived from common ground-based measurements such as broadband irradiance.
+# More information on a range of spectral factor models, as wel as the
+# variables upon which they are based, can be found in [1]_.
+
+from matplotlib import pyplot as plt
+import pandas as pd
+import pvlib as pv
+from pvlib import location
+from pvlib.solarposition import get_solarposition
+from pvlib.atmosphere import get_relative_airmass
+
+# Let's import some data. This example uses a Typical Meteorological Year 3
+# (TMY3) file for the
+# location of Greensboro, North Carolina, from the pvlib data directory. This
+# TMY3 file is constructed using the median month from each year between 1980
+# and 2003, from which we extract the first week of August 2001 to analyse.
+meteo, metadata = pv.iotools.read_tmy3(
+    r'C:\Users\ezxrd3\Documents\GitHub\pvlib-python\pvlib\data\723170TYA.csv',
+    map_variables=True)
+meteo = meteo.sort_index()
+meteo = meteo.between_time('06:00', '20:00').loc['2001-08-01':'2001-08-07']
+
+# %%
+# pvlib Spectral Factor Functions
+# -----------------------------
+# This example demonstrates the application of three pvlib spectral factor
+# functions, namely `sapm`_, `pvspec`, and `firstsolar`_.
+
+# %%
+# SAPM
+# ----
+# The SAPM function for the spectral mismatch
+# factor calculates :math:`M` using absolute airmass, :math:`AM_a` as an input.
+
+# %%
+# PVSPEC
+# ------
+# The PVSPEC function for the spectral mismatch factor calculates :math:`M`
+# using :math:`AM_a` and the clearsky index, :math:`k_c` as inputs.
+
+# %%
+# First Solar
+# -----------
+# The First Solar function for the spectral mismatch factor calculates
+# :math:`M` using :math:`AM_a` and the atmospheric precipitable water content,
+# :math:`W`, as inputs.
+
+# %%
+# Calculation of inputs
+# ---------------------
+# Let's calculate the absolute air mass, which is required for all three
+# models. We use the Kasten and Young [2]_ model, which requires the apparent
+# sun zenith. Note: TMY3 files timestamps indicate the end of the hour, so we
+# shift the indices back 30-minutes to calculate solar position at the centre
+# of the interval.
+
+# Create a location object
+lat, lon = metadata['latitude'], metadata['longitude']
+alt = altitude = metadata['altitude']
+tz = 'Etc/GMT+5'
+loc = location.Location(lat, lon, tz=tz, name='Greensboro, NC')
+
+# Calculate solar position parameters
+solpos = get_solarposition(
+    meteo.index.shift(freq="-30min"), lat, lon, alt,
+    pressure=meteo.pressure*100,  # convert from millibar to Pa
+    temperature=meteo.temp_air)
+solpos.index = meteo.index  # reset index to end of the hour
+
+amr = get_relative_airmass(solpos.apparent_zenith).dropna()  # relative airmass
+ama = amr*(meteo.pressure/1013.25)  # absolute airmass
+
+# Now we calculate the clearsky index, :math:`kc`, by comparing the TMY3 GHI to
+# the modelled clearky GHI.
+
+cs = loc.get_clearsky(meteo.index)
+kc = cs.ghi/meteo.ghi
+
+# :math:`W` is provided in the TMY3 file but in other cases can be calculated
+# from temperature and relative humidity.
+
+w = meteo.precipitable_water
+
+# %%
+# Calculation of Spectral Mismatch
+
+# Let's calculate the spectral mismatch factor using the three pvlib functions.
+# First, we need to import some model coefficients for the SAPM spectral factor
+# function, which, unlike the other two functions, lacks built-in coefficients.
+
+# Import some for a mc-Si module from the SAPM module database.
+module = pv.pvsystem.retrieve_sam('SandiaMod')['LG_LG290N1C_G3__2013_']
+# Calculate :math:`M` using the three models for an mc-Si PV module.
+m_sapm = pv.spectrum.spectral_factor_sapm(ama, module)
+m_pvspec = pv.spectrum.spectral_factor_pvspec(ama, kc, 'multisi')
+m_fs = pv.spectrum.spectral_factor_firstsolar(w, ama, 'multisi')
+df_results = pd.concat([m_sapm, m_pvspec, m_fs], axis=1)
+df_results.columns = ['SAPM', 'PVSPEC', 'FS']
+# %%
+# Comparison Plots
+
+# We can plot the results to visualisee variability between the models. Note
+# that this is not an exact comparison since the exact same PV modules has
+# not been modelled in each case, only the same module technology.
+
+# Convert Dataframe Indexes to Month-Day our:Minute format
+df_results.index = df_results.index.strftime("%m-%d")
+
+# Plot :math:`M`
+fig1, ax1 = plt.subplots()
+df_results.plot(ax=ax1)
+
+ax1.set_xlabel('Date (m-d H:M)')
+ax1.set_ylabel('Mismatch (-)')
+ax1.legend()
+plt.show()
+
+# We can also zoom in one one day, for example August 1st.
+df_results.index = m_fs.index
+df_results = df_results.loc['2001-08-01':'2001-08-01']
+df_results.index = df_results.index.strftime("%H:%M")
+fig2, ax1 = plt.subplots()
+df_results.plot(ax=ax1)
+plt.show()


### PR DESCRIPTION
 - [X] Closes #2107 
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Context described in Issue #2107 
PR is currently a draft. Current questions I'd like to ask:

- What duration of analysis is best? I analyse a week and plot both one week and a day at present.
- If sticking with the current duration, I prefer to plot the full week and then zoom in on one day; but this section of code:
```
df_results.index = m_fs.index
df_results = df_results.loc['2001-08-01':'2001-08-01']
df_results.index = df_results.index.strftime("%H:%M")
fig2, ax1 = plt.subplots()
df_results.plot(ax=ax1)
plt.show()
```
where I effectively reset and then reformat the index, and then replot a new graph seems inefficient. Is it possible to do this in a better way? Somehow duplicating and limiting the axis of the first graph perhaps?
- For one day, between what times should data be plotted? Starting from 0600 enables the inclusion of a value of `M` generated by the First Solar Model when the other two modules yield `0`, but this means the y-axis must start from zero, which cramps up the plots  to the point where it is hard to visualise differences between the curves. Starting at 0700 resolves this but means that one non-zero value of M is omitted. PV output at these times is likely negligible but for the purpose of illustrating a calculation of `M` using different models I am still wondering what might be the best option here.