### PR TITLE
Fix minor issue in OEDI 9068 example gallery page

### DIFF
--- a/docs/examples/system-models/plot_oedi_9068.py
+++ b/docs/examples/system-models/plot_oedi_9068.py
@@ -165,7 +165,7 @@ psm3, psm3_metadata = pvlib.iotools.get_psm3(latitude, longitude, api_key,
 # module fraction and returns the average irradiance over the total module
 # surface.
 
-solar_position = location.get_solarposition(psm3.index, latitude, longitude)
+solar_position = location.get_solarposition(psm3.index)
 tracker_angles = mount.get_orientation(
     solar_position['apparent_zenith'],
     solar_position['azimuth']

--- a/docs/sphinx/source/whatsnew/v0.12.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.1.rst
@@ -68,7 +68,7 @@ Documentation
 * Update references in :py:func:`~pvlib.iotools.get_cams` and :py:func:`~pvlib.iotools.read_cams`
   (:issue:`2427`, :pull:`2457`)
 * Fix ``Edit on GitHub`` links in stable documentation so they point to the tagged repository version matching the build environment (e.g., v0.12.0). (:issue:`2456`, :pull:`2460`)
-
+* Fix a minor issue with calculation of solar position in the OEDI 9068 gallery page. (:pull:`2468`)
 
 Requirements
 ~~~~~~~~~~~~


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR corrects a problem where `latitude` and `longitude` are being passed to `location.get_solarposition`'s `temperature` and `pressure` parameters:

https://github.com/pvlib/pvlib-python/blob/389e3d1ad239c11890825873a29e8317c7b44bbd/docs/examples/system-models/plot_oedi_9068.py#L168