### PR TITLE
Add function for estimating PVsyst SDM parameters from IEC 61853-1 data

### DIFF
--- a/docs/sphinx/source/reference/pv_modeling/parameters.rst
+++ b/docs/sphinx/source/reference/pv_modeling/parameters.rst
@@ -12,7 +12,7 @@ Functions for fitting single diode models
     ivtools.sdm.fit_cec_sam
     ivtools.sdm.fit_desoto
     ivtools.sdm.fit_pvsyst_sandia
-    ivtools.sdm.fit_pvsyst_iec61853_sandia
+    ivtools.sdm.fit_pvsyst_iec61853_sandia_2025
     ivtools.sdm.fit_desoto_sandia
 
 Functions for fitting the single diode equation

--- a/docs/sphinx/source/reference/pv_modeling/parameters.rst
+++ b/docs/sphinx/source/reference/pv_modeling/parameters.rst
@@ -12,6 +12,7 @@ Functions for fitting single diode models
     ivtools.sdm.fit_cec_sam
     ivtools.sdm.fit_desoto
     ivtools.sdm.fit_pvsyst_sandia
+    ivtools.sdm.fit_pvsyst_iec61853_sandia
     ivtools.sdm.fit_desoto_sandia
 
 Functions for fitting the single diode equation

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -16,7 +16,7 @@ Enhancements
 ~~~~~~~~~~~~
 * :py:mod:`pvlib.ivtools.sdm` is now a subpackage. (:issue:`2252`, :pull:`2256`)
 * Add a function for estimating PVsyst SDM parameters from IEC 61853-1 matrix
-  data (:py:func:`~pvlib.ivtools.sdm.fit_pvsyst_iec61853_sandia`). (:issue:`2185`, :pull:`2429`)
+  data (:py:func:`~pvlib.ivtools.sdm.fit_pvsyst_iec61853_sandia_2025`). (:issue:`2185`, :pull:`2429`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -14,8 +14,9 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-* ``pvlib.ivtools.sdm`` is now a subpackage. (:issue:`2252`, :pull:`2256`)
-
+* :py:mod:`pvlib.ivtools.sdm` is now a subpackage. (:issue:`2252`, :pull:`2256`)
+* Add a function for estimating PVsyst SDM parameters from IEC 61853-1 matrix
+  data (:py:func:`~pvlib.ivtools.sdm.fit_pvsyst_iec61853_sandia`). (:issue:`2185`, :pull:`2429`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/ivtools/sdm/__init__.py
+++ b/pvlib/ivtools/sdm/__init__.py
@@ -15,6 +15,6 @@ from pvlib.ivtools.sdm.desoto import (  # noqa: F401
 
 from pvlib.ivtools.sdm.pvsyst import (  # noqa: F401
     fit_pvsyst_sandia,
-    fit_pvsyst_iec61853_sandia,
+    fit_pvsyst_iec61853_sandia_2025,
     pvsyst_temperature_coeff,
 )

--- a/pvlib/ivtools/sdm/__init__.py
+++ b/pvlib/ivtools/sdm/__init__.py
@@ -15,5 +15,6 @@ from pvlib.ivtools.sdm.desoto import (  # noqa: F401
 
 from pvlib.ivtools.sdm.pvsyst import (  # noqa: F401
     fit_pvsyst_sandia,
+    fit_pvsyst_iec61853_sandia,
     pvsyst_temperature_coeff,
 )

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -402,6 +402,9 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
 
     Notes
     -----
+    Input arrays of operating conditions and electrical measurements must be
+    1-D with equal lengths.
+    
     This method is non-iterative.  In some cases, it may be desirable to
     refine the estimated parameter values using a numerical optimizer like
     those provided in ``scipy.optimize``.

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -405,6 +405,10 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     Input arrays of operating conditions and electrical measurements must be
     1-D with equal lengths.
 
+    Values supplied for ``alpha_sc``, ``beta_mp``, and ``R_s`` must be
+    consistent with the matrix data, as these values are used when estimating
+    other model parameters.
+
     This method is non-iterative.  In some cases, it may be desirable to
     refine the estimated parameter values using a numerical optimizer such as
     the default method in ``scipy.optimize.minimize``.

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -406,8 +406,8 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     1-D with equal lengths.
 
     This method is non-iterative.  In some cases, it may be desirable to
-    refine the estimated parameter values using a numerical optimizer like
-    those provided in ``scipy.optimize``.
+    refine the estimated parameter values using a numerical optimizer such as
+    the default method in ``scipy.optimize.minimize``.
 
     References
     ----------

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -315,7 +315,9 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
                                cells_in_series, EgRef=1.121,
                                alpha_sc=None, beta_mp=None,
                                r_sh_coeff=0.12, R_s=None,
-                               min_Rsh_irradiance=None):
+                               min_Rsh_irradiance=None,
+                               irradiance_tolerance=20,
+                               temperature_tolerance=1):
     """
     Estimate parameters for the PVsyst module performance model using
     IEC 61853-1 matrix measurements.
@@ -357,6 +359,14 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
         Irradiance threshold below which values are excluded when estimating
         shunt resistance parameter values.  May be useful for modules
         with problematic low-light measurements. [W/m²]
+    irradiance_tolerance : float, default 20
+        Tolerance for irradiance variation around the STC value.
+        The default value corresponds to a +/- 2% interval around the STC
+        value of 1000 W/m². [W/m²]
+    temperature_tolerance : float, default 1
+        Tolerance for temperature variation around the STC value.
+        The default value corresponds to a +/- 1 degree interval around the STC
+        value of 25 degrees. [C]
 
     Returns
     -------
@@ -409,8 +419,10 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
     except ImportError:
         raise ImportError('fit_pvsyst_iec61853_sandia requires statsmodels')
 
-    is_g_stc = effective_irradiance == 1000
-    is_t_stc = temp_cell == 25
+    is_g_stc = np.isclose(effective_irradiance, 1000, rtol=0,
+                          atol=irradiance_tolerance)
+    is_t_stc = np.isclose(temp_cell, 25, rtol=0,
+                          atol=temperature_tolerance)
 
     if alpha_sc is None:
         i_sc_ref = float(i_sc[is_g_stc & is_t_stc])

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -314,7 +314,7 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
                                i_sc, v_oc, i_mp, v_mp,
                                cells_in_series, EgRef=1.121,
                                alpha_sc=None, beta_mp=None,
-                               r_sh_coeff=0.12, R_s=None,
+                               R_s=None, r_sh_coeff=0.12,
                                min_Rsh_irradiance=None,
                                irradiance_tolerance=20,
                                temperature_tolerance=1):
@@ -349,12 +349,12 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
         Temperature coefficient of maximum power voltage.  If not specified,
         it will be estimated using the ``v_mp`` values at irradiance of
         1000 W/m2. [1/K]
-    r_sh_coeff : float, default 0.12
-        Shunt resistance fitting coefficient.  The default value is taken
-        from [1]_.
     R_s : float, optional
         Series resistance value.  If not provided, a value will be estimated
         from the input measurements. [ohm]
+    r_sh_coeff : float, default 0.12
+        Shunt resistance fitting coefficient.  The default value is taken
+        from [1]_.
     min_Rsh_irradiance : float, optional
         Irradiance threshold below which values are excluded when estimating
         shunt resistance parameter values.  May be useful for modules

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -425,9 +425,9 @@ def fit_pvsyst_iec61853_sandia(effective_irradiance, temp_cell,
                           atol=temperature_tolerance)
 
     if alpha_sc is None:
-        i_sc_ref = float(i_sc[is_g_stc & is_t_stc])
         mu_i_sc = _fit_tempco_pvsyst_iec61853_sandia(i_sc[is_g_stc],
                                                      temp_cell[is_g_stc])
+        i_sc_ref = float(i_sc[is_g_stc & is_t_stc].item())
         alpha_sc = mu_i_sc * i_sc_ref
 
     if beta_mp is None:
@@ -553,7 +553,7 @@ def _fit_diode_ideality_factor_pvsyst_iec61853_sandia(
     y = v_mp + i_mp*R_s - v_oc
 
     results = sm.OLS(endog=y, exog=x).fit()
-    gamma_ref = results.params[0]
+    gamma_ref = results.params['x1']
     return gamma_ref, 0
 
 

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -404,7 +404,7 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     -----
     Input arrays of operating conditions and electrical measurements must be
     1-D with equal lengths.
-    
+
     This method is non-iterative.  In some cases, it may be desirable to
     refine the estimated parameter values using a numerical optimizer like
     those provided in ``scipy.optimize``.
@@ -435,8 +435,7 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     R_sh_ref, R_sh_0, R_sh_exp = \
         _fit_shunt_resistances_pvsyst_iec61853_sandia_2025(
             i_sc, i_mp, v_mp, effective_irradiance, temp_cell, beta_mp,
-            coeff=r_sh_coeff, min_irradiance=min_Rsh_irradiance
-    )
+            coeff=r_sh_coeff, min_irradiance=min_Rsh_irradiance)
 
     if R_s is None:
         R_s = _fit_series_resistance_pvsyst_iec61853_sandia_2025(v_oc, i_mp,
@@ -446,8 +445,7 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
         _fit_diode_ideality_factor_pvsyst_iec61853_sandia_2025(
             i_sc[is_t_stc], v_oc[is_t_stc], i_mp[is_t_stc], v_mp[is_t_stc],
             effective_irradiance[is_t_stc], temp_cell[is_t_stc],
-            R_sh_ref, R_sh_0, R_sh_exp, R_s, cells_in_series
-    )
+            R_sh_ref, R_sh_0, R_sh_exp, R_s, cells_in_series)
 
     I_o_ref = _fit_saturation_current_pvsyst_iec61853_sandia_2025(
         i_sc, v_oc, effective_irradiance, temp_cell, gamma_ref, mu_gamma,

--- a/tests/ivtools/sdm/test_pvsyst.py
+++ b/tests/ivtools/sdm/test_pvsyst.py
@@ -334,6 +334,6 @@ def test_fit_pvsyst_iec61853_sandia_tolerance(pvsyst_iec61853_table3,
     with pytest.raises(ValueError, match='Coefficient array is empty'):
         sdm.fit_pvsyst_iec61853_sandia(**inputs, irradiance_tolerance=0.1)
 
-    with pytest.raises(ValueError, match='can only convert an array of size 1'):
+    with pytest.raises(ValueError,
+                       match='can only convert an array of size 1'):
         sdm.fit_pvsyst_iec61853_sandia(**inputs, temperature_tolerance=0.1)
-    

--- a/tests/ivtools/sdm/test_pvsyst.py
+++ b/tests/ivtools/sdm/test_pvsyst.py
@@ -294,7 +294,7 @@ def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
                                                    r_sh_coeff=0.3)
     assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
                           atol=0, rtol=1e-3)
-    
+
     fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
                                                    R_s=0.5)
     assert not np.isclose(fitted_params['R_s'], expected['R_s'],

--- a/tests/ivtools/sdm/test_pvsyst.py
+++ b/tests/ivtools/sdm/test_pvsyst.py
@@ -7,6 +7,8 @@ from pvlib import pvsystem
 
 from tests.conftest import requires_statsmodels, TESTS_DATA_DIR
 
+import pytest
+
 
 def _read_iv_curves_for_test(datafile, npts):
     """ read constants and npts IV curves from datafile """
@@ -198,3 +200,107 @@ def test_pvsyst_temperature_coeff():
         params['I_L_ref'], params['I_o_ref'], params['R_sh_ref'],
         params['R_sh_0'], params['R_s'], params['cells_in_series'])
     assert_allclose(gamma_pdc, expected, rtol=0.0005)
+
+
+@pytest.fixture
+def pvsyst_iec61853_table3():
+    # test cases in Table 3 of https://doi.org/10.1109/JPHOTOV.2025.3554338
+    parameters = ['alpha_sc', 'I_L_ref', 'I_o_ref', 'gamma_ref', 'mu_gamma',
+                  'R_sh_ref', 'R_sh_0', 'R_sh_exp', 'R_s', 'cells_in_series',
+                  'EgRef']
+    high_current = {
+        'true': [1e-3, 10, 1e-11, 1.0, -1e-4, 300, 1500, 5.5, 0.2, 60, 1.121],
+        'estimated': [9.993e-4, 9.997, 1.408e-10, 1.109, -1.666e-5, 543.7,
+                      6130, 5.5, 0.176, 60, 1.121]
+    }
+    high_voltage = {
+        'true': [1e-3, 1.8, 1e-9, 1.5, 1e-4, 3000, 10000, 5.5, 5.0, 108, 1.4],
+        'estimated': [9.983e-4, 1.799, 1.225e-8, 1.706, 2.662e-4, 4288, 47560,
+                      5.5, 4.292, 108, 1.4],
+    }
+    for d in [high_current, high_voltage]:
+        for key in d:
+            d[key] = dict(zip(parameters, np.array(d[key])))
+
+    return {
+        'high current': high_current, 'high voltage': high_voltage
+    }
+
+
+@pytest.fixture
+def iec61853_conditions():
+    ee = np.array([100, 100, 200, 200, 400, 400, 400, 600, 600, 600, 600,
+                   800, 800, 800, 800, 1000, 1000, 1000, 1000, 1100, 1100,
+                   1100], dtype=np.float64)
+    tc = np.array([15, 25, 15, 25, 15, 25, 50, 15, 25, 50, 75,
+                   15, 25, 50, 75, 15, 25, 50, 75, 25, 50, 75],
+                  dtype=np.float64)
+    return ee, tc
+
+
+@requires_statsmodels
+def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
+                                    iec61853_conditions):
+    ee, tc = iec61853_conditions
+    for _, case in pvsyst_iec61853_table3.items():
+        true_params = case['true']
+        expected_params = case['estimated']
+
+        sde_params = pvsystem.calcparams_pvsyst(ee, tc, **true_params)
+        iv = pvsystem.singlediode(*sde_params)
+
+        fitted_params = sdm.fit_pvsyst_iec61853_sandia(
+            ee, tc, iv['i_sc'], iv['v_oc'], iv['i_mp'], iv['v_mp'],
+            true_params['cells_in_series'], EgRef=true_params['EgRef'],
+        )
+        for key in expected_params.keys():
+            assert np.isclose(fitted_params[key], expected_params[key],
+                              atol=0, rtol=1e-3)
+
+
+@requires_statsmodels
+def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
+                                             iec61853_conditions):
+    # verify that modifying each optional parameter results in different output
+    ee, tc = iec61853_conditions
+    case = pvsyst_iec61853_table3['high current']
+    true_params = case['true']
+    expected = case['estimated']
+    sde_params = pvsystem.calcparams_pvsyst(ee, tc, **true_params)
+    iv = pvsystem.singlediode(*sde_params)
+
+    main_inputs = dict(
+        effective_irradiance=ee, temp_cell=tc, i_sc=iv['i_sc'],
+        v_oc=iv['v_oc'], i_mp=iv['i_mp'], v_mp=iv['v_mp'],
+        cells_in_series=true_params['cells_in_series']
+    )
+
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   EgRef=1.0)
+    assert not np.isclose(fitted_params['I_o_ref'], expected['I_o_ref'],
+                          atol=0, rtol=1e-3)
+
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   alpha_sc=0.5e-3)
+    assert not np.isclose(fitted_params['alpha_sc'], expected['alpha_sc'],
+                          atol=0, rtol=1e-3)
+
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   beta_mp=-1e-4)
+    assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
+                          atol=0, rtol=1e-3)
+
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   r_sh_coeff=0.3)
+    assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
+                          atol=0, rtol=1e-3)
+    
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   R_s=0.5)
+    assert not np.isclose(fitted_params['R_s'], expected['R_s'],
+                          atol=0, rtol=1e-3)
+
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
+                                                   min_Rsh_irradiance=500)
+    assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
+                          atol=0, rtol=1e-3)

--- a/tests/ivtools/sdm/test_pvsyst.py
+++ b/tests/ivtools/sdm/test_pvsyst.py
@@ -238,7 +238,6 @@ def iec61853_conditions():
     return ee, tc
 
 
-@requires_statsmodels
 def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
                                     iec61853_conditions):
     ee, tc = iec61853_conditions
@@ -258,7 +257,6 @@ def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
                               atol=0, rtol=1e-3)
 
 
-@requires_statsmodels
 def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
                                              iec61853_conditions):
     # verify that modifying each optional parameter results in different output
@@ -306,7 +304,6 @@ def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
                           atol=0, rtol=1e-3)
 
 
-@requires_statsmodels
 def test_fit_pvsyst_iec61853_sandia_tolerance(pvsyst_iec61853_table3,
                                               iec61853_conditions):
     # verify that the *_tolerance parameters allow non-"perfect" irradiance

--- a/tests/ivtools/sdm/test_pvsyst.py
+++ b/tests/ivtools/sdm/test_pvsyst.py
@@ -238,8 +238,8 @@ def iec61853_conditions():
     return ee, tc
 
 
-def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
-                                    iec61853_conditions):
+def test_fit_pvsyst_iec61853_sandia_2025(pvsyst_iec61853_table3,
+                                         iec61853_conditions):
     ee, tc = iec61853_conditions
     for _, case in pvsyst_iec61853_table3.items():
         true_params = case['true']
@@ -248,7 +248,7 @@ def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
         sde_params = pvsystem.calcparams_pvsyst(ee, tc, **true_params)
         iv = pvsystem.singlediode(*sde_params)
 
-        fitted_params = sdm.fit_pvsyst_iec61853_sandia(
+        fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(
             ee, tc, iv['i_sc'], iv['v_oc'], iv['i_mp'], iv['v_mp'],
             true_params['cells_in_series'], EgRef=true_params['EgRef'],
         )
@@ -257,8 +257,8 @@ def test_fit_pvsyst_iec61853_sandia(pvsyst_iec61853_table3,
                               atol=0, rtol=1e-3)
 
 
-def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
-                                             iec61853_conditions):
+def test_fit_pvsyst_iec61853_sandia_2025_optional(pvsyst_iec61853_table3,
+                                                  iec61853_conditions):
     # verify that modifying each optional parameter results in different output
     ee, tc = iec61853_conditions
     case = pvsyst_iec61853_table3['high current']
@@ -273,39 +273,39 @@ def test_fit_pvsyst_iec61853_sandia_optional(pvsyst_iec61853_table3,
         cells_in_series=true_params['cells_in_series']
     )
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   EgRef=1.0)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        EgRef=1.0)
     assert not np.isclose(fitted_params['I_o_ref'], expected['I_o_ref'],
                           atol=0, rtol=1e-3)
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   alpha_sc=0.5e-3)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        alpha_sc=0.5e-3)
     assert not np.isclose(fitted_params['alpha_sc'], expected['alpha_sc'],
                           atol=0, rtol=1e-3)
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   beta_mp=-1e-4)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        beta_mp=-1e-4)
     assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
                           atol=0, rtol=1e-3)
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   r_sh_coeff=0.3)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        r_sh_coeff=0.3)
     assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
                           atol=0, rtol=1e-3)
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   R_s=0.5)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        R_s=0.5)
     assert not np.isclose(fitted_params['R_s'], expected['R_s'],
                           atol=0, rtol=1e-3)
 
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**main_inputs,
-                                                   min_Rsh_irradiance=500)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**main_inputs,
+                                                        min_Rsh_irradiance=500)
     assert not np.isclose(fitted_params['R_sh_ref'], expected['R_sh_ref'],
                           atol=0, rtol=1e-3)
 
 
-def test_fit_pvsyst_iec61853_sandia_tolerance(pvsyst_iec61853_table3,
-                                              iec61853_conditions):
+def test_fit_pvsyst_iec61853_sandia_2025_tolerance(pvsyst_iec61853_table3,
+                                                   iec61853_conditions):
     # verify that the *_tolerance parameters allow non-"perfect" irradiance
     # and temperature values
     ee, tc = iec61853_conditions
@@ -322,15 +322,16 @@ def test_fit_pvsyst_iec61853_sandia_tolerance(pvsyst_iec61853_table3,
         v_oc=iv['v_oc'], i_mp=iv['i_mp'], v_mp=iv['v_mp'],
         cells_in_series=true_params['cells_in_series']
     )
-    fitted_params = sdm.fit_pvsyst_iec61853_sandia(**inputs)
+    fitted_params = sdm.fit_pvsyst_iec61853_sandia_2025(**inputs)
     # still get approximately the expected values
     for key in expected.keys():
         assert np.isclose(fitted_params[key], expected[key], atol=0, rtol=1e-2)
 
     # but if the changes exceed the specified tolerance, then error:
     with pytest.raises(ValueError, match='Coefficient array is empty'):
-        sdm.fit_pvsyst_iec61853_sandia(**inputs, irradiance_tolerance=0.1)
+        sdm.fit_pvsyst_iec61853_sandia_2025(**inputs, irradiance_tolerance=0.1)
 
     with pytest.raises(ValueError,
                        match='can only convert an array of size 1'):
-        sdm.fit_pvsyst_iec61853_sandia(**inputs, temperature_tolerance=0.1)
+        sdm.fit_pvsyst_iec61853_sandia_2025(**inputs,
+                                            temperature_tolerance=0.1)


### PR DESCRIPTION
 - [x] Closes #2185
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The method is a sequence of regressions, each estimating one of the PVsyst SDM parameters.  The steps are not very complicated, but it's a lot of parameters, so the full method needs a nontrivial amount of code (~300 lines, including docs).  We tested it on a range of PV technologies and found good results:

![image](https://github.com/user-attachments/assets/29138f77-0375-4623-a93e-37b8c03dc8ec)

For details, please see our open-access JPV article describing the method (currently in early access): https://doi.org/10.1109/JPHOTOV.2025.3554338

This PR builds on two recent SDM PRs:
- #2256
- #2428