### PR TITLE
PSM4 `get_` functions: remove default values for `year`

### DIFF
--- a/pvlib/iotools/psm4.py
+++ b/pvlib/iotools/psm4.py
@@ -173,9 +173,6 @@ def get_nsrdb_psm4_aggregated(latitude, longitude, api_key, email,
     latitude = ('%8.4f' % latitude).strip()
     # TODO: make format_WKT(object_type, *args) in tools.py
 
-    # convert to string to accomodate integer years being passed in
-    year = str(year)
-
     # convert pvlib names in parameters to PSM4 convention
     parameters = [REQUEST_VARIABLE_MAP.get(a, a) for a in parameters]
 
@@ -450,9 +447,6 @@ def get_nsrdb_psm4_conus(latitude, longitude, api_key, email, year,
     latitude = ('%8.4f' % latitude).strip()
     # TODO: make format_WKT(object_type, *args) in tools.py
 
-    # convert to string to accomodate integer years being passed in
-    year = str(year)
-
     # convert pvlib names in parameters to PSM4 convention
     parameters = [REQUEST_VARIABLE_MAP.get(a, a) for a in parameters]
 
@@ -591,9 +585,6 @@ def get_nsrdb_psm4_full_disc(latitude, longitude, api_key, email,
     longitude = ('%9.4f' % longitude).strip()
     latitude = ('%8.4f' % latitude).strip()
     # TODO: make format_WKT(object_type, *args) in tools.py
-
-    # convert to string to accomodate integer years being passed in
-    year = str(year)
 
     # convert pvlib names in parameters to PSM4 convention
     parameters = [REQUEST_VARIABLE_MAP.get(a, a) for a in parameters]


### PR DESCRIPTION
 - [x] Addresses https://github.com/pvlib/pvlib-python/pull/2378#discussion_r2126950140
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

See https://github.com/pvlib/pvlib-python/pull/2378#discussion_r2126950140.

Note that these functions haven't been included in a release yet, so no problem to change default values like this.