### PR TITLE
 Clarify output variable mapping in calcparams_ functions

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -38,7 +38,8 @@ Documentation
 * Fix Procedural and Object Oriented simulation examples having slightly different results, in :ref:`introtutorial`. (:issue:`2366`, :pull:`2367`)
 * Restructure the user guide with subsections (:issue:`2302`, :pull:`2310`)
 * Add references for :py:func:`pvlib.snow.loss_townsend`. (:issue:`2383`, :pull:`2384`)
-* Add :term:`ghi_clear` to the :ref:`nomenclature` page (:issue:`2272`, :pull`2397`)
+* Add :term:`ghi_clear` to the :ref:`nomenclature` page (:issue:`2272`, :pull:`2397`)
+* Add output variable naming clarifaction to :py:func:`pvlib.pvsystem.calcparams_desoto` and :py:func:`pvlib.pvsystem.calcparams_pvsyst` (:issue:`716`, :pull:`2405`)
 
 Testing
 ~~~~~~~
@@ -78,3 +79,4 @@ Contributors
 * Kevin Anderson (:ghuser:`kandersolar`)
 * Echedey Luis (:ghuser:`echedey-ls`)
 * Mark Campanelli (:ghuser:`markcampanelli`)
+* Max Jackson (:ghuser:`MaxJackson`)

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1832,10 +1832,6 @@ def calcparams_cec(effective_irradiance, temp_cell,
     '''
 
     # pass adjusted temperature coefficient to desoto
-    # Returns the following: 
-    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
-    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
-    
     return calcparams_desoto(effective_irradiance, temp_cell,
                              alpha_sc*(1.0 - Adjust/100),
                              a_ref, I_L_ref, I_o_ref,

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1709,7 +1709,7 @@ def calcparams_desoto(effective_irradiance, temp_cell,
     Rs = R_s
 
     numeric_args = (effective_irradiance, temp_cell)
-    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
+    # IL: photocurrent, I0: saturation_current, Rs: resistance_series,
     # Rsh: resistance_shunt
     out = (IL, I0, Rs, Rsh, nNsVth)
 
@@ -1977,7 +1977,7 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
     Rs = R_s
 
     numeric_args = (effective_irradiance, temp_cell)
-    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
+    # IL: photocurrent, I0: saturation_current, Rs: resistance_series,
     # Rsh: resistance_shunt
     out = (IL, I0, Rs, Rsh, nNsVth)
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1978,7 +1978,7 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
 
     numeric_args = (effective_irradiance, temp_cell)
     # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
-    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
+    # Rsh: resistance_shunt
     out = (IL, I0, Rs, Rsh, nNsVth)
 
     if all(map(np.isscalar, numeric_args)):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1709,6 +1709,8 @@ def calcparams_desoto(effective_irradiance, temp_cell,
     Rs = R_s
 
     numeric_args = (effective_irradiance, temp_cell)
+    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
+    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
     out = (IL, I0, Rs, Rsh, nNsVth)
 
     if all(map(np.isscalar, numeric_args)):
@@ -1830,6 +1832,10 @@ def calcparams_cec(effective_irradiance, temp_cell,
     '''
 
     # pass adjusted temperature coefficient to desoto
+    # Returns the following: 
+    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
+    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
+    
     return calcparams_desoto(effective_irradiance, temp_cell,
                              alpha_sc*(1.0 - Adjust/100),
                              a_ref, I_L_ref, I_o_ref,
@@ -1975,6 +1981,8 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
     Rs = R_s
 
     numeric_args = (effective_irradiance, temp_cell)
+    # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
+    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
     out = (IL, I0, Rs, Rsh, nNsVth)
 
     if all(map(np.isscalar, numeric_args)):

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1710,7 +1710,7 @@ def calcparams_desoto(effective_irradiance, temp_cell,
 
     numeric_args = (effective_irradiance, temp_cell)
     # IL: photocurrent, I0: saturation_current, Rs: resistance_series, 
-    # Rsh: resistance_shunt, nNsVth: product of thermal voltage, diode ideality factor and cells in series
+    # Rsh: resistance_shunt
     out = (IL, I0, Rs, Rsh, nNsVth)
 
     if all(map(np.isscalar, numeric_args)):


### PR DESCRIPTION

 - [x] Closes #[716](https://github.com/pvlib/pvlib-python/issues/716)
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The functions `pvsystem.calcparams_desoto`, `pvsystem.calcparams_cec` and `pvsystem.calcparams_pvsyst` return variables which are named/labeled differently than the variables in the functions themselves. This PR adds inline comments where the return variables are initialized to help clarify exactly what calculated values are being returned.