### PR TITLE
Update `spectral_factor_sapm` docstring returns statement

### DIFF
--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -559,7 +559,7 @@ def spectral_factor_sapm(airmass_absolute, module):
     Returns
     -------
     f1 : numeric
-        The SAPM spectral loss coefficient.
+        The spectral mismatch factor [unitless]
 
     Notes
     -----

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -559,7 +559,7 @@ def spectral_factor_sapm(airmass_absolute, module):
     Returns
     -------
     f1 : numeric
-        The spectral mismatch factor [unitless]
+        The spectral mismatch factor. [unitless]
 
     Notes
     -----


### PR DESCRIPTION
Minor revision to the "returns" statement in the docs for `pvib.spectrum.spectral_factor_sapm()` following [this review
](https://github.com/pvlib/pvlib-python/pull/2116#discussion_r1670684016)