### PR TITLE
Removed unused input as shown in issue #2105

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.1.rst
@@ -41,6 +41,8 @@ Documentation
 * Added gallery example on calculating cell temperature for
   floating PV. (:pull:`2110`)
 
+* Removed unused "times" input from dni_et() function (:issue:`2105`)
+
 Requirements
 ~~~~~~~~~~~~
 
@@ -51,3 +53,4 @@ Contributors
 * Leonardo Micheli (:ghuser:`lmicheli`)
 * Echedey Luis (:ghuser:`echedey-ls`)
 * Rajiv Daxini (:ghuser:`RDaxini`)
+* Jose Meza (:ghuser:`JoseMezaMendieta`)

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -59,7 +59,7 @@ def ephem_data(times):
 
 
 @pytest.fixture
-def dni_et(times):
+def dni_et():
     return np.array(
         [1321.1655834833093, 1321.1655834833093, 1321.1655834833093,
          1321.1655834833093])


### PR DESCRIPTION
 - [x] Closes #2105 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.


Removed the unused "times" input for the dni_et() function in test_irradiance.py. Since it was unused, it did not impact current tests. No tests added and no comments added since it was just a deletion. 
