### PR TITLE
Remove deprecated `spectrum.get_am15g` function

### DIFF
--- a/docs/sphinx/source/reference/effects_on_pv_system_output/spectrum.rst
+++ b/docs/sphinx/source/reference/effects_on_pv_system_output/spectrum.rst
@@ -8,7 +8,6 @@ Spectrum
 
    spectrum.spectrl2
    spectrum.get_example_spectral_response
-   spectrum.get_am15g
    spectrum.get_reference_spectra
    spectrum.calc_spectral_mismatch_field
    spectrum.spectral_factor_caballero

--- a/docs/sphinx/source/whatsnew/v0.11.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.0.rst
@@ -28,7 +28,7 @@ Deprecations
 ~~~~~~~~~~~~
 * The ``pvlib.irradiance.SURFACE_ALBEDOS`` dictionary has been moved to
   :py:const:`pvlib.albedo.SURFACE_ALBEDOS`. (:pull:`2095`)
-* Function :py:func:`pvlib.spectrum.get_am15g` has been deprecated in favor
+* Function :py:func:`!pvlib.spectrum.get_am15g` has been deprecated in favor
   of the new function :py:func:`pvlib.spectrum.get_reference_spectra`. Use
   ``pvlib.spectrum.get_reference_spectra(standard="ASTM G173-03")["global"]``
   instead. (:pull:`2039`)

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -12,6 +12,8 @@ Breaking Changes
 * Users must now provide ModelChain.spectral_model, or the 'no_loss' spectral
   model is assumed. pvlib.modelchain.ModelChain no longer attempts to infer
   the spectral model from PVSystem attributes. (:issue:`2017`, :pull:`2253`)
+* Remove deprecated :py:func:`!pvlib.spectrum.get_am15g` function; use
+  :py:func:`~pvlib.spectrum.get_reference_spectra` instead.  (:pull:`2409`)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -14,7 +14,7 @@ Enhancements
   (:issue:`1516`, :pull:`1518`)
 * New module to calculate spectral mismatch from field spectral measurements
   :py:func:`~pvlib.spectrum.get_example_spectral_response`
-  :py:func:`~pvlib.spectrum.get_am15g`
+  :py:func:`!~pvlib.spectrum.get_am15g`
   :py:func:`~pvlib.spectrum.calc_spectral_mismatch_field`
   (:issue:`1523`, :pull:`1524`)
 * Added Townsend-Powers monthly snow loss model:

--- a/docs/sphinx/source/whatsnew/v0.9.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.9.3.rst
@@ -14,7 +14,7 @@ Enhancements
   (:issue:`1516`, :pull:`1518`)
 * New module to calculate spectral mismatch from field spectral measurements
   :py:func:`~pvlib.spectrum.get_example_spectral_response`
-  :py:func:`!~pvlib.spectrum.get_am15g`
+  :py:func:`!pvlib.spectrum.get_am15g`
   :py:func:`~pvlib.spectrum.calc_spectral_mismatch_field`
   (:issue:`1523`, :pull:`1524`)
 * Added Townsend-Powers monthly snow loss model:

--- a/pvlib/spectrum/__init__.py
+++ b/pvlib/spectrum/__init__.py
@@ -8,7 +8,6 @@ from pvlib.spectrum.mismatch import (  # noqa: F401
     spectral_factor_jrc,
 )
 from pvlib.spectrum.irradiance import (  # noqa: F401
-    get_am15g,
     get_reference_spectra,
     average_photon_energy,
 )

--- a/pvlib/spectrum/irradiance.py
+++ b/pvlib/spectrum/irradiance.py
@@ -4,75 +4,12 @@ calculations related to spectral irradiance data.
 """
 
 import pvlib
-from pvlib._deprecation import deprecated
 import numpy as np
 import pandas as pd
 from pathlib import Path
 from functools import partial
 from scipy import constants
 from scipy.integrate import trapezoid
-
-
-@deprecated(
-    since="0.11",
-    removal="0.12",
-    name="pvlib.spectrum.get_am15g",
-    alternative="pvlib.spectrum.get_reference_spectra",
-    addendum=(
-        "The new function reads more data. Use it with "
-        + "standard='ASTM G173-03' and extract the 'global' column."
-    ),
-)
-def get_am15g(wavelength=None):
-    r"""
-    Read the ASTM G173-03 AM1.5 global spectrum on a 37-degree tilted surface,
-    optionally interpolated to the specified wavelength(s).
-
-    Global (tilted) irradiance includes direct and diffuse irradiance from sky
-    and ground reflections, and is more formally called hemispherical
-    irradiance (on a tilted surface).  In the context of photovoltaic systems
-    the irradiance on a flat receiver is frequently called plane-of-array (POA)
-    irradiance.
-
-    Parameters
-    ----------
-    wavelength: 1-D sequence of numeric, optional
-        Wavelengths at which the spectrum is interpolated.
-        By default the 2002 wavelengths of the standard are returned. [nm].
-
-    Returns
-    -------
-    am15g: pandas.Series
-        The AM1.5g standard spectrum indexed by ``wavelength``. [W/(m²nm)].
-
-    Notes
-    -----
-    If ``wavelength`` is specified this function uses linear interpolation.
-
-    If the values in ``wavelength`` are too widely spaced, the integral of the
-    spectrum may deviate from the standard value of 1000.37 W/m².
-
-    The values in the data file provided with pvlib-python are copied from an
-    Excel file distributed by NREL, which is found here:
-    https://www.nrel.gov/grid/solar-resource/assets/data/astmg173.xls
-
-    More information about reference spectra is found here:
-    https://www.nrel.gov/grid/solar-resource/spectra-am1.5.html
-
-    See Also
-    --------
-    pvlib.spectrum.get_reference_spectra : reads also the direct and
-      extraterrestrial components of the spectrum.
-
-    References
-    ----------
-    .. [1] ASTM "G173-03 Standard Tables for Reference Solar Spectral
-       Irradiances: Direct Normal and Hemispherical on 37° Tilted Surface."
-    """  # noqa: E501
-    # Contributed by Anton Driesse (@adriesse), PV Performance Labs. Aug. 2022
-    # modified by @echedey-ls, as a wrapper of spectrum.get_reference_spectra
-    standard = get_reference_spectra(wavelength, standard="ASTM G173-03")
-    return standard["global"]
 
 
 def get_reference_spectra(wavelengths=None, standard="ASTM G173-03"):

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -3,17 +3,14 @@ from numpy.testing import assert_allclose, assert_approx_equal, assert_equal
 import pandas as pd
 import numpy as np
 from pvlib import spectrum
-from pvlib._deprecation import pvlibDeprecationWarning
 
 from tests.conftest import assert_series_equal, fail_on_pvlib_version
 
 
 @fail_on_pvlib_version('0.12')
-def test_get_am15g():
+def test_get_reference_spectra_am15g():
     # test that the reference spectrum is read and interpolated correctly
-    with pytest.warns(pvlibDeprecationWarning,
-                      match="get_reference_spectra instead"):
-        e = spectrum.get_am15g()
+    e = spectrum.get_reference_spectra()['global']
     assert_equal(len(e), 2002)
     assert_equal(np.sum(e.index), 2761442)
     assert_approx_equal(np.sum(e), 1002.88, significant=6)
@@ -21,9 +18,7 @@ def test_get_am15g():
     wavelength = [270, 850, 950, 1200, 1201.25, 4001]
     expected = [0.0, 0.893720, 0.147260, 0.448250, 0.4371025, 0.0]
 
-    with pytest.warns(pvlibDeprecationWarning,
-                      match="get_reference_spectra instead"):
-        e = spectrum.get_am15g(wavelength)
+    e = spectrum.get_reference_spectra(wavelength)['global']
     assert_equal(len(e), len(wavelength))
     assert_allclose(e, expected, rtol=1e-6)
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR removes the `get_am15g` function, which was deprecated in v0.11.0 when we added the more general `get_reference_spectra` function.