### PR TITLE
Add example whatsnew file

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.X.Y-example.rst
+++ b/docs/sphinx/source/whatsnew/v0.X.Y-example.rst
@@ -1,0 +1,45 @@
+.. _whatsnew_0XXYY:
+
+
+v0.X.Y (Month XX, 20YY)
+-----------------------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Benchmarking
+~~~~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Maintenance
+~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+


### PR DESCRIPTION
Part of pvlib's [release procedures](https://github.com/pvlib/pvlib-python/wiki/Release-procedures) is to add a new empty Whatsnew file after the release of a new version.

I believe the current practice is to take the previous whatsnew file and delete the content. This is tedious. More of a problem is that not all releases include all types of contributions and thus the added whatsnew file is often missing sections. While, these sections typically get added, they tend to get added in a random order (maybe not a big deal).

In any case, to make the release procedure smoother I suggest having a Whatsnew template that we use as the bases for the new  Whatsnew file that is added after a release. The example Whatsnew file has all possible sections (at least the ones we've used historically). Please comment if you think more should be added, if some are obsolete, or if you think that they should be ordered differently.