### PR TITLE
Update expected response text in `get_solaranywhere` test

### DIFF
--- a/tests/iotools/test_solaranywhere.py
+++ b/tests/iotools/test_solaranywhere.py
@@ -283,7 +283,8 @@ def test_get_solaranywhere_timeout_tgy(solaranywhere_api_key):
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_solaranywhere_not_available(solaranywhere_api_key):
     # Test if RuntimeError is raised if location in the ocean is requested
-    with pytest.raises(RuntimeError, match="Tile is outside of our coverage"):
+    with pytest.raises(RuntimeError,
+                       match="Location is outside of our coverage area"):
         pvlib.iotools.get_solaranywhere(
             latitude=40, longitude=-70,
             api_key=solaranywhere_api_key,


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Looks like SolarAnywhere made slight adjustments to the error messages returned by their API.  A test is failing with

```
FAILED tests/iotools/test_solaranywhere.py::test_get_solaranywhere_not_available - AssertionError: Regex pattern did not match.
 Regex: 'Tile is outside of our coverage'
 Input: 'Location is outside of our coverage area (Latitude = 40, Longitude = -70)'
```

Example CI failure: https://github.com/pvlib/pvlib-python/actions/runs/14497459980/job/40668716357