### PR TITLE
add missing 0.12.1 to whatsnew.rst

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.12.1.rst
 .. include:: whatsnew/v0.12.0.rst
 .. include:: whatsnew/v0.11.2.rst
 .. include:: whatsnew/v0.11.1.rst

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -36,3 +36,4 @@ Contributors
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Rajiv Daxini (:ghuser:`RDaxini`)
 * Kevin Anderson (:ghuser:`kandersolar`)
+* Will Holmgren (:ghuser:`wholmgren`)


### PR DESCRIPTION
Need to add the latest what's new file to the whatsnew index. Noticed when trying to review https://pvlib-python--2378.org.readthedocs.build/en/2378/whatsnew.html

![image](https://github.com/user-attachments/assets/d4642c55-6299-4b1d-aa94-8a5ff911bf9a)


Please feel free to directly edit the PR if simple fixes are required.