### PR TITLE
fix typos in #2229

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -15,7 +15,7 @@ Enhancements
 Documentation
 ~~~~~~~~~~~~~
 * Edited docstrings for :py:func:`~pvlib.pvsystem.dc_ohms_from_percent` and
-  :py:func:`~pvlib.pvsystem.dc_ohmic_loss` for clarity. (:issue:`1601`, :pull:`2229`)
+  :py:func:`~pvlib.pvsystem.dc_ohmic_losses` for clarity. (:issue:`1601`, :pull:`2229`)
 
 
 Testing

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2952,7 +2952,7 @@ def dc_ohmic_losses(resistance, current):
 
     .. math::
 
-        L = I \times R^2
+        L = I^2 \times R
 
     where :math:`I` is the current (A) and :math:`R` is the resistance of the
     conductor (ohms).


### PR DESCRIPTION
 - ~~[ ] Closes #xxxx~~
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [X] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fix typos in #2229