### PR TITLE
Extract private functions for each PVsyst SDM auxiliary equation in `calcparams_pvsyst`

### DIFF
--- a/pvlib/ivtools/sdm/_fit_desoto_pvsyst_sandia.py
+++ b/pvlib/ivtools/sdm/_fit_desoto_pvsyst_sandia.py
@@ -9,6 +9,7 @@ from scipy.special import lambertw
 
 from pvlib.pvsystem import singlediode, v_from_i
 from pvlib.ivtools.utils import rectify_iv_curve, _numdiff
+from pvlib.pvsystem import _pvsyst_rsh
 
 
 def _initial_iv_params(ivcurves, ee, voc, isc, rsh, nnsvth):
@@ -167,7 +168,9 @@ def _extract_sdm_params(ee, tc, iph, io, rs, rsh, n, u, specs, const,
         # Find parameters for Rsh equation
 
         def fun_rsh(x, rshexp, ee, e0, rsh):
-            tf = np.log10(_rsh_pvsyst(x, R_sh_exp, ee, e0)) - np.log10(rsh)
+            tf = np.log10(
+                _pvsyst_rsh(ee, x[1], x[0], R_sh_exp, e0) - np.log10(rsh)
+            )
             return tf
 
         x0 = np.array([grsh0, grshref])
@@ -291,20 +294,6 @@ def _update_io(voc, iph, io, rs, rsh, nnsvth):
         k += 1.
 
     return new_io
-
-
-def _rsh_pvsyst(x, rshexp, g, go):
-    # computes rsh for PVsyst model where the parameters are in vector xL
-    # x[0] = Rsh0
-    # x[1] = Rshref
-
-    rsho = x[0]
-    rshref = x[1]
-
-    rshb = np.maximum(
-        (rshref - rsho * np.exp(-rshexp)) / (1. - np.exp(-rshexp)), 0.)
-    rsh = rshb + (rsho - rshb) * np.exp(-rshexp * g / go)
-    return rsh
 
 
 def _filter_params(ee, isc, io, rs, rsh):

--- a/pvlib/ivtools/sdm/_fit_desoto_pvsyst_sandia.py
+++ b/pvlib/ivtools/sdm/_fit_desoto_pvsyst_sandia.py
@@ -9,7 +9,7 @@ from scipy.special import lambertw
 
 from pvlib.pvsystem import singlediode, v_from_i
 from pvlib.ivtools.utils import rectify_iv_curve, _numdiff
-from pvlib.pvsystem import _pvsyst_rsh
+from pvlib.pvsystem import _pvsyst_Rsh
 
 
 def _initial_iv_params(ivcurves, ee, voc, isc, rsh, nnsvth):
@@ -168,8 +168,9 @@ def _extract_sdm_params(ee, tc, iph, io, rs, rsh, n, u, specs, const,
         # Find parameters for Rsh equation
 
         def fun_rsh(x, rshexp, ee, e0, rsh):
-            tf = np.log10(
-                _pvsyst_rsh(ee, x[1], x[0], R_sh_exp, e0) - np.log10(rsh)
+            tf = (
+                np.log10(_pvsyst_Rsh(ee, x[1], x[0], R_sh_exp, e0))
+                - np.log10(rsh)
             )
             return tf
 

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -1948,31 +1948,17 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
 
     '''
 
-    # Boltzmann constant in J/K
-    k = constants.k
+    gamma = _pvsyst_gamma(temp_cell, gamma_ref, mu_gamma, temp_ref)
 
-    # elementary charge in coulomb
-    q = constants.e
+    nNsVth = _pvsyst_nNsVth(temp_cell, gamma, cells_in_series)
 
-    # reference temperature
-    Tref_K = temp_ref + 273.15
-    Tcell_K = temp_cell + 273.15
+    IL = _pvsyst_IL(effective_irradiance, temp_cell, I_L_ref, alpha_sc,
+                    irrad_ref, temp_ref)
 
-    gamma = gamma_ref + mu_gamma * (Tcell_K - Tref_K)
-    nNsVth = gamma * k / q * cells_in_series * Tcell_K
+    I0 = _pvsyst_Io(temp_cell, gamma, I_o_ref, EgRef, temp_ref)
 
-    IL = effective_irradiance / irrad_ref * \
-        (I_L_ref + alpha_sc * (Tcell_K - Tref_K))
-
-    I0 = I_o_ref * ((Tcell_K / Tref_K) ** 3) * \
-        (np.exp((q * EgRef) / (k * gamma) * (1 / Tref_K - 1 / Tcell_K)))
-
-    Rsh_tmp = \
-        (R_sh_ref - R_sh_0 * np.exp(-R_sh_exp)) / (1.0 - np.exp(-R_sh_exp))
-    Rsh_base = np.maximum(0.0, Rsh_tmp)
-
-    Rsh = Rsh_base + (R_sh_0 - Rsh_base) * \
-        np.exp(-R_sh_exp * effective_irradiance / irrad_ref)
+    Rsh = _pvsyst_Rsh(effective_irradiance, R_sh_ref, R_sh_0, R_sh_exp,
+                      irrad_ref)
 
     Rs = R_s
 
@@ -1990,6 +1976,54 @@ def calcparams_pvsyst(effective_irradiance, temp_cell,
         return np.broadcast_arrays(*out)
 
     return tuple(pd.Series(a, index=index).rename(None) for a in out)
+
+
+def _pvsyst_Rsh(effective_irradiance, R_sh_ref, R_sh_0, R_sh_exp=5.5,
+                irrad_ref=1000):
+    Rsh_tmp = \
+        (R_sh_ref - R_sh_0 * np.exp(-R_sh_exp)) / (1.0 - np.exp(-R_sh_exp))
+    Rsh_base = np.maximum(0.0, Rsh_tmp)
+
+    Rsh = Rsh_base + (R_sh_0 - Rsh_base) * \
+        np.exp(-R_sh_exp * effective_irradiance / irrad_ref)
+
+    return Rsh
+
+
+def _pvsyst_IL(effective_irradiance, temp_cell, I_L_ref, alpha_sc,
+               irrad_ref=1000, temp_ref=25):
+    Tref_K = temp_ref + 273.15
+    Tcell_K = temp_cell + 273.15
+    IL = effective_irradiance / irrad_ref * \
+        (I_L_ref + alpha_sc * (Tcell_K - Tref_K))
+    return IL
+
+
+def _pvsyst_Io(temp_cell, gamma, I_o_ref, EgRef, temp_ref=25):
+    k = constants.k  # Boltzmann constant in J/K
+    q = constants.e  # elementary charge in coulomb
+
+    Tref_K = temp_ref + 273.15
+    Tcell_K = temp_cell + 273.15
+
+    Io = I_o_ref * ((Tcell_K / Tref_K) ** 3) * \
+        (np.exp((q * EgRef) / (k * gamma) * (1 / Tref_K - 1 / Tcell_K)))
+
+    return Io
+
+
+def _pvsyst_gamma(temp_cell, gamma_ref, mu_gamma, temp_ref=25):
+    gamma = gamma_ref + mu_gamma * (temp_cell - temp_ref)
+    return gamma
+
+
+def _pvsyst_nNsVth(temp_cell, gamma, cells_in_series):
+    k = constants.k  # Boltzmann constant in J/K
+    q = constants.e  # elementary charge in coulomb
+    Tcell_K = temp_cell + 273.15
+
+    nNsVth = gamma * k / q * cells_in_series * Tcell_K
+    return nNsVth
 
 
 def retrieve_sam(name=None, path=None):


### PR DESCRIPTION
 - [x] Closes #1094
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR extracts each of the "auxiliary equations" from `calcparams_pvsyst` into reusable private functions.  This has been previously suggested for the shunt resistance equation (https://github.com/pvlib/pvlib-python/issues/1094#issuecomment-731838015), and all of them will be used in the upcoming implementation of #2185.