### PR TITLE
Update virtual environment guide URL on contributing page

### DIFF
--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -70,10 +70,9 @@ Requests <https://help.github.com/articles/using-pull-requests/>`_.
 We strongly recommend using virtual environments for development.
 Virtual environments make it trivial to switch between different
 versions of software. This `astropy guide
-<https://astropy-astrofrog.readthedocs.io/en/latest/development/workflow/
-virtual_pythons.html>`_ is a good reference for virtual environments. If
-this is your first pull request, don't worry about using a virtual
-environment.
+<https://learn.scientific-python.org/development/tutorials/dev-environment/>`_
+is a good reference for virtual environments. If this is your first pull
+request, don't worry about using a virtual environment.
 
 You must include documentation and unit tests for any new or improved
 code. We can provide help and advice on this after you start the pull

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -68,7 +68,7 @@ into detail on each of these steps. Also see GitHub's `Set Up Git
 Requests <https://help.github.com/articles/using-pull-requests/>`_.
 
 We strongly recommend using virtual environments for development.
-Virtual environments make it trivial to switch between different
+Virtual environments make it easier to switch between different
 versions of software. This `scientific-python.org guide
 <https://learn.scientific-python.org/development/tutorials/dev-environment/>`_
 is a good reference for virtual environments. The pvlib-python `installation

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -71,8 +71,11 @@ We strongly recommend using virtual environments for development.
 Virtual environments make it trivial to switch between different
 versions of software. This `scientific-python.org guide
 <https://learn.scientific-python.org/development/tutorials/dev-environment/>`_
-is a good reference for virtual environments. If this is your first pull
-request, don't worry about using a virtual environment.
+is a good reference for virtual environments. The pvlib-python `installation
+user guide <https://pvlib-python.readthedocs.io/en/stable/user_guide/
+installation.html#set-up-a-virtual-environment>`_ also provides instructions on
+setting up a virtual environment. If this is your first pull request, don't
+worry about using a virtual environment.
 
 You must include documentation and unit tests for any new or improved
 code. We can provide help and advice on this after you start the pull

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -69,7 +69,7 @@ Requests <https://help.github.com/articles/using-pull-requests/>`_.
 
 We strongly recommend using virtual environments for development.
 Virtual environments make it trivial to switch between different
-versions of software. This `astropy guide
+versions of software. This `scientific-python.org guide
 <https://learn.scientific-python.org/development/tutorials/dev-environment/>`_
 is a good reference for virtual environments. If this is your first pull
 request, don't worry about using a virtual environment.

--- a/docs/sphinx/source/contributing.rst
+++ b/docs/sphinx/source/contributing.rst
@@ -70,7 +70,7 @@ Requests <https://help.github.com/articles/using-pull-requests/>`_.
 We strongly recommend using virtual environments for development.
 Virtual environments make it trivial to switch between different
 versions of software. This `astropy guide
-<http://astropy.readthedocs.org/en/latest/development/workflow/
+<https://astropy-astrofrog.readthedocs.io/en/latest/development/workflow/
 virtual_pythons.html>`_ is a good reference for virtual environments. If
 this is your first pull request, don't worry about using a virtual
 environment.


### PR DESCRIPTION
 - [X] Closes #2199
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Original link: https://docs.astropy.org/en/latest/development/workflow/virtual_pythons.html
New link: https://astropy-astrofrog.readthedocs.io/en/latest/development/workflow/virtual_pythons.html
Could someone confirm the new link here is the correct/intended webpage for the guide?