### PR TITLE
Change server parameter to url in get_cams

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -6,7 +6,9 @@ v0.12.1 (XXXX, 2025)
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-
+* The ``server`` parameter in :py:func:`~pvlib.iotools.get_cams` has been renamed
+  to ``url`` to be consistent with the other iotoools.
+  :pull:`2463`
 
 Deprecations
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -6,9 +6,7 @@ v0.12.1 (XXXX, 2025)
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-* The ``server`` parameter in :py:func:`~pvlib.iotools.get_cams` has been renamed
-  to ``url`` to be consistent with the other iotoools.
-  :pull:`2463`
+
 
 Deprecations
 ~~~~~~~~~~~~
@@ -17,6 +15,10 @@ Deprecations
 
   - :py:func:`~pvlib.iotools.parse_psm3`
   - :py:func:`~pvlib.iotools.parse_cams`
+
+* The ``server`` parameter in :py:func:`~pvlib.iotools.get_cams` has been renamed
+  to ``url`` to be consistent with the other iotools.
+  :pull:`2463`
 
 
 Bug fixes

--- a/pvlib/iotools/sodapro.py
+++ b/pvlib/iotools/sodapro.py
@@ -9,7 +9,7 @@ import io
 import warnings
 from pvlib import tools
 
-from pvlib._deprecation import deprecated
+from pvlib._deprecation import deprecated, renamed_kwarg_warning
 
 URL = 'api.soda-solardata.com'
 
@@ -45,10 +45,15 @@ SUMMATION_PERIOD_TO_TIME_STEP = {'0 year 0 month 0 day 0 h 1 min 0 s': '1min',
                                  '0 year 1 month 0 day 0 h 0 min 0 s': '1M'}
 
 
+@renamed_kwarg_warning(
+    since='0.13.0',
+    old_param_name='server',
+    new_param_name='url',
+    removal="0.14.0")
 def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
              altitude=None, time_step='1h', time_ref='UT', verbose=False,
              integrated=False, label=None, map_variables=True,
-             server=URL, timeout=30):
+             url=URL, timeout=30):
     """Retrieve irradiance and clear-sky time series from CAMS.
 
     Time-series of radiation and/or clear-sky global, beam, and
@@ -98,7 +103,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     map_variables: bool, default: True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. See variable :const:`VARIABLE_MAP`.
-    server: str, default: :const:`pvlib.iotools.sodapro.URL`
+    url: str, default: :const:`pvlib.iotools.sodapro.URL`
         Base url of the SoDa Pro CAMS Radiation API.
     timeout : int, default: 30
         Time in seconds to wait for server response before timeout
@@ -199,7 +204,7 @@ def get_cams(latitude, longitude, start, end, email, identifier='mcclear',
     email = email.replace('@', '%2540')  # Format email address
     identifier = 'get_{}'.format(identifier.lower())  # Format identifier str
 
-    base_url = f"https://{server}/service/wps"
+    base_url = f"https://{url}/service/wps"
 
     data_inputs_dict = {
         'latitude': latitude,

--- a/tests/iotools/test_sodapro.py
+++ b/tests/iotools/test_sodapro.py
@@ -253,7 +253,7 @@ def test_get_cams(requests_mock, testfile, index, columns, values, dtypes,
 
 def test_get_cams_bad_request(requests_mock):
     """Test that a the correct errors/warnings ares raised for invalid
-    requests inputs. Also tests if the specified server url gets used"""
+    requests inputs. Also tests if the specified url gets used"""
 
     # Subset of an xml file returned for errornous requests
     mock_response_bad_text = """<?xml version="1.0" encoding="utf-8"?>
@@ -281,7 +281,7 @@ def test_get_cams_bad_request(requests_mock):
             time_ref='TST',
             verbose=False,
             time_step='1h',
-            server='pro.soda-is.com')
+            url='pro.soda-is.com')
     # Test if value error is raised if incorrect identifier is specified
     with pytest.raises(ValueError, match='Identifier must be either'):
         _ = sodapro.get_cams(
@@ -291,7 +291,7 @@ def test_get_cams_bad_request(requests_mock):
             longitude=12.5251,
             email='test@test.com',
             identifier='test',  # incorrect identifier
-            server='pro.soda-is.com')
+            url='pro.soda-is.com')
     # Test if value error is raised if incorrect time step is specified
     with pytest.raises(ValueError, match='Time step not recognized'):
         _ = sodapro.get_cams(
@@ -302,4 +302,4 @@ def test_get_cams_bad_request(requests_mock):
             email='test@test.com',
             identifier='mcclear',
             time_step='test',  # incorrect time step
-            server='pro.soda-is.com')
+            url='pro.soda-is.com')


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR renames the parameter ``server`` in ``get_cams`` to ``url`` to be consistent with the other iotools.