### PR TITLE
[DOC] Fix `Edit on Github` sidebar link always points to latest commit

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -501,7 +501,7 @@ def make_github_url(file_name):
 
     The target URL is built differently based on the type of page.  The pydata
     sphinx theme has a built-in `file_name` variable that looks like
-    "/docs/sphinx/source/api.rst" or "generated/pvlib.atmosphere.alt2pres.rst"
+    "docs/sphinx/source/api.rst" or "generated/pvlib.atmosphere.alt2pres.rst"
     """
     # is it a gallery page?
     if any(d in file_name for d in sphinx_gallery_conf['gallery_dirs']):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2456
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Fix `Edit on GitHub` links on the right sidebar in stable docs point to latest commit in main, so there is a mismatch if code lines were added/deleted since the last stable release.

The fix consists in switching the base repo url from `https://github.com/pvlib/pvlib-python/blob/main` to e.g. `https://github.com/pvlib/pvlib-python/blob/v0.11.1` depending on the environment variables set by ReadTheDocs at build time. RTD docs on that: https://docs.readthedocs.com/platform/stable/reference/environment-variables.html

Another possibility for "latest" builds is to point to the specific commit, but I doubt that is any useful.

Sidenote for pull requests: it's impossible to link to their repo since user + branch name are unknown by RTD.
Local builds will default to main branch files.
