### PR TITLE
Change default method in Location.get_sun_rise_set_transit

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -20,6 +20,8 @@ Breaking Changes
   Use :py:func:`~pvlib.spectrum.spectral_factor_firstsolar` instead. (:issue:`2130`, :pull:`2131`)
 * Remove deprecated :py:func:`!pvlib.spectrum.get_am15g` function; use
   :py:func:`~pvlib.spectrum.get_reference_spectra` instead.  (:pull:`2409`)
+* Change default method of :py:func:`~pvlib.location.Location.get_sun_rise_set_transit`
+  to 'spa' instead of 'pyephem'.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.11.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.11.3.rst
@@ -21,7 +21,7 @@ Breaking Changes
 * Remove deprecated :py:func:`!pvlib.spectrum.get_am15g` function; use
   :py:func:`~pvlib.spectrum.get_reference_spectra` instead.  (:pull:`2409`)
 * Change default method of :py:func:`~pvlib.location.Location.get_sun_rise_set_transit`
-  to 'spa' instead of 'pyephem'.
+  to ``'spa'`` instead of ``'pyephem'``. (:pull:`2410`)
 
 Bug fixes
 ~~~~~~~~~

--- a/pvlib/location.py
+++ b/pvlib/location.py
@@ -368,7 +368,7 @@ class Location:
 
         return airmass
 
-    def get_sun_rise_set_transit(self, times, method='pyephem', **kwargs):
+    def get_sun_rise_set_transit(self, times, method='spa', **kwargs):
         """
         Calculate sunrise, sunset and transit times.
 
@@ -376,7 +376,7 @@ class Location:
         ----------
         times : DatetimeIndex
             Must be localized to the Location
-        method : str, default 'pyephem'
+        method : str, default 'spa'
             'pyephem', 'spa', or 'geometric'
 
         kwargs :


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

I would like to suggest that we switch the default method of ``pvlib.location.Location.get_sun_rise_set_transit`` to ``spa`` instead of ``pyephem``.

The main reason is that I think it's annoying that we're defaulting to a method that requires the installation of an optional external package when we have functions within pvlib that can do this.

Also, as pointed out by @cwhanse in https://github.com/pvlib/pvlib-python/issues/1631#issuecomment-1375976914, the pyephem package is in maintenance-only mode, which is another reason not to rely to much on this.