### PR TITLE
Remove broken link in pvsystem.retrieve_sam

### DIFF
--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2032,7 +2032,7 @@ def retrieve_sam(name=None, path=None):
     Notes
     -----
     Files available at
-    https://github.com/NREL/SAM/tree/develop/deploy/libraries
+        https://github.com/NREL/SAM/tree/develop/deploy/libraries
 
     Examples
     --------

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2029,13 +2029,6 @@ def retrieve_sam(name=None, path=None):
     KeyError
         If the provided ``name`` is not a valid database name.
 
-    Notes
-    -----
-    Files available at
-        https://github.com/NREL/SAM/tree/develop/deploy/libraries
-    Documentation for module and inverter data sets:
-        https://sam.nrel.gov/photovoltaic/pv-sub-page-2.html
-
     Examples
     --------
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -2029,6 +2029,11 @@ def retrieve_sam(name=None, path=None):
     KeyError
         If the provided ``name`` is not a valid database name.
 
+    Notes
+    -----
+    Files available at
+    https://github.com/NREL/SAM/tree/develop/deploy/libraries
+
     Examples
     --------
 


### PR DESCRIPTION
 - [X] Closes #2288 
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [X] Pull request is nearly complete and ready for detailed review.
 - [X] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

If I understood correctly, the conclusion in #2288 is to remove the links entirely rather than update the second one with https://sam.nrel.gov/photovoltaic/pv-publications.html (?)