### PR TITLE
correct `dEgdT` units in `ivtools.sdm.fit_desoto`

### DIFF
--- a/pvlib/ivtools/sdm.py
+++ b/pvlib/ivtools/sdm.py
@@ -151,17 +151,17 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
     i_sc: float
         Short-circuit current at reference conditions. [A]
     alpha_sc: float
-        The short-circuit current (i_sc) temperature coefficient of the
+        The short-circuit current (``i_sc``) temperature coefficient of the
         module. [A/K]
     beta_voc: float
-        The open-circuit voltage (v_oc) temperature coefficient of the
+        The open-circuit voltage (``v_oc``) temperature coefficient of the
         module. [V/K]
     cells_in_series: integer
         Number of cell in the module.
     EgRef: float, default 1.121 eV - value for silicon
         Energy of bandgap of semi-conductor used. [eV]
     dEgdT: float, default -0.0002677 - value for silicon
-        Variation of bandgap according to temperature. [eV/K]
+        Variation of bandgap according to temperature. [1/K]
     temp_ref: float, default 25
         Reference temperature condition. [C]
     irrad_ref: float, default 1000
@@ -194,7 +194,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
         EgRef: float
             Energy of bandgap of semi-conductor used. [eV]
         dEgdT: float
-            Variation of bandgap according to temperature. [eV/K]
+            Variation of bandgap according to temperature. [1/K]
         irrad_ref: float
             Reference irradiance condition. [Wm⁻²]
         temp_ref: float


### PR DESCRIPTION
 - [X] Closes #2319
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] ~Tests added~
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] ~Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [X] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.
