### PR TITLE
Deprecate `parse_bsrn`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -17,10 +17,11 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 * The following ``parse_`` functions in :py:mod:`pvlib.iotools` are deprecated,
-  with the corresponding ``read_`` functions taking their place: (:issue:`2444`, :pull:`2458`)
+  with the corresponding ``read_`` functions taking their place: (:issue:`2444`, :pull:`2458`, :pull:`2466`)
 
   - :py:func:`~pvlib.iotools.parse_psm3`
   - :py:func:`~pvlib.iotools.parse_cams`
+  - :py:func:`~pvlib.iotools.parse_bsrn`
 
 * The ``server`` parameter in :py:func:`~pvlib.iotools.get_cams` has been renamed
   to ``url`` to be consistent with the other iotools.

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -8,6 +8,10 @@ import ftplib
 import warnings
 import io
 import os
+from functools import partial
+
+from pvlib.tools import _file_context_manager
+from pvlib._deprecation import deprecated
 
 BSRN_FTP_URL = "ftp.bsrn.awi.de"
 
@@ -136,7 +140,7 @@ def get_bsrn(station, start, end, username, password,
 
     See Also
     --------
-    pvlib.iotools.read_bsrn, pvlib.iotools.parse_bsrn
+    pvlib.iotools.read_bsrn
 
     References
     ----------
@@ -191,7 +195,7 @@ def get_bsrn(station, start, end, username, password,
                 bio.seek(0)  # reset buffer to start of file
                 gzip_file = io.TextIOWrapper(gzip.GzipFile(fileobj=bio),
                                              encoding='latin1')
-                dfi, metadata = parse_bsrn(gzip_file, logical_records)
+                dfi, metadata = _parse_bsrn(gzip_file, logical_records)
                 dfs.append(dfi)
             # FTP client raises an error if the file does not exist on server
             except ftplib.error_perm as e:
@@ -217,7 +221,7 @@ def get_bsrn(station, start, end, username, password,
     return data, metadata
 
 
-def parse_bsrn(fbuf, logical_records=('0100',)):
+def _parse_bsrn(fbuf, logical_records=('0100',)):
     """
     Parse a file-like buffer of a BSRN station-to-archive file.
 
@@ -382,7 +386,7 @@ def read_bsrn(filename, logical_records=('0100',)):
     Parameters
     ----------
     filename: str or path-like
-        Name or path of a BSRN station-to-archive data file
+        Name, path, or in-memory buffer of a BSRN station-to-archive data file
     logical_records: list or tuple, default: ('0100',)
         List of the logical records (LR) to parse. Options include: '0100',
         '0300', and '0500'.
@@ -439,7 +443,7 @@ def read_bsrn(filename, logical_records=('0100',)):
 
     See Also
     --------
-    pvlib.iotools.parse_bsrn, pvlib.iotools.get_bsrn
+    pvlib.iotools.get_bsrn
 
     References
     ----------
@@ -455,9 +459,13 @@ def read_bsrn(filename, logical_records=('0100',)):
        <https://bsrn.awi.de/data/conditions-of-data-release/>`_
     """  # noqa: E501
     if str(filename).endswith('.gz'):  # check if file is a gzipped (.gz) file
-        open_func, mode = gzip.open, 'rt'
+        open_func = partial(gzip.open, mode='rt')
     else:
-        open_func, mode = open, 'r'
-    with open_func(filename, mode) as f:
-        content = parse_bsrn(f, logical_records)
+        open_func = _file_context_manager(filename, mode='r')
+    with open_func(filename) as f:
+        content = _parse_bsrn(f, logical_records)
     return content
+
+
+parse_bsrn = deprecated(since="0.13.0", name="parse_bsrn",
+                        alternative="read_bsrn")(read_bsrn)

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -459,10 +459,10 @@ def read_bsrn(filename, logical_records=('0100',)):
        <https://bsrn.awi.de/data/conditions-of-data-release/>`_
     """  # noqa: E501
     if str(filename).endswith('.gz'):  # check if file is a gzipped (.gz) file
-        open_func = partial(gzip.open, mode='rt')
+        open_func, mode = gzip.open, 'rt'
     else:
-        open_func = _file_context_manager(filename, mode='r')
-    with open_func(filename) as f:
+        open_func, mode = _file_context_manager, 'r'
+    with open_func(filename, mode) as f:
         content = _parse_bsrn(f, logical_records)
     return content
 

--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -8,7 +8,6 @@ import ftplib
 import warnings
 import io
 import os
-from functools import partial
 
 from pvlib.tools import _file_context_manager
 from pvlib._deprecation import deprecated

--- a/tests/iotools/test_bsrn.py
+++ b/tests/iotools/test_bsrn.py
@@ -17,6 +17,7 @@ from tests.conftest import (
 
 from pvlib._deprecation import pvlibDeprecationWarning
 
+
 @pytest.fixture(scope="module")
 def bsrn_credentials():
     """Supplies the BSRN FTP credentials for testing purposes.


### PR DESCRIPTION
 - [x] Towards #2444
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.
