### PR TITLE
Remove pvgis_tmy outputformat='basic'

### DIFF
--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -520,10 +520,12 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         with io.StringIO(res.content.decode('utf-8')) as src:
             data, meta = parse_epw(src)
             months_selected, inputs = None, None
+    # raise exception if pvgis format isn't in ['csv', 'json', 'epw']
     else:
-        # this line is never reached because if outputformat is not valid then
-        # the response is HTTP/1.1 400 BAD REQUEST which is handled earlier
-        pass
+        err_msg = (
+            "pvgis format '{:s}' was unknown, must be either 'json', 'csv', or 'epw'.")\
+            .format(outputformat)
+        raise ValueError(err_msg)
 
     if map_variables:
         data = data.rename(columns=VARIABLE_MAP)


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

PVGIS offers multiple output formats. For hourly data the file formats ['csv', 'json', 'basic'] are available, whereas for TMY data file format of ['csv', 'json', 'epw', 'basic'] are available.

I suggest that we drop support for the ``'basic'`` output format as there is no point to it; the file type is the same as the csv option but without any header or metadata. For this reason, the file option is also not available on the pvgis web interface and is already not supported by pvlib's pvgis_hourly functions.

The motivation is to reduce the maintenance burden, as dropping support for this file format reduces the code complexity significantly without any drawbacks for users. I'm currently planning more changes to the pvgis functions, but would like this change to be merged first. The planned changes mostly involve changing the outputs to be (data,meta) to be consistent with the rest of the iotools.