### PR TITLE
Deprecate `parse_psm3` and `parse_cams`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -11,7 +11,7 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 * The following ``parse_`` functions in :py:mod:`pvlib.iotools` are deprecated,
-  with the corresponding ``read_`` functions taking their place: (:issue:`2444`, :pull:``)
+  with the corresponding ``read_`` functions taking their place: (:issue:`2444`, :pull:`2458`)
 
   - :py:func:`~pvlib.iotools.parse_psm3`
   - :py:func:`~pvlib.iotools.parse_cams`

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -8,6 +8,15 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 
+Deprecations
+~~~~~~~~~~~~
+* The following ``parse_`` functions in :py:mod:`pvlib.iotools` are deprecated,
+  with the corresponding ``read_`` functions taking their place: (:issue:`2444`, :pull:``)
+
+  - :py:func:`~pvlib.iotools.parse_psm3`
+  - :py:func:`~pvlib.iotools.parse_cams`
+
+
 Bug fixes
 ~~~~~~~~~
 

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -242,7 +242,7 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
     """
     Read a file or file-like buffer with data in the format of a CAMS
     Radiation or McClear file.
-    
+
     The CAMS solar radiation services are described in [1]_.
 
     Parameters
@@ -283,7 +283,7 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
         while True:
             line = fbuf.readline().rstrip('\n')
             if line.startswith('# Observation period'):
-                # The last line of the metadata section contains the column names
+                # The last line of the metadata section has the column names
                 names = line.lstrip('# ').split(';')
                 break  # End of metadata section has been reached
             elif ': ' in line:

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -353,5 +353,6 @@ def read_cams(filename, integrated=False, label=None, map_variables=True):
 
     return data, metadata
 
+
 parse_cams = deprecated(since="0.12.1", name="parse_cams",
                         alternative="read_cams")(read_cams)

--- a/tests/iotools/test_psm3.py
+++ b/tests/iotools/test_psm3.py
@@ -16,6 +16,8 @@ import pytest
 from requests import HTTPError
 from io import StringIO
 
+from pvlib._deprecation import pvlibDeprecationWarning
+
 
 TMY_TEST_DATA = TESTS_DATA_DIR / 'test_psm3_tmy-2017.csv'
 YEAR_TEST_DATA = TESTS_DATA_DIR / 'test_psm3_2017.csv'
@@ -130,7 +132,7 @@ def test_get_psm3_tmy_errors(
 
 @pytest.fixture
 def io_input(request):
-    """file-like object for parse_psm3"""
+    """file-like object for read_psm3"""
     with MANUAL_TEST_DATA.open() as f:
         data = f.read()
     obj = StringIO(data)
@@ -139,7 +141,8 @@ def io_input(request):
 
 def test_parse_psm3(io_input):
     """test parse_psm3"""
-    data, metadata = psm3.parse_psm3(io_input, map_variables=False)
+    with pytest.warns(pvlibDeprecationWarning, match='Use read_psm3 instead'):
+        data, metadata = psm3.parse_psm3(io_input, map_variables=False)
     expected = pd.read_csv(YEAR_TEST_DATA)
     assert_psm3_equal(data, metadata, expected)
 
@@ -147,6 +150,12 @@ def test_parse_psm3(io_input):
 def test_read_psm3():
     """test read_psm3"""
     data, metadata = psm3.read_psm3(MANUAL_TEST_DATA, map_variables=False)
+    expected = pd.read_csv(YEAR_TEST_DATA)
+    assert_psm3_equal(data, metadata, expected)
+
+
+def test_read_psm3_buffer(io_input):
+    data, metadata = psm3.read_psm3(io_input, map_variables=False)
     expected = pd.read_csv(YEAR_TEST_DATA)
     assert_psm3_equal(data, metadata, expected)
 

--- a/tests/iotools/test_sodapro.py
+++ b/tests/iotools/test_sodapro.py
@@ -11,6 +11,8 @@ from pvlib.iotools import sodapro
 from tests.conftest import TESTS_DATA_DIR, assert_frame_equal
 
 
+from pvlib._deprecation import pvlibDeprecationWarning
+
 testfile_mcclear_verbose = TESTS_DATA_DIR / 'cams_mcclear_1min_verbose.csv'
 testfile_mcclear_monthly = TESTS_DATA_DIR / 'cams_mcclear_monthly.csv'
 testfile_radiation_verbose = TESTS_DATA_DIR / 'cams_radiation_1min_verbose.csv'
@@ -144,7 +146,6 @@ values_radiation_monthly = np.array([
      0.9897]])
 
 
-# @pytest.fixture
 def generate_expected_dataframe(values, columns, index, dtypes):
     """Create dataframe from arrays of values, columns and index, in order to
     use this dataframe to compare to.
@@ -185,6 +186,12 @@ def test_read_cams_integrated_unmapped_label():
     assert_frame_equal(out, expected, check_less_precise=True)
 
 
+def test_parse_cams_deprecated():
+    with pytest.warns(pvlibDeprecationWarning, match='Use read_cams instead'):
+        with open(testfile_radiation_verbose, mode="r") as fbuf:
+            _ = sodapro.parse_cams(fbuf)
+
+
 def test_read_cams_metadata():
     _, metadata = sodapro.read_cams(testfile_mcclear_monthly, integrated=False)
     assert metadata['Time reference'] == 'Universal time (UT)'
@@ -203,7 +210,7 @@ def test_read_cams_metadata():
      values_radiation_monthly, dtypes_radiation, 'cams_radiation')])
 def test_get_cams(requests_mock, testfile, index, columns, values, dtypes,
                   identifier):
-    """Test that get_cams generates the correct URI request and that parse_cams
+    """Test that get_cams generates the correct URI request and that read_cams
     is being called correctly"""
     # Open local test file containing McClear mothly data
     with open(testfile, 'r') as test_file:


### PR DESCRIPTION
 - [x] Progress towards #2444
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

To keep reviews manageable, I thought it better to not deprecate all the `parse_` functions in one PR.  This one does just PSM3 and CAMS, which are both straightforward.  