### PR TITLE
Add ape_e spectral factor model

### DIFF
--- a/docs/sphinx/source/reference/effects_on_pv_system_output/spectrum.rst
+++ b/docs/sphinx/source/reference/effects_on_pv_system_output/spectrum.rst
@@ -16,5 +16,6 @@ Spectrum
    spectrum.spectral_factor_sapm
    spectrum.spectral_factor_pvspec
    spectrum.spectral_factor_jrc
+   spectrum.spectral_factor_daxini
    spectrum.sr_to_qe
    spectrum.qe_to_sr

--- a/pvlib/spectrum/__init__.py
+++ b/pvlib/spectrum/__init__.py
@@ -9,6 +9,7 @@ from pvlib.spectrum.mismatch import (  # noqa: F401
     spectral_factor_sapm,
     spectral_factor_pvspec,
     spectral_factor_jrc,
+    spectral_factor_daxini,
     sr_to_qe,
     qe_to_sr
 )

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -849,16 +849,18 @@ def spectral_factor_daxini(ape, band_depth, module_type=None,
         Average photon energy (APE, :math:`\varphi`) [eV]
 
     band_depth : numeric
-        Depth of a spectral band, :math:`\varepsilon` [:math:`Wm^-2`]
+        Depth of a spectral band, :math:`\varepsilon` [Wm:math:`^{-2}`]
 
-    module_type : str, optional. The default is None.
+    module_type : str, optional
         One of the following PV technology strings from [1]_:
 
-        * ``asi-t`` - anyonymous triple junction amorphous Si
+        * ``asi-t`` - anyonymous triple junction amorphous Si module
         * ``'cdte'`` - anyonymous CdTe module.
-        * ``'multisi'`` - anyonymous multicrystalline Si module.
+        * ``'multisi'`` - anyonymous multicrystalline Si module
 
-    coefficients : array-ike, optional
+        The default is None.
+
+    coefficients : array-like, optional
         User-defined coefficients, if not using one of the default coefficient
         sets via the ``module_type`` parameter. The default is None.
 
@@ -884,23 +886,22 @@ def spectral_factor_daxini(ape, band_depth, module_type=None,
     where :math:`a_{0-5}` are module-specific coefficients. In [1]_,
     :math:`\varphi` is calculated between the limits of 350nm to 1050nm.
     While several atmopsheric windows and water absorption bands within the
-    spectral irradiance range 350nm-1050nm are tested as candidates for
+    spectral irradiance range 350nm-1050nm were tested as candidates for
     :math:`\varepsilon`, ultimately the 650nm-670nm is recommended for the PV
     devices analysed in the study. It should be noted that "depth" here refers
     to the area beneath the spectral irradiance curve within the specified
     wavelength limits, which in this case are 650nm-670nm. Therefore,
     :math:`\varepsilon` is calculated by integrating the spectral irradiance,
     with respect to wavelength, between 650nm-670nm. The purpose of this second
-    index, used in conjunction with the APE, is to distinguish between
-    different spectra that have the same or similar APE values, which reduces
-    the reliability of an single-variable APE spectral mismatch estimation
-    function.
+    index is to distinguish between different spectra that have the same or
+    similar APE values, the occurance of which reduces the reliability of a
+    single-variable APE spectral mismatch estimation function.
 
     The model is developed and validated using one year of outdoor
     meteorological, PV, and spectral irradiance data measured at the National
     Renewable Energy Laboratory in Golden, Colorado, USA. The data used are
     publicly available and can be found at [2]_ and [3]_. The primary
-    publications associated with these data releases are [4]_, and [5] and
+    publications associated with these data releases are [4]_, and [5]_ and
     [6]_, respectively.
 
     References
@@ -911,7 +912,7 @@ def spectral_factor_daxini(ape, band_depth, module_type=None,
            Energy 284: 129046.
            :doi:`10.1016/j.energy.2023.129046`
     .. [2] Measurement and Instrumentation Data Center (MIDC)
-           :doi:`10.5439/1052221
+           :doi:`10.5439/1052221`
     .. [3] Data for Validating Models for PV Module Performance
            :doi:`10.21948/1811521`
     .. [4] Stoffel, T., and Andreas, A. NREL Solar Radiation Research

--- a/pvlib/tests/test_spectrum.py
+++ b/pvlib/tests/test_spectrum.py
@@ -474,6 +474,43 @@ def test_spectral_factor_jrc_supplied_ambiguous():
                                      coefficients=None)
 
 
+@pytest.mark.parametrize("module_type,expected", [
+    ('multisi', pd.Series([0.98897, 1.000677, 1.00829])),
+    ('cdte', pd.Series([0.94950, 0.98647, 1.04016])),
+    ('asi-t', pd.Series([0.92752, 1.02894, 1.13527])),
+])
+def test_spectral_factor_daxini_series(module_type, expected):
+    apes = pd.Series([1.82, 1.87, 1.95])
+    bands = pd.Series([2, 4, 8])
+    out = spectrum.spectral_factor_daxini(apes, bands,
+                                          module_type=module_type)
+    assert isinstance(out, pd.Series)
+    assert np.allclose(expected, out, atol=1e-5)
+
+
+def test_spectral_factor_daxini_supplied():
+    # use the cdte coeffs
+    coeffs = (-0.5313, 0.7208, 0.02232, 0.05321, 1.629e-4, -0.01445)
+    out = spectrum.spectral_factor_daxini(1.87, 4, coefficients=coeffs)
+    expected = 0.98647
+    assert_allclose(out, expected, atol=1e-5)
+
+
+def test_spectral_factor_daxini_supplied_redundant():
+    # Error when specifying both module_type and coefficients
+    coeffs = (-0.5313, 0.7208, 0.02232, 0.05321, 1.629e-4, -0.01445)
+    with pytest.raises(ValueError, match='supply only one of'):
+        spectrum.spectral_factor_daxini(1.87, 4, module_type='cdte',
+                                        coefficients=coeffs)
+
+
+def test_spectral_factor_daxini_supplied_ambiguous():
+    # Error when specifying neither module_type nor coefficients
+    with pytest.raises(ValueError, match='No valid input provided'):
+        spectrum.spectral_factor_daxini(1.87, 4, module_type=None,
+                                        coefficients=None)
+
+
 @pytest.fixture
 def sr_and_eqe_fixture():
     # Just some arbitrary data for testing the conversion functions


### PR DESCRIPTION
 - [X] Relates to #2065 
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [X] Tests added
 - [X] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This function calculates the spectral mismatch factor using the average photon energy and the depth of a water absorption band as inputs. Context: #2065 