### PR TITLE
Drop `wheel` from build requirements; no longer needed as of setuptools 70.1

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -26,7 +26,7 @@ Documentation
 
 Requirements
 ~~~~~~~~~~~~
-* ``wheel`` is no longer a required build dependency. (:pull:`2439`)
+* ``wheel`` is no longer a build dependency. (:pull:`2439`)
 
 Testing
 ~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -24,6 +24,10 @@ Documentation
 * Documented how `np.nan` values are handled by :py:func:`~pvlib.spectrum.average_photon_energy`
   (:issue:`2423`, :pull:`2426`)
 
+Requirements
+~~~~~~~~~~~~
+* ``wheel`` is no longer a required build dependency. (:pull:`2439`)
+
 Testing
 ~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=70.1", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The [wheel readme](https://github.com/pypa/wheel) says:

> This project used to contain the implementation of the [setuptools](https://pypi.org/project/setuptools/) bdist_wheel command, but as of setuptools v70.1, it no longer needs wheel installed for that to work. Thus, you should install this only if you intend to use the wheel command line tool!

So if we upgrade our minimum `setuptools` to [70.1](https://setuptools.pypa.io/en/stable/history.html#v70-1-0), we don't need to list `wheel` in `pyproject.toml` anymore.

