### PR TITLE
Add optional initial guess to fit_desoto

### DIFF
--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -80,6 +80,26 @@ def test_fit_desoto():
                        rtol=1e-4)
 
 
+def test_fit_desoto_init_guess():
+    init_guess = {'IL_0': 9.43, 'Io_0': 6.04e-7, 'Rs_0': 0.155, 'Rsh_0': 100.,
+                  'a_0': 2.312}
+    result, _ = sdm.fit_desoto(v_mp=31.0, i_mp=8.71, v_oc=38.3, i_sc=9.43,
+                               alpha_sc=0.005658, beta_voc=-0.13788,
+                               cells_in_series=60, init_guess=init_guess)
+    result_expected = {'I_L_ref': 9.45232,
+                       'I_o_ref': 3.22460e-10,
+                       'R_s': 0.297814,
+                       'R_sh_ref': 125.798,
+                       'a_ref': 1.59128,
+                       'alpha_sc': 0.005658,
+                       'EgRef': 1.121,
+                       'dEgdT': -0.0002677,
+                       'irrad_ref': 1000,
+                       'temp_ref': 25}
+    assert np.allclose(pd.Series(result), pd.Series(result_expected),
+                       rtol=1e-4)
+
+
 def test_fit_desoto_failure():
     with pytest.raises(RuntimeError) as exc:
         sdm.fit_desoto(v_mp=31.0, i_mp=8.71, v_oc=38.3, i_sc=9.43,


### PR DESCRIPTION
 - [x] Closes #1014 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Also corrects the references in the docstring of fit_desoto
