### PR TITLE
Address sphinx build issues

### DIFF
--- a/docs/examples/shading/plot_martinez_shade_loss.py
+++ b/docs/examples/shading/plot_martinez_shade_loss.py
@@ -47,7 +47,7 @@ import pvlib
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.dates import ConciseDateFormatter
+from matplotlib.dates import DateFormatter
 
 pitch = 4  # meters
 width = 1.5  # meters
@@ -235,10 +235,6 @@ for k, shade_losses in shade_losses_per_module.items():
     ax1.plot(times, shade_losses, label=k, linestyle=linestyle)
 ax1.legend(loc="upper center")
 ax1.grid()
-ax1.set_xlabel("Time")
-ax1.xaxis.set_major_formatter(
-    ConciseDateFormatter("%H:%M", tz="Europe/Madrid")
-)
 ax1.set_ylabel(r"$P_{out}$ losses")
 ax1.set_title("Per module")
 
@@ -248,9 +244,7 @@ for k, shade_losses in shade_losses_per_row.items():
 ax2.legend(loc="upper center")
 ax2.grid()
 ax2.set_xlabel("Time")
-ax2.xaxis.set_major_formatter(
-    ConciseDateFormatter("%H:%M", tz="Europe/Madrid")
-)
+ax2.xaxis.set_major_formatter(DateFormatter("%H:%M", tz="Europe/Madrid"))
 ax2.set_ylabel(r"$P_{out}$ losses")
 ax2.set_title("Per row")
 fig.tight_layout()

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -73,7 +73,9 @@ intersphinx_mapping = {
 
 # Enable hover tooltips
 hoverxref_auto_ref = True
-hoverxref_roles = ["class", "meth", "func", "ref", "term", "obj", "mod"]
+hoverxref_roles = [
+    "class", "meth", "func", "ref", "term", "obj", "mod", "data"
+]
 hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
 hoverxref_domains = ["py"]
 hoverxref_intersphinx = list(intersphinx_mapping.keys())

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
 
 # Enable hover tooltips
 hoverxref_auto_ref = True
-hoverxref_roles = ["class", "meth", "func", "ref", "term"]
+hoverxref_roles = ["class", "meth", "func", "ref", "term", "obj"]
 hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
 hoverxref_domains = ["py"]
 hoverxref_intersphinx = list(intersphinx_mapping.keys())

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
 
 # Enable hover tooltips
 hoverxref_auto_ref = True
-hoverxref_roles = ["class", "meth", "func", "ref", "term", "obj"]
+hoverxref_roles = ["class", "meth", "func", "ref", "term", "obj", "mod"]
 hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
 hoverxref_domains = ["py"]
 hoverxref_intersphinx = list(intersphinx_mapping.keys())


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR fixes two issues with the documentation build.  The first is to prevent the build log from filling up with many instances of this message:

> Using default style (tooltip) for unknown typ (obj). Define it in hoverxref_role_types.

The second is an issue with the latest matplotlib release that produces the following error:

https://app.readthedocs.org/projects/pvlib-python/builds/26591140/

```
WARNING: 
../../examples/shading/plot_martinez_shade_loss.py unexpectedly failed to execute correctly:

    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/checkouts/2306/docs/examples/shading/plot_martinez_shade_loss.py", line 256, in <module>
        fig.tight_layout()
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/figure.py", line 3640, in tight_layout
        engine.execute(self)
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/layout_engine.py", line 183, in execute
        kwargs = get_tight_layout_figure(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/_tight_layout.py", line 266, in get_tight_layout_figure
        kwargs = _auto_adjust_subplotpars(fig, renderer,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/_tight_layout.py", line 82, in _auto_adjust_subplotpars
        bb += [martist._get_tightbbox_for_layout_only(ax, renderer)]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/artist.py", line 1402, in _get_tightbbox_for_layout_only
        return obj.get_tightbbox(*args, **{**kwargs, "for_layout_only": True})
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/axes/_base.py", line 4519, in get_tightbbox
        ba = martist._get_tightbbox_for_layout_only(axis, renderer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/artist.py", line 1402, in _get_tightbbox_for_layout_only
        return obj.get_tightbbox(*args, **{**kwargs, "for_layout_only": True})
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/axis.py", line 1362, in get_tightbbox
        ticks_to_draw = self._update_ticks()
                        ^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/axis.py", line 1293, in _update_ticks
        major_labels = self.major.formatter.format_ticks(major_locs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/pvlib-python/envs/2306/lib/python3.11/site-packages/matplotlib/dates.py", line 799, in format_ticks
        if (self._locator.axis and
            ^^^^^^^^^^^^^^^^^^
    AttributeError: 'str' object has no attribute 'axis'
```