### PR TITLE
Create and list whatsnew page for v0.11.2

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.11.2.rst
 .. include:: whatsnew/v0.11.1.rst
 .. include:: whatsnew/v0.11.0.rst
 .. include:: whatsnew/v0.10.5.rst

--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -1,0 +1,30 @@
+.. _whatsnew_01120:
+
+
+v0.11.2 (Anticipated December, 2024)
+------------------------------------
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+
+


### PR DESCRIPTION
Per the release procedure, this PR adds and lists a whatsnew page for the next release (v0.11.2). This will make the whatsnew page viewable in the latest docs and in PR builds.
