### PR TITLE
[WIP] Implement hoverxref for floating tooltips (definitions)

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -61,6 +61,11 @@ extensions = [
 mathjax3_config = {'chtml': {'displayAlign': 'left',
                              'displayIndent': '2em'}}
 
+# Enable hover tooltips for glossary terms
+hoverxref_roles = [
+    'term',
+]
+
 napoleon_use_rtype = False  # group rtype on same line together with return
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Work in progress. Not for review.

 - [X] Partially closes #2284; related [comment](https://github.com/pvlib/pvlib-python/issues/1421#issuecomment-2403272459)
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~Tests added~
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.