### PR TITLE
fix a typo at the singlediode function

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.1.rst
@@ -69,3 +69,4 @@ Contributors
 * Mark A. Mikofski (:ghuser:`mikofski`)
 * Ben Pierce (:ghuser:`bgpierc`)
 * Jose Meza (:ghuser:`JoseMezaMendieta`)
+* Luiz Reis (:ghuser:`luizreiscver`)

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -632,7 +632,7 @@ def _shape_of_max_size(*args):
 def _prepare_newton_inputs(x0, args, method_kwargs):
     """
     Make inputs compatible with Scipy's newton by:
-    - converting all arugments (`x0` and `args`) into numpy.ndarrays if any
+    - converting all arguments (`x0` and `args`) into numpy.ndarrays if any 
       argument is not a scalar.
     - broadcasting the initial guess `x0` to the shape of the argument with
       the greatest size.

--- a/pvlib/singlediode.py
+++ b/pvlib/singlediode.py
@@ -632,7 +632,7 @@ def _shape_of_max_size(*args):
 def _prepare_newton_inputs(x0, args, method_kwargs):
     """
     Make inputs compatible with Scipy's newton by:
-    - converting all arguments (`x0` and `args`) into numpy.ndarrays if any 
+    - converting all arguments (`x0` and `args`) into numpy.ndarrays if any
       argument is not a scalar.
     - broadcasting the initial guess `x0` to the shape of the argument with
       the greatest size.


### PR DESCRIPTION
 - [X] Closes #2177 
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [X] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

