### PR TITLE
Make `dni_extra` a required parameter for `ghi_from_poa_driesse_2023`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -22,6 +22,8 @@ Bug Fixes
   (:issue:`1338`, :pull:`2227`)
 * Handle DST transitions that happen at midnight in :py:func:`pvlib.solarposition.hour_angle`
   (:issue:`2132` :pull:`2133`)
+* Chnaged `dni_extra` to a required parameter in :py:func:`pvlib.irradiance.ghi_from_poa_driesse_2023`
+  (:issue:`2279` :pull:`2331`)
 
 Bug fixes
 ~~~~~~~~~
@@ -85,3 +87,4 @@ Contributors
 * Echedey Luis (:ghuser:`echedey-ls`)
 * Kevin Anderson (:ghuser:`kandersolar`)
 * Scott Nelson (:ghuser:`scttnlsn`)
+* Ioannis Sifnaios (:ghuser:`IoannisSifnaios`)

--- a/docs/sphinx/source/whatsnew/v0.11.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.2.rst
@@ -22,7 +22,7 @@ Bug Fixes
   (:issue:`1338`, :pull:`2227`)
 * Handle DST transitions that happen at midnight in :py:func:`pvlib.solarposition.hour_angle`
   (:issue:`2132` :pull:`2133`)
-* Chnaged `dni_extra` to a required parameter in :py:func:`pvlib.irradiance.ghi_from_poa_driesse_2023`
+* Changed ``dni_extra`` to a required parameter in :py:func:`pvlib.irradiance.ghi_from_poa_driesse_2023`
   (:issue:`2279` :pull:`2331`)
 
 Bug fixes

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1528,7 +1528,7 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
 def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
                               solar_zenith, solar_azimuth,
                               poa_global,
-                              dni_extra=None, airmass=None, albedo=0.25,
+                              dni_extra, airmass=None, albedo=0.25,
                               xtol=0.01,
                               full_output=False):
     '''
@@ -1549,7 +1549,7 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
         Solar azimuth angle. [degree]
     poa_global : numeric
         Plane-of-array global irradiance, aka global tilted irradiance. [Wm⁻²]
-    dni_extra : numeric, optional
+    dni_extra : numeric
         Extraterrestrial direct normal irradiance. [Wm⁻²]
     airmass : numeric, optional
         Relative airmass (not adjusted for pressure). [unitless]


### PR DESCRIPTION
 - [x] Closes #2279
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
~~- [ ] Tests added~~
~~- [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
~~- [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

[Compiled read the docs result](https://pvlib-python--2331.org.readthedocs.build/en/2331/reference/generated/pvlib.irradiance.ghi_from_poa_driesse_2023.html)