### PR TITLE
`aoi` definition in variables_style_rules.csv

### DIFF
--- a/pvlib/data/variables_style_rules.csv
+++ b/pvlib/data/variables_style_rules.csv
@@ -11,7 +11,7 @@ ghi;global horizontal irradiance
 ghi_extra;horizontal irradiance at top of atmosphere (extraterrestrial)
 gri;ground-reflected irradiance
 ape;average photon energy
-aoi;angle of incidence between ±90°
+aoi;angle of incidence. Angle between the surface normal vector and the vector pointing towards the sun's centre
 aoi_projection;cos(aoi)
 airmass;airmass
 airmass_relative;relative airmass

--- a/pvlib/data/variables_style_rules.csv
+++ b/pvlib/data/variables_style_rules.csv
@@ -11,7 +11,7 @@ ghi;global horizontal irradiance
 ghi_extra;horizontal irradiance at top of atmosphere (extraterrestrial)
 gri;ground-reflected irradiance
 ape;average photon energy
-aoi;angle of incidence. Angle between the surface normal vector and the vector pointing towards the sun's centre
+aoi;angle of incidence. Angle between the surface normal vector and the vector pointing towards the sun's center
 aoi_projection;cos(aoi)
 airmass;airmass
 airmass_relative;relative airmass

--- a/pvlib/data/variables_style_rules.csv
+++ b/pvlib/data/variables_style_rules.csv
@@ -11,7 +11,7 @@ ghi;global horizontal irradiance
 ghi_extra;horizontal irradiance at top of atmosphere (extraterrestrial)
 gri;ground-reflected irradiance
 ape;average photon energy
-aoi;angle of incidence between :math:`90\deg` and :math:`90\deg`
+aoi;angle of incidence between ±90°
 aoi_projection;cos(aoi)
 airmass;airmass
 airmass_relative;relative airmass


### PR DESCRIPTION
 - [ ] ~Closes #xxxx~
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~Tests added~
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

[Original definition](https://pvlib-python.readthedocs.io/en/stable/user_guide/variables_style_rules.html) says angles "between 90deg and 90deg", but this should be plus/minus 90deg (right?)