### PR TITLE
[MAINT]: Partially move `test_conftest` to `test__deprecation`

### DIFF
--- a/pvlib/tests/test_conftest.py
+++ b/pvlib/tests/test_conftest.py
@@ -1,50 +1,6 @@
 import pytest
-import pandas
 
 from pvlib.tests import conftest
-from pvlib.tests.conftest import fail_on_pvlib_version
-
-from pvlib._deprecation import pvlibDeprecationWarning, deprecated
-
-@pytest.mark.xfail(strict=True,
-                   reason='fail_on_pvlib_version should cause test to fail')
-@fail_on_pvlib_version('0.0')
-def test_fail_on_pvlib_version():
-    pass
-
-
-@fail_on_pvlib_version('100000.0')
-def test_fail_on_pvlib_version_pass():
-    pass
-
-
-@pytest.mark.xfail(strict=True, reason='ensure that the test is called')
-@fail_on_pvlib_version('100000.0')
-def test_fail_on_pvlib_version_fail_in_test():
-    raise Exception
-
-
-# set up to test using fixtures with function decorated with
-# conftest.fail_on_pvlib_version
-@pytest.fixture()
-def some_data():
-    return "some data"
-
-
-def alt_func(*args):
-    return args
-
-
-deprec_func = deprecated('350.8', alternative='alt_func',
-                         name='deprec_func', removal='350.9')(alt_func)
-
-
-@fail_on_pvlib_version('350.9')
-def test_use_fixture_with_decorator(some_data):
-    # test that the correct data is returned by the some_data fixture
-    assert some_data == "some data"
-    with pytest.warns(pvlibDeprecationWarning):  # test for deprecation warning
-        deprec_func(some_data)
 
 
 @pytest.mark.parametrize('function_name', ['assert_index_equal',


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Addresses comment https://github.com/pvlib/pvlib-python/pull/2237#discussion_r1785095895
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Rearranging things for future selfs: https://github.com/pvlib/pvlib-python/pull/2237#discussion_r1785095895
