### PR TITLE
Update tracking.py Tracking Misalignment offser for One Axis

### DIFF
--- a/pvlib/tracking.py
+++ b/pvlib/tracking.py
@@ -8,7 +8,8 @@ from pvlib import shading
 
 def singleaxis(apparent_zenith, apparent_azimuth,
                axis_tilt=0, axis_azimuth=0, max_angle=90,
-               backtrack=True, gcr=2.0/7.0, cross_axis_tilt=0):
+               backtrack=True, gcr=2.0/7.0, cross_axis_tilt=0
+               offset=0):
     """
     Determine the rotation angle of a single-axis tracker when given particular
     solar zenith and azimuth angles.
@@ -84,6 +85,11 @@ def singleaxis(apparent_zenith, apparent_azimuth,
         positive cross-axis tilt if the tracker axes plane slopes down to the
         west. Use :func:`~pvlib.tracking.calc_cross_axis_tilt` to calculate
         ``cross_axis_tilt``. [degrees]
+    offset : float, default 0.0
+      is an additional angle that causes a delay/advance of the tracking 
+      position over the the ideal true tracker_theta angle before 
+      .calc_surface_orientation
+      ``offset``. [degrees]
 
     Returns
     -------
@@ -143,7 +149,7 @@ def singleaxis(apparent_zenith, apparent_azimuth,
         axis_azimuth=axis_azimuth,
         solar_zenith=apparent_zenith,
         solar_azimuth=apparent_azimuth,
-    )
+    ) + offset
 
     # filter for sun above panel horizon
     zen_gt_90 = apparent_zenith > 90


### PR DESCRIPTION
This is a offset parameter as result of this google group thread, 
[https://groups.google.com/g/pvlib-python/c/1k3pX76AlnU](Help with Tracking Misalignment for One Axis)

---

additional  parameter   
offset : float, default 0.0
      is an additional angle that causes a delay/advance of the tracking 
      position over the the ideal true tracker_theta angle before 
      .calc_surface_orientation
      ``offset``. [degrees]

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
