### PR TITLE
Document and test `np.nan` handling in `spectrum.average_photon_energy`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -19,6 +19,8 @@ Enhancements
 Documentation
 ~~~~~~~~~~~~~
 * Add a supporting reference to :py:func:`pvlib.atmosphere.get_relative_airmass` (:issue:`2390`, :pull:`2424`)
+* Documented how `np.nan` values are handled by :py:func:`~pvlib.spectrum.average_photon_energy`
+  (:issue:`2423`, :pull:`2426`)
 
 Testing
 ~~~~~~~
@@ -31,3 +33,4 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 * Cliff Hansen (:ghuser:`cwhanse`)
+* Rajiv Daxini (:ghuser:`RDaxini`)

--- a/pvlib/spectrum/irradiance.py
+++ b/pvlib/spectrum/irradiance.py
@@ -138,7 +138,7 @@ def average_photon_energy(spectra):
     ape : numeric or pandas.Series
         Average Photon Energy [eV].
         Note: returns ``np.nan`` in the case of all-zero spectral irradiance
-        input, or where one or more spectral irradiance values equal
+        input, or where one or more spectral irradiance values is
         ``np.nan``.
 
     Notes

--- a/pvlib/spectrum/irradiance.py
+++ b/pvlib/spectrum/irradiance.py
@@ -138,7 +138,8 @@ def average_photon_energy(spectra):
     ape : numeric or pandas.Series
         Average Photon Energy [eV].
         Note: returns ``np.nan`` in the case of all-zero spectral irradiance
-        input.
+        input, or where one or more spectral irradiance values equal
+        ``np.nan``.
 
     Notes
     -----

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -136,20 +136,19 @@ def test_average_photon_energy_nan_irr():
     # test for handling NaN input
 
     spectra_df_nan = spectrum.get_reference_spectra().T
-    spectra_df_singlenan = spectra_df_nan.copy()
-    spectra_df_singlenan.loc["global", 315.0] = np.nan
-    spectra_df_allnan = spectra_df_nan * np.nan
+    spectra_df_nan.loc["global", 315.0] = np.nan
+    spectra_df_nan.loc['extraterrestrial', :] = np.nan
 
     spectra_series_nan = spectrum.get_reference_spectra()['global']
     spectra_series_singlenan = spectra_series_nan.copy()
     spectra_series_singlenan.loc[315.0] = np.nan
     spectra_series_allnan = spectra_series_nan*np.nan
 
-    output = [
-        spectrum.average_photon_energy(spectra_df_singlenan),
-        spectrum.average_photon_energy(spectra_df_allnan),
-        spectrum.average_photon_energy(spectra_series_singlenan),
-        spectrum.average_photon_energy(spectra_series_allnan)
-    ]
+    out1 = spectrum.average_photon_energy(spectra_df_nan)
+    out2 = spectrum.average_photon_energy(spectra_series_singlenan)
+    out3 = spectrum.average_photon_energy(spectra_series_allnan)
 
-    assert (all(np.isnan(out)) for out in output)
+    assert np.all(np.isnan(out1['global']))
+    assert np.all(np.isnan(out1['extraterrestrial']))
+    assert np.all(np.isnan(out2))
+    assert np.all(np.isnan(out3))

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -130,3 +130,25 @@ def test_average_photon_energy_zero_irr():
     expected_2 = np.nan
     assert_allclose(out_1, expected_1, atol=1e-3)
     assert_allclose(out_2, expected_2, atol=1e-3)
+
+def test_average_photon_energy_nan_irr():
+    # test for handling NaN input
+
+    spectra_df_nan = spectrum.get_reference_spectra().T
+    spectra_df_singlenan = spectra_df_nan.copy()
+    spectra_df_singlenan.loc["global", 315.0] = np.nan
+    spectra_df_allnan = spectra_df_nan * np.nan
+
+    spectra_series_nan = spectrum.get_reference_spectra()['global']
+    spectra_series_singlenan = spectra_series_nan.copy()
+    spectra_series_singlenan.loc[315.0] = np.nan
+    spectra_series_allnan = spectra_series_nan*np.nan
+    
+    out = [
+        spectrum.average_photon_energy(spectra_df_singlenan),
+        spectrum.average_photon_energy(spectra_df_allnan),
+        spectrum.average_photon_energy(spectra_series_singlenan),
+        spectrum.average_photon_energy(spectra_series_allnan)
+    ]
+
+    assert all(np.isnan(out))

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -143,7 +143,7 @@ def test_average_photon_energy_nan_irr():
     spectra_series_singlenan = spectra_series_nan.copy()
     spectra_series_singlenan.loc[315.0] = np.nan
     spectra_series_allnan = spectra_series_nan*np.nan
-    
+
     out = [
         spectrum.average_photon_energy(spectra_df_singlenan),
         spectrum.average_photon_energy(spectra_df_allnan),

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -131,6 +131,7 @@ def test_average_photon_energy_zero_irr():
     assert_allclose(out_1, expected_1, atol=1e-3)
     assert_allclose(out_2, expected_2, atol=1e-3)
 
+
 def test_average_photon_energy_nan_irr():
     # test for handling NaN input
 
@@ -144,11 +145,11 @@ def test_average_photon_energy_nan_irr():
     spectra_series_singlenan.loc[315.0] = np.nan
     spectra_series_allnan = spectra_series_nan*np.nan
 
-    out = [
+    output = [
         spectrum.average_photon_energy(spectra_df_singlenan),
         spectrum.average_photon_energy(spectra_df_allnan),
         spectrum.average_photon_energy(spectra_series_singlenan),
         spectrum.average_photon_energy(spectra_series_allnan)
     ]
 
-    assert all(np.isnan(out))
+    assert (all(np.isnan(out)) for out in output)

--- a/tests/spectrum/test_irradiance.py
+++ b/tests/spectrum/test_irradiance.py
@@ -148,7 +148,6 @@ def test_average_photon_energy_nan_irr():
     out2 = spectrum.average_photon_energy(spectra_series_singlenan)
     out3 = spectrum.average_photon_energy(spectra_series_allnan)
 
-    assert np.all(np.isnan(out1['global']))
-    assert np.all(np.isnan(out1['extraterrestrial']))
+    assert np.all(np.isnan(out1[['global', 'extraterrestrial']]))
     assert np.all(np.isnan(out2))
     assert np.all(np.isnan(out3))


### PR DESCRIPTION
 - [X] Closes #2423
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [X] Tests added
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [X] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.