### PR TITLE
Add configuration key to readthedocs.yml

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -22,9 +22,12 @@ Testing
 
 Requirements
 ~~~~~~~~~~~~
+* Add sphinx configuration key to `readthedocs.yml` (:issue:`2357`,
+:pull:`2358`)
 
 
 Contributors
 ~~~~~~~~~~~~
+* Rajiv Daxini (:ghuser:`RDaxini`)
 
 

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -35,6 +35,4 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 * Rajiv Daxini (:ghuser:`RDaxini`)
-
-
 * Mark Campanelli (:ghuser:`markcampanelli`)

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -29,7 +29,7 @@ Maintenance
 * Fix ReadTheDocs builds by upgrading `readthedocs.yml` configuration
 (:issue:`2357`, :pull:`2358`)
 * asv 0.4.2 upgraded to asv 0.6.4 to fix CI failure due to pinned older conda.
-  (pull:`2352`)
+  (:pull:`2352`)
 
 
 Contributors

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -22,8 +22,12 @@ Testing
 
 Requirements
 ~~~~~~~~~~~~
-* Add sphinx configuration key to `readthedocs.yml` (:issue:`2357`,
-:pull:`2358`)
+
+
+Maintenance
+~~~~~~~~~~~
+* Fix ReadTheDocs builds by upgrading `readthedocs.yml` configuration
+(:issue:`2357`, :pull:`2358`)
 
 
 Contributors

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -27,7 +27,7 @@ Requirements
 Maintenance
 ~~~~~~~~~~~
 * Fix ReadTheDocs builds by upgrading `readthedocs.yml` configuration
-(:issue:`2357`, :pull:`2358`)
+  (:issue:`2357`, :pull:`2358`)
 * asv 0.4.2 upgraded to asv 0.6.4 to fix CI failure due to pinned older conda.
   (:pull:`2352`)
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+sphinx:
+    configuration: docs/sphinx/source/conf.py
+
 build:
    os: ubuntu-lts-latest
    tools:


### PR DESCRIPTION
 - [X] Closes #2357
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] ~Tests added~
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [X] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Not super familiar with build tools but wanted to give this a go... seemed straightforward.