### PR TITLE
Replaced the explicit `readme.text` and `readme.content-type` fields with `readme="README.md"` in `pyproject.toml`.

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -32,6 +32,7 @@ Maintenance
   (:issue:`2357`, :pull:`2358`)
 * asv 0.4.2 upgraded to asv 0.6.4 to fix CI failure due to pinned older conda.
   (:pull:`2352`)
+* Replaced the explicit `readme.text` and `readme.content-type` fields with `readme="README.md"` in `pyproject.toml`. (:pull:`2389`)
 
 
 Contributors
@@ -40,3 +41,4 @@ Contributors
 * Mark Campanelli (:ghuser:`markcampanelli`)
 * Jason Lun Leung (:ghuser:`jason-rpkt`)
 * Manoj K S (:ghuser:`manojks1999`)
+* Aditi Juneja (:ghuser:`Schefflera-Arboricola`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,20 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Topic :: Scientific/Engineering',
 ]
-readme.text = """
-pvlib python is a community developed toolbox that provides a set of
-functions and classes for simulating the performance of photovoltaic
-energy systems and accomplishing related tasks.  The core mission of pvlib
-python is to provide open, reliable, interoperable, and benchmark
-implementations of PV system models.
-
-We need your help to make pvlib-python a great tool!
-
-Documentation: http://pvlib-python.readthedocs.io
-
-Source code: https://github.com/pvlib/pvlib-python
-"""
-readme.content-type = "text/x-rst"
+readme = "README.md"
 dynamic = ["version"]
 
 


### PR DESCRIPTION
Why made this change? 
- Ensures consistency—changes to `README.md` automatically reflect on PyPI without needing to update `pyproject.toml`.  
- Allows more project details to be displayed on PyPI.  
- Reduces maintenance overhead by avoiding redundant updates.  
- Makes the `pyproject.toml` less populated

Let me know if there's any concern about showing too much on PyPI. Happy to adjust if needed. 

Thank you :)

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
