### PR TITLE
Raise helpful exceptions for irradiance.gti_dirint

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -10,7 +10,7 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
-* :pyPfunc:`~pvlib.irradiance.gti_dirint` now raises an informative message
+* :py:func:`~pvlib.irradiance.gti_dirint` now raises an informative message
   when input data don't include values with AOI<90 (:issue:`1342`, :pull:`2347`)
 
 Documentation

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -10,7 +10,8 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
-
+* :pyPfunc:`~pvlib.irradiance.gti_dirint` now raises an informative message
+  when input data don't include values with AOI<90 (:issue:`1342`, :pull:`2347`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -37,3 +38,4 @@ Contributors
 ~~~~~~~~~~~~
 * Rajiv Daxini (:ghuser:`RDaxini`)
 * Mark Campanelli (:ghuser:`markcampanelli`)
+* Cliff Hansen (:ghuser:`cwhanse`)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2368,6 +2368,9 @@ def gti_dirint(poa_global, aoi, solar_zenith, solar_azimuth, times,
            irradiance, Solar Energy 122, 1037-1046.
            :doi:`10.1016/j.solener.2015.10.024`
     """
+    # check input data and raise Exceptions where data will cause the
+    # algorithm to fail
+    _gti_dirint_check_input(aoi)
 
     aoi_lt_90 = aoi < 90
 
@@ -2397,6 +2400,17 @@ def gti_dirint(poa_global, aoi, solar_zenith, solar_azimuth, times,
     output = pd.DataFrame(output, index=times)
 
     return output
+
+
+def _gti_dirint_check_input(aoi):
+    r"""
+    Helper for gti_dirint
+
+    Raises Exceptions from input data that cause the algorithm to fail.
+    """
+    if (aoi >= 90).all():
+        raise ValueError("AOI >= 90 for all input data to gti_dirint. "
+                         "gti_dirint requires some data with AOI < 90.")
 
 
 def _gti_dirint_lt_90(poa_global, aoi, aoi_lt_90, solar_zenith, solar_azimuth,

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2408,7 +2408,7 @@ def _gti_dirint_check_input(aoi):
 
     Raises Exceptions from input data that cause the algorithm to fail.
     """
-    if (aoi >= 90).all():
+    if not (aoi < 90).any():
         raise ValueError("AOI >= 90 for all input data to gti_dirint. "
                          "gti_dirint requires some data with AOI < 90.")
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2409,7 +2409,7 @@ def _gti_dirint_check_input(aoi):
     Raises Exceptions from input data that cause the algorithm to fail.
     """
     if not (aoi < 90).any():
-        raise ValueError("AOI >= 90 for all input data to gti_dirint. "
+        raise ValueError("There are no times with AOI < 90. "
                          "gti_dirint requires some data with AOI < 90.")
 
 

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -939,11 +939,10 @@ def test_gti_dirint_data_error():
 
     aoi = np.array([100, 170, 110])
     with pytest.raises(
-        ValueError, match="AOI >= 90 for all input data to gti_dirint"
-        ):
-        irradiance.gti_dirint(
-            poa_global, aoi, zenith, azimuth, times, surface_tilt,
-            surface_azimuth)
+        ValueError, match="AOI >= 90 for all input data to gti_dirint"):
+            irradiance.gti_dirint(
+                poa_global, aoi, zenith, azimuth, times, surface_tilt,
+                surface_azimuth)
 
 
 def test_erbs():

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -939,13 +939,13 @@ def test_gti_dirint_data_error():
 
     aoi = np.array([100, 170, 110])
     with pytest.raises(
-            ValueError, match="AOI >= 90 for all input data to gti_dirint"
-            ):
+        ValueError, match="AOI >= 90 for all input data to gti_dirint"
+        ):
         irradiance.gti_dirint(
             poa_global, aoi, zenith, azimuth, times, surface_tilt,
             surface_azimuth)
-    
-    
+
+
 def test_erbs():
     index = pd.DatetimeIndex(['20190101']*3 + ['20190620'])
     ghi = pd.Series([0, 50, 1000, 1000], index=index)

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -939,7 +939,7 @@ def test_gti_dirint_data_error():
 
     aoi = np.array([100, 170, 110])
     with pytest.raises(
-            ValueError, match="AOI >= 90 for all input data to gti_dirint"):
+            ValueError, match="There are no times with AOI < 90"):
         irradiance.gti_dirint(
             poa_global, aoi, zenith, azimuth, times, surface_tilt,
             surface_azimuth)

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -939,10 +939,10 @@ def test_gti_dirint_data_error():
 
     aoi = np.array([100, 170, 110])
     with pytest.raises(
-        ValueError, match="AOI >= 90 for all input data to gti_dirint"):
-            irradiance.gti_dirint(
-                poa_global, aoi, zenith, azimuth, times, surface_tilt,
-                surface_azimuth)
+            ValueError, match="AOI >= 90 for all input data to gti_dirint"):
+        irradiance.gti_dirint(
+            poa_global, aoi, zenith, azimuth, times, surface_tilt,
+            surface_azimuth)
 
 
 def test_erbs():

--- a/pvlib/tests/test_irradiance.py
+++ b/pvlib/tests/test_irradiance.py
@@ -928,6 +928,24 @@ def test_gti_dirint():
     assert_frame_equal(output, expected)
 
 
+def test_gti_dirint_data_error():
+    times = pd.DatetimeIndex(
+        ['2014-06-24T06-0700', '2014-06-24T09-0700', '2014-06-24T12-0700'])
+    poa_global = np.array([20, 300, 1000])
+    zenith = np.array([80, 45, 20])
+    azimuth = np.array([90, 135, 180])
+    surface_tilt = 30
+    surface_azimuth = 180
+
+    aoi = np.array([100, 170, 110])
+    with pytest.raises(
+            ValueError, match="AOI >= 90 for all input data to gti_dirint"
+            ):
+        irradiance.gti_dirint(
+            poa_global, aoi, zenith, azimuth, times, surface_tilt,
+            surface_azimuth)
+    
+    
 def test_erbs():
     index = pd.DatetimeIndex(['20190101']*3 + ['20190620'])
     ghi = pd.Series([0, 50, 1000, 1000], index=index)


### PR DESCRIPTION
 - [x] Closes #1342
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~~[] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

`gti_dirint` could fail for a number of not-well-defined conditions. One known condition is reported in #1342, where all inputs have AOI >= 90. 

I could not determine exactly how much data is "required" by `gti_dirint`. For instance, if there are insufficient daily data with 60 < AOI < 85 (see [these lines](https://github.com/pvlib/pvlib-python/blob/9fb2eb3aa7984c6283252e53e3052fe2c2cee90e/pvlib/irradiance.py#L2577-2595)), the function will proceed with `kt_prime_gte_90= np.nan` and will basically assume that the day is entirely clear at [this line](https://github.com/pvlib/pvlib-python/blob/9fb2eb3aa7984c6283252e53e3052fe2c2cee90e/pvlib/irradiance.py#L1897). I can't say that's a failure of the code, but I'm skeptical that `gti_dirint` will return anything meaningful. I don't know if we want to check, or what exception or warning to raise.

In any case, the check added in this PR closes the issue reported in #1342, and sets up `gti_dirint` to have additional checks added, should that be desired.