### PR TITLE
Change get_pvgis_tmy coerce_year default to 1990

### DIFF
--- a/pvlib/iotools/pvgis.py
+++ b/pvlib/iotools/pvgis.py
@@ -434,7 +434,7 @@ def _coerce_and_roll_tmy(tmy_data, tz, year):
 def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
                   userhorizon=None, startyear=None, endyear=None,
                   map_variables=True, url=URL, timeout=30,
-                  roll_utc_offset=None, coerce_year=None):
+                  roll_utc_offset=None, coerce_year=1990):
     """
     Get TMY data from PVGIS.
 
@@ -478,8 +478,10 @@ def get_pvgis_tmy(latitude, longitude, outputformat='json', usehorizon=True,
         dataframe by ``roll_utc_offset`` so it starts at midnight on January
         1st. Ignored if ``None``, otherwise will force year to ``coerce_year``.
     coerce_year: int, optional
-        Use to force indices to desired year. Will default to 1990 if
-        ``coerce_year`` is not specified, but ``roll_utc_offset`` is specified.
+        Use to force indices to desired year. Defaults to 1990. Specify ``None``
+        to return the actual indicies used for the TMY. If ``coerce_year`` is
+        ``None``, but ``roll_utc_offset`` is specified, then ``coerce`` year
+        will be set to the default.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR changes the default ``coerce_year`` behavior of the ``pvlib.iotools.get_pvgis_tmy`` function. This is a breaking change and is not deprecated since it comes during the same release as other changes to the function that cannot be deprecated (see #2470).

The desire for this change is that the ``get_pvgis_tmy`` function is commonly used for introductory tutorials, where beginners often spend a lot of time on getting "strange" plots because the TMY indexes span +10 years.