### PR TITLE
changed default types to float in solarposition.py

### DIFF
--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -856,8 +856,8 @@ def ephemeris(time, latitude, longitude, pressure=101325.0, temperature=12.0):
 
 
 def calc_time(lower_bound, upper_bound, latitude, longitude, attribute, value,
-              altitude=0.0, pressure=101325.0, temperature=12.0, horizon='+0:00',
-              xtol=1.0e-12):
+              altitude=0.0, pressure=101325.0, temperature=12.0,
+              horizon='+0:00', xtol=1.0e-12):
     """
     Calculate the time between lower_bound and upper_bound
     where the attribute is equal to value. Uses PyEphem for

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -27,16 +27,10 @@ from pvlib import atmosphere, tools
 from pvlib.tools import datetime_to_djd, djd_to_datetime
 
 
-def get_solarposition(
-    time,
-    latitude,
-    longitude,
-    altitude,
-    pressure = None,
-    method = 'nrel_numpy',
-    temperature = 12.,
-    **kwargs
-):
+def get_solarposition(time, latitude, longitude,
+                      altitude=None, pressure=None,
+                      method='nrel_numpy',
+                      temperature=12.0, **kwargs):
     """
     A convenience wrapper for the solar position calculators.
 

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -1052,7 +1052,9 @@ def equation_of_time_spencer71(dayofyear):
     Myers [4]_ and printed in both the Fourier paper from the Sundial
     Mailing List and R. Hulstrom's [5]_ book.
 
-    .. _Fourier paper: http://www.mail-archive.com/sundial@uni-koeln.de/msg01050.html
+    .. `Fourier paper:
+        <http://www.mail-archive.com/
+        sundial@uni-koeln.de/msg01050.html>`_
 
     Parameters
     ----------
@@ -1100,7 +1102,8 @@ def equation_of_time_pvcdrom(dayofyear):
     `PVCDROM`_ is a website by Solar Power Lab at Arizona State
     University (ASU)
 
-    .. _PVCDROM: http://www.pveducation.org/pvcdrom/2-properties-sunlight/solar-time
+    .. `PVCDROM: <http://www.pveducation.org/
+    pvcdrom/2-properties-sunlight/solar-time>`_
 
     Parameters
     ----------

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -28,13 +28,13 @@ from pvlib.tools import datetime_to_djd, djd_to_datetime
 
 
 def get_solarposition(
-    time: pd.DatetimeIndex,
-    latitude: float,
-    longitude: float,
-    altitude: float | None = None,
-    pressure: float | None = None,
-    method: str = 'nrel_numpy',
-    temperature: float = 12.,
+    time,
+    latitude,
+    longitude,
+    altitude,
+    pressure = None,
+    method = 'nrel_numpy',
+    temperature = 12.,
     **kwargs
 ):
     """
@@ -155,11 +155,11 @@ def spa_c(time, latitude, longitude, pressure=101325., altitude=0.,
     longitude : float
         Longitude in decimal degrees. Positive east of prime meridian,
         negative to west.
-    pressure : float, default 101325
+    pressure : float, default 101325.0
         Pressure in Pascals
-    altitude : float, default 0
+    altitude : float, default 0.0
         Height above sea level. [m]
-    temperature : float, default 12
+    temperature : float, default 12.0
         Temperature in C
     delta_t : float, default 67.0
         Difference between terrestrial time and UT1.
@@ -308,11 +308,11 @@ def spa_python(time, latitude, longitude,
     longitude : float
         Longitude in decimal degrees. Positive east of prime meridian,
         negative to west.
-    altitude : float, default 0
+    altitude : float, default 0.0
         Distance above sea level.
-    pressure : int or float, optional, default 101325
+    pressure : int or float, optional, default 101325.0
         avg. yearly air pressure in Pascals.
-    temperature : int or float, optional, default 12
+    temperature : int or float, optional, default 12.0
         avg. yearly air temperature in degrees C.
     delta_t : float or array, optional, default 67.0
         Difference between terrestrial time and UT1.
@@ -513,9 +513,9 @@ def _ephem_setup(latitude, longitude, altitude, pressure, temperature,
 
 def sun_rise_set_transit_ephem(times, latitude, longitude,
                                next_or_previous='next',
-                               altitude=0,
-                               pressure=101325,
-                               temperature=12, horizon='0:00'):
+                               altitude=0.,
+                               pressure=101325.,
+                               temperature=12., horizon='0:00'):
     """
     Calculate the next sunrise and sunset times using the PyEphem package.
 
@@ -529,11 +529,11 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
         Longitude in degrees, positive east of prime meridian, negative to west
     next_or_previous : str
         'next' or 'previous' sunrise and sunset relative to time
-    altitude : float, default 0
+    altitude : float, default 0.0
         distance above sea level in meters.
-    pressure : int or float, optional, default 101325
+    pressure : int or float, optional, default 101325.0
         air pressure in Pascals.
-    temperature : int or float, optional, default 12
+    temperature : int or float, optional, default 12.0
         air temperature in degrees C.
     horizon : string, format +/-X:YY
         arc degrees:arc minutes from geometrical horizon for sunrise and
@@ -596,8 +596,8 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
                                            'transit': trans})
 
 
-def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
-            temperature=12, horizon='+0:00'):
+def pyephem(time, latitude, longitude, altitude=0., pressure=101325.,
+            temperature=12., horizon='+0:00'):
     """
     Calculate the solar position using the PyEphem package.
 
@@ -611,11 +611,11 @@ def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
     longitude : float
         Longitude in decimal degrees. Positive east of prime meridian,
         negative to west.
-    altitude : float, default 0
+    altitude : float, default 0.0
         Height above sea level in meters. [m]
-    pressure : int or float, optional, default 101325
+    pressure : int or float, optional, default 101325.0
         air pressure in Pascals.
-    temperature : int or float, optional, default 12
+    temperature : int or float, optional, default 12.0
         air temperature in degrees C.
     horizon : string, optional, default '+0:00'
         arc degrees:arc minutes from geometrical horizon for sunrise and
@@ -685,7 +685,7 @@ def pyephem(time, latitude, longitude, altitude=0, pressure=101325,
     return sun_coords
 
 
-def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
+def ephemeris(time, latitude, longitude, pressure=101325.0, temperature=12.0):
     """
     Python-native solar position calculator.
     The accuracy of this code is not guaranteed.
@@ -701,9 +701,9 @@ def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
     longitude : float
         Longitude in decimal degrees. Positive east of prime meridian,
         negative to west.
-    pressure : float or Series, default 101325
+    pressure : float or Series, default 101325.0
         Ambient pressure (Pascals)
-    temperature : float or Series, default 12
+    temperature : float or Series, default 12.0
         Ambient temperature (C)
 
     Returns
@@ -862,7 +862,7 @@ def ephemeris(time, latitude, longitude, pressure=101325, temperature=12):
 
 
 def calc_time(lower_bound, upper_bound, latitude, longitude, attribute, value,
-              altitude=0, pressure=101325, temperature=12, horizon='+0:00',
+              altitude=0.0, pressure=101325.0, temperature=12.0, horizon='+0:00',
               xtol=1.0e-12):
     """
     Calculate the time between lower_bound and upper_bound
@@ -885,12 +885,12 @@ def calc_time(lower_bound, upper_bound, latitude, longitude, attribute, value,
         and 'az' (which must be given in radians).
     value : int or float
         The value of the attribute to solve for
-    altitude : float, default 0
+    altitude : float, default 0.0
         Distance above sea level.
-    pressure : int or float, optional, default 101325
+    pressure : int or float, optional, default 101325.0
         Air pressure in Pascals. Set to 0 for no
         atmospheric correction.
-    temperature : int or float, optional, default 12
+    temperature : int or float, optional, default 12.0
         Air temperature in degrees C.
     horizon : string, optional, default '+0:00'
         arc degrees:arc minutes from geometrical horizon for sunrise and

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -27,10 +27,16 @@ from pvlib import atmosphere, tools
 from pvlib.tools import datetime_to_djd, djd_to_datetime
 
 
-def get_solarposition(time, latitude, longitude,
-                      altitude=None, pressure=None,
-                      method='nrel_numpy',
-                      temperature=12, **kwargs):
+def get_solarposition(
+    time: pd.DatetimeIndex,
+    latitude: float,
+    longitude: float,
+    altitude: float | None = None,
+    pressure: float | None = None,
+    method: str = 'nrel_numpy',
+    temperature: float = 12.,
+    **kwargs
+):
     """
     A convenience wrapper for the solar position calculators.
 
@@ -125,8 +131,8 @@ def get_solarposition(time, latitude, longitude,
     return ephem_df
 
 
-def spa_c(time, latitude, longitude, pressure=101325, altitude=0,
-          temperature=12, delta_t=67.0,
+def spa_c(time, latitude, longitude, pressure=101325., altitude=0.,
+          temperature=12., delta_t=67.0,
           raw_spa_output=False):
     r"""
     Calculate the solar position using the C implementation of the NREL
@@ -279,7 +285,7 @@ def _datetime_to_unixtime(dtindex):
 
 
 def spa_python(time, latitude, longitude,
-               altitude=0, pressure=101325, temperature=12, delta_t=67.0,
+               altitude=0., pressure=101325., temperature=12., delta_t=67.0,
                atmos_refract=None, how='numpy', numthreads=4):
     """
     Calculate the solar position using a python implementation of the

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -1052,9 +1052,7 @@ def equation_of_time_spencer71(dayofyear):
     Myers [4]_ and printed in both the Fourier paper from the Sundial
     Mailing List and R. Hulstrom's [5]_ book.
 
-    .. `Fourier paper:
-        <http://www.mail-archive.com/
-        sundial@uni-koeln.de/msg01050.html>`_
+    .. _Fourier paper: http://www.mail-archive.com/sundial@uni-koeln.de/msg01050.html
 
     Parameters
     ----------
@@ -1102,8 +1100,7 @@ def equation_of_time_pvcdrom(dayofyear):
     `PVCDROM`_ is a website by Solar Power Lab at Arizona State
     University (ASU)
 
-    .. `PVCDROM: <http://www.pveducation.org/
-    pvcdrom/2-properties-sunlight/solar-time>`_
+    .. _PVCDROM: http://www.pveducation.org/pvcdrom/2-properties-sunlight/solar-time
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes (NONE)
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
I have added type hints to get_solarposition() and I have also changed the default values of the function inputs to `float` instead of `int` to make my linter stop yelling at me.