### PR TITLE
Add minus sign in front of dEgdT, `sdm.py`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -22,6 +22,8 @@ Bug fixes
 ~~~~~~~~~
 * :py:func:`~pvlib.spa.julian_day_dt` now accounts for the 10 day difference
   between Julian and Gregorian calendars prior to the year 1582. (:issue:`2077`, :pull:`2249`)
+* Corrected sign of temperature coefficient ``dEgdT`` in :py:func:`~pvlib.pvsystem.fit_desoto_sandia`.
+  Results may differ slightly from previous versions. (:issue:`2311`, :pull:`2322`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -871,7 +871,7 @@ def _extract_sdm_params(ee, tc, iph, io, rs, rsh, n, u, specs, const,
         params['R_sh_exp'] = R_sh_exp
 
     elif model == 'desoto':
-        dEgdT = 0.0002677
+        dEgdT = -0.0002677
         x_for_io = const['q'] / const['k'] * (
             1. / tok - 1. / tck[u] + dEgdT * (tc[u] - const['T0']) / tck[u])
 

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -567,6 +567,8 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
             dark current at STC [A]
         EgRef : float
             effective band gap at STC [eV]
+        dEgdT : float
+            temperature coefficient of Eg [1/K]
         R_s : float
             series resistance at STC [ohm]
         R_sh_ref : float

--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -567,8 +567,6 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
             dark current at STC [A]
         EgRef : float
             effective band gap at STC [eV]
-        dEgdT : float
-            temperature coefficient of Eg [1/K]
         R_s : float
             series resistance at STC [ohm]
         R_sh_ref : float

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -138,8 +138,8 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     modeled['R_s'] = result['R_s']
     modeled['R_sh_ref'] = result['R_sh_ref']
     expected = pd.Series(params)
-    assert_allclose(modeled[params.keys()].values,
-                    expected[params.keys()].values)
+    assert np.allclose(modeled[params.keys()].values,
+                       expected[params.keys()].values, rtol=5e-2)
     assert_allclose(result['dEgdT'], -0.0002677)
     assert_allclose(result['EgRef'], 1.3112547292120638)
     assert_allclose(result['cells_in_series'], specs['cells_in_series'])

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -139,7 +139,7 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     modeled['R_sh_ref'] = result['R_sh_ref']
     expected = pd.Series(params)
     assert_allclose(modeled[params.keys()].values,
-                    expected[params.keys()].values, rtol=5e-2)
+                    expected[params.keys()].values)
     assert_allclose(result['dEgdT'], -0.0002677)
     assert_allclose(result['EgRef'], 1.3112547292120638)
     assert_allclose(result['cells_in_series'], specs['cells_in_series'])

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -138,8 +138,8 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     modeled['R_s'] = result['R_s']
     modeled['R_sh_ref'] = result['R_sh_ref']
     expected = pd.Series(params)
-    assert np.allclose(modeled[params.keys()].values,
-                       expected[params.keys()].values, rtol=5e-2)
+    assert_allclose(modeled[params.keys()].values,
+                    expected[params.keys()].values, rtol=5e-2)
 
 
 def _read_iv_curves_for_test(datafile, npts):

--- a/pvlib/tests/ivtools/test_sdm.py
+++ b/pvlib/tests/ivtools/test_sdm.py
@@ -140,6 +140,9 @@ def test_fit_desoto_sandia(cec_params_cansol_cs5p_220p):
     expected = pd.Series(params)
     assert_allclose(modeled[params.keys()].values,
                     expected[params.keys()].values, rtol=5e-2)
+    assert_allclose(result['dEgdT'], -0.0002677)
+    assert_allclose(result['EgRef'], 1.3112547292120638)
+    assert_allclose(result['cells_in_series'], specs['cells_in_series'])
 
 
 def _read_iv_curves_for_test(datafile, npts):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2321
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fixes the typo in line 874 of `sdm.py`, where `dEgdT = -0.0002677` instead of the same without the minus sign.

Inspired by today's AdventOfCode, I've regexed if this typo is everywhere else and I can confirm it isn't. Regex: `(?<!-)0.0002677`

Tests are passing locally. @cwhanse , should I create a test with a hella lot of precision to test this?
