### PR TITLE
Show distribution file sizes in `publish.yml` GH Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
         pip install $(find dist -type f -name "*.whl") --target=./tmp
 
     - name: List installed file sizes
+      run: |
         du -h ./tmp
 
     # only publish distribution to PyPI for tagged commits

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Build packages
       run: python -m build
 
+    - name: List distribution file sizes
+      run: ls -hl dist/*
+
     - name: Check metadata verification
       run: python -m twine check --strict dist/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       run: python -m build
 
     - name: List distribution file sizes
-      run: ls -hl dist/*
+      run: du -h dist/*
 
     - name: Check metadata verification
       run: python -m twine check --strict dist/*
@@ -45,8 +45,8 @@ jobs:
         pip install $(find dist -type f -name "*.whl") --target=./tmp
 
     - name: List installed file sizes
-      run: |
-        cd ./tmp && du -h pvlib
+      run: du -h pvlib
+      working-directory: ./tmp
 
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,11 @@ jobs:
     - name: Check metadata verification
       run: python -m twine check --strict dist/*
 
+    - name: Ensure that the wheel installs correctly, and show installed size
+      run: |
+        pip install $(find dist -type f -name "*.whl")
+        du -h $(python -c "import pvlib; print(pvlib.__path__[0])")
+        
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: List installed file sizes
       run: |
-        du -h ./tmp
+        cd ./tmp && du -h pvlib
 
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,11 +39,14 @@ jobs:
     - name: Check metadata verification
       run: python -m twine check --strict dist/*
 
-    - name: Ensure that the wheel installs correctly, and show installed size
+    - name: Ensure that the wheel installs successfully
       run: |
-        pip install $(find dist -type f -name "*.whl")
-        du -h $(python -c "import pvlib; print(pvlib.__path__[0])")
-        
+        mkdir ./tmp
+        pip install $(find dist -type f -name "*.whl") --target=./tmp
+
+    - name: List installed file sizes
+        du -h ./tmp
+
     # only publish distribution to PyPI for tagged commits
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

With ongoing work around reducing the size of our distribution files, it is helpful to log the filesize in PR dist builds.  