### PR TITLE
Replace freq '1M' with '1ME'

### DIFF
--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -160,7 +160,7 @@ def get_bsrn(station, start, end, username, password,
 
     # Generate list files to download based on start/end (SSSMMYY.dat.gz)
     filenames = pd.date_range(
-        start, end.replace(day=1) + pd.DateOffset(months=1), freq='1M')\
+        start, end.replace(day=1) + pd.DateOffset(months=1), freq='1ME')\
         .strftime(f"{station}%m%y.dat.gz").tolist()
 
     # Create FTP connection

--- a/pvlib/iotools/srml.py
+++ b/pvlib/iotools/srml.py
@@ -237,7 +237,7 @@ def get_srml(station, start, end, filetype='PO', map_variables=True,
 
     # Generate list of months
     months = pd.date_range(
-        start, end.replace(day=1) + pd.DateOffset(months=1), freq='1M')
+        start, end.replace(day=1) + pd.DateOffset(months=1), freq='1ME')
     months_str = months.strftime('%y%m')
 
     # Generate list of filenames

--- a/pvlib/tests/iotools/test_sodapro.py
+++ b/pvlib/tests/iotools/test_sodapro.py
@@ -19,7 +19,7 @@ testfile_radiation_monthly = DATA_DIR / 'cams_radiation_monthly.csv'
 
 index_verbose = pd.date_range('2020-06-01 12', periods=4, freq='1min',
                               tz='UTC')
-index_monthly = pd.date_range('2020-01-01', periods=4, freq='1M')
+index_monthly = pd.date_range('2020-01-01', periods=4, freq='1ME')
 
 
 dtypes_mcclear_verbose = [

--- a/pvlib/tests/test_clearsky.py
+++ b/pvlib/tests/test_clearsky.py
@@ -225,7 +225,7 @@ def test_lookup_linke_turbidity_nointerp():
 
 def test_lookup_linke_turbidity_months():
     times = pd.date_range(start='2014-04-01', end='2014-07-01',
-                          freq='1M', tz='America/Phoenix')
+                          freq='1ME', tz='America/Phoenix')
     expected = pd.Series(
         np.array([2.89918032787, 2.97540983607, 3.19672131148]), index=times
     )
@@ -235,7 +235,7 @@ def test_lookup_linke_turbidity_months():
 
 def test_lookup_linke_turbidity_months_leapyear():
     times = pd.date_range(start='2016-04-01', end='2016-07-01',
-                          freq='1M', tz='America/Phoenix')
+                          freq='1ME', tz='America/Phoenix')
     expected = pd.Series(
         np.array([2.89918032787, 2.97540983607, 3.19672131148]), index=times
     )
@@ -245,14 +245,14 @@ def test_lookup_linke_turbidity_months_leapyear():
 
 def test_lookup_linke_turbidity_nointerp_months():
     times = pd.date_range(start='2014-04-10', end='2014-07-10',
-                          freq='1M', tz='America/Phoenix')
+                          freq='1ME', tz='America/Phoenix')
     expected = pd.Series(np.array([2.85, 2.95, 3.]), index=times)
     out = clearsky.lookup_linke_turbidity(times, 32.125, -110.875,
                                           interp_turbidity=False)
     assert_series_equal(expected, out)
     # changing the dates shouldn't matter if interp=False
     times = pd.date_range(start='2014-04-05', end='2014-07-05',
-                          freq='1M', tz='America/Phoenix')
+                          freq='1ME', tz='America/Phoenix')
     out = clearsky.lookup_linke_turbidity(times, 32.125, -110.875,
                                           interp_turbidity=False)
     assert_series_equal(expected, out)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The `freq='1M'` is used a couple of places in the pvlib iotools, however, this results in the following future warning:

> FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
  months = pd.date_range(

