### PR TITLE
Add section label to contributing page index.rst

### DIFF
--- a/docs/sphinx/source/contributing/index.rst
+++ b/docs/sphinx/source/contributing/index.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 ============
 Contributing
 ============


### PR DESCRIPTION
 - [ ] ~Closes #xxxx~
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] ~Tests added~
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] ~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Quick fix: Link to the contributing section on the [package overview](https://pvlib-python.readthedocs.io/en/stable/user_guide/package_overview.html#how-do-i-contribute) section led to the contributing on the pandas webpage rather than our contributing section. Added a section label to the index of our contributing page to fix this.