### PR TITLE
Fix examples of shaded_fraction1d

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.1.rst
@@ -51,6 +51,7 @@ Documentation
 * Added gallery example demonstrating how to use
   different Perez coefficients in a ModelChain.
   (:issue:`2127`, :pull:`2148`)
+* Fixed examples in :py:func:`pvlib.shading.shaded_fraction1d`. (:pull:`#2215`)
 
 * Removed unused "times" input from dni_et() function (:issue:`2105`)
 

--- a/pvlib/shading.py
+++ b/pvlib/shading.py
@@ -449,11 +449,11 @@ def shaded_fraction1d(
     Tilted row with a pitch of 3 m, a collector width of
     2 m, and row rotations of 30°. In the morning.
 
-    >>> shaded_fraction1d(solar_zenith=80, solar_azimuth=104.5,
+    >>> shaded_fraction1d(solar_zenith=80, solar_azimuth=135,
     ...     axis_azimuth=90, shaded_row_rotation=30, shading_row_rotation=30,
     ...     collector_width=2, pitch=3, axis_tilt=0,
     ...     surface_to_axis_offset=0.05, cross_axis_slope=0)
-    0.6827437712114521
+    0.47755694708090535
 
     **Fixed-tilt north-facing array on sloped terrain**
 
@@ -463,11 +463,11 @@ def shaded_fraction1d(
     10° slope, where their axis is on the most inclined
     direction (zero cross-axis slope). Shaded in the morning.
 
-    >>> shaded_fraction1d(solar_zenith=65, solar_azimuth=75.5,
+    >>> shaded_fraction1d(solar_zenith=80, solar_azimuth=75.5,
     ...     axis_azimuth=270, shaded_row_rotation=50, shading_row_rotation=30,
     ...     collector_width=2.5, pitch=4, axis_tilt=10,
     ...     surface_to_axis_offset=0.05, cross_axis_slope=0)
-    0.6975923460352351
+    0.793244836197256
 
     **N-S single-axis tracker on sloped terrain**
 
@@ -476,10 +476,10 @@ def shaded_fraction1d(
     in the morning. Terrain slope is 7° west-east (east-most
     tracker is higher than the west-most tracker).
 
-    >>> shaded_fraction1d(solar_zenith=50, solar_azimuth=90, axis_azimuth=180,
+    >>> shaded_fraction1d(solar_zenith=80, solar_azimuth=90, axis_azimuth=180,
     ...     shaded_row_rotation=-30, collector_width=1.4, pitch=3, axis_tilt=0,
     ...     surface_to_axis_offset=0.10, cross_axis_slope=7)
-    0.5828961460616938
+    0.8242176864434579
 
     Note the previous example only is valid for the shaded fraction of the
     west-most tracker in the morning, and assuming it is the
@@ -491,10 +491,10 @@ def shaded_fraction1d(
     tracker, you must input the corresponding ``shaded_row_rotation``
     in the afternoon.
 
-    >>> shaded_fraction1d(solar_zenith=50, solar_azimuth=270, axis_azimuth=180,
+    >>> shaded_fraction1d(solar_zenith=80, solar_azimuth=270, axis_azimuth=180,
     ...     shaded_row_rotation=30, collector_width=1.4, pitch=3, axis_tilt=0,
     ...     surface_to_axis_offset=0.10, cross_axis_slope=7)
-    0.4399034444363955
+    0.018002567182254348
 
     You must switch the input/output depending on the
     sign of the projected solar zenith angle. See


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Solves issue raised at mailing list: https://groups.google.com/g/pvlib-python/c/Yl5tL3HKtMU
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
I forgot to update the outputs after doing changes to the inputs...
![th-2293064154](https://github.com/user-attachments/assets/5e60cc4c-243b-4743-b8d3-b2255f625a1d)

Docs link: https://pvlib-python--2215.org.readthedocs.build/en/2215/reference/generated/pvlib.shading.shaded_fraction1d.html

Do you think we need an whatsnew entry for this?