### PR TITLE
Fix duplicate `.. _references` label

### DIFF
--- a/docs/sphinx/source/contributing/style_guide.rst
+++ b/docs/sphinx/source/contributing/style_guide.rst
@@ -70,7 +70,7 @@ the ``docs/readthedocs.org:pvlib-python`` link within the checks
 status box at the bottom of the pull request.
 
 
-.. _references:
+.. _reference_style:
 
 References
 ----------

--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -32,7 +32,7 @@ Documentation
   :py:class:`~pvlib.pvsystem.SingleAxisTrackerMount`, and
   :py:class:`~pvlib.pvsystem.FixedMount` docstrings. Various formatting edits
   for clarity. (:issue:`1942`, :pull:`2232`)
-* Added a new citation style guide (:ref:`references`) to the contributing
+* Added a new citation style guide (:ref:`reference_style`) to the contributing
   page. (:issue:`2202`, :pull:`2226`)
 * Updated :py:func:`~pvlib.irradiance.reindl` to include definitions of terms
   and a new "notes" section (:issue:`2183`, :pull:`2193`)


### PR DESCRIPTION
 - [X] Closes #2298
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The alternative would be to change the user guide page section label (see linked issue #2298)