### PR TITLE
Include solarfactors in python 3.12 tests

### DIFF
--- a/ci/requirements-py3.12.yml
+++ b/ci/requirements-py3.12.yml
@@ -25,4 +25,4 @@ dependencies:
     - statsmodels
     - pip:
         - nrel-pysam>=2.0
-        # - solarfactors  # required shapely<2 isn't available for 3.12
+        - solarfactors


### PR DESCRIPTION
With the new solarfactors v1.6.0 release (and the shapely 2.0 compatibility it brings), it can be successfully installed and used on python 3.12 and above.  That means we don't need to exclude it from the python 3.12 test environment anymore.