### PR TITLE
Update plot_oedi_9068.py

### DIFF
--- a/docs/examples/system-models/plot_oedi_9068.py
+++ b/docs/examples/system-models/plot_oedi_9068.py
@@ -179,7 +179,7 @@ averaged_irradiance = pvlib.bifacial.infinite_sheds.get_irradiance_poa(
     solar_position['apparent_zenith'], solar_position['azimuth'],
     gcr, axis_height, pitch,
     psm3['ghi'], psm3['dhi'], psm3['dni'], psm3['albedo'],
-    model='haydavies', dni_extra=dni_extra,
+    model='haydavies', dni_extra=dni_extra
 )
 
 # %%
@@ -191,7 +191,7 @@ cell_temperature_steady_state = pvlib.temperature.faiman(
     poa_global=averaged_irradiance['poa_global'],
     temp_air=psm3['temp_air'],
     wind_speed=psm3['wind_speed'],
-    **temperature_model_parameters,
+    **temperature_model_parameters
 )
 
 cell_temperature = pvlib.temperature.prilliman(
@@ -213,7 +213,7 @@ weather_inputs = pd.DataFrame({
     'poa_direct': averaged_irradiance['poa_direct'],
     'poa_diffuse': averaged_irradiance['poa_diffuse'],
     'cell_temperature': cell_temperature,
-    'precipitable_water': psm3['precipitable_water'],  # for the spectral model
+    'precipitable_water': psm3['precipitable_water']  # for the spectral model
 })
 model.run_model_from_poa(weather_inputs)
 


### PR DESCRIPTION
removed extra comas ',' in the code

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
