### PR TITLE
Change location.get_sun_rise_set_transit default method

### DIFF
--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -328,15 +328,15 @@ class Location:
 
         return airmass
 
-    def get_sun_rise_set_transit(self, times, method='pyephem', **kwargs):
+    def get_sun_rise_set_transit(self, times, method='spa', **kwargs):
         """
-        Calculate sunrise, sunset and transit times.
+        Calculate sunrise, sunset, and transit times.
 
         Parameters
         ----------
         times : DatetimeIndex
             Must be localized to the Location
-        method : str, default 'pyephem'
+        method : str, default 'spa'
             'pyephem', 'spa', or 'geometric'
 
         kwargs :


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The default method for `pvlib.location.Location.get_sun_rise_set_transit` is ``'pyephem'`` which is an external package. It seems desirable that the default is changed to ```'spa'`` given that they are equally accurate and that SPA is included internally in pvlib.