### PR TITLE
Move scheduled deprecations from 0.13 to 0.14

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1627,7 +1627,7 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
     since='0.11.2',
     old_param_name='clearsky_ghi',
     new_param_name='ghi_clear',
-    removal="0.13.0")
+    removal="0.14.0")
 def clearsky_index(ghi, ghi_clear, max_clearsky_index=2.0):
     """
     Calculate the clearsky index.
@@ -2172,12 +2172,12 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     since='0.11.2',
     old_param_name='ghi_clearsky',
     new_param_name='ghi_clear',
-    removal="0.13.0")
+    removal="0.14.0")
 @renamed_kwarg_warning(
     since='0.11.2',
     old_param_name='dni_clearsky',
     new_param_name='dni_clear',
-    removal="0.13.0")
+    removal="0.14.0")
 def dirindex(ghi, ghi_clear, dni_clear, zenith, times, pressure=101325.,
              use_delta_kt_prime=True, temp_dew=None, min_cos_zenith=0.065,
              max_zenith=87):
@@ -3662,7 +3662,7 @@ def _get_dirint_coeffs():
     since='0.11.2',
     old_param_name='clearsky_dni',
     new_param_name='dni_clear',
-    removal="0.13.0")
+    removal="0.14.0")
 def dni(ghi, dhi, zenith, dni_clear=None, clearsky_tolerance=1.1,
         zenith_threshold_for_zero_dni=88.0,
         zenith_threshold_for_clearsky_limit=80.0):

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1112,7 +1112,7 @@ def test_dirindex(times):
         equal_nan=True)
 
 
-@fail_on_pvlib_version("0.13")
+@fail_on_pvlib_version("0.14")
 def test_dirindex_ghi_clearsky_deprecation():
     times = pd.DatetimeIndex(['2014-06-24T18-1200'])
     ghi = pd.Series([1038.62], index=times)
@@ -1157,7 +1157,7 @@ def test_dirindex_min_cos_zenith_max_zenith():
     assert_series_equal(out, expected)
 
 
-@fail_on_pvlib_version("0.13")
+@fail_on_pvlib_version("0.14")
 def test_dirindex_dni_clearsky_deprecation():
     times = pd.DatetimeIndex(['2014-06-24T12-0700', '2014-06-24T18-0700'])
     ghi = pd.Series([0, 1], index=times)
@@ -1188,7 +1188,7 @@ def test_dni():
                                    146.190220008, 573.685662283]))
 
 
-@fail_on_pvlib_version("0.13")
+@fail_on_pvlib_version("0.14")
 def test_dni_dni_clearsky_deprecation():
     ghi = pd.Series([90, 100, 100, 100, 100])
     dhi = pd.Series([100, 90, 50, 50, 50])
@@ -1291,7 +1291,7 @@ def test_clearsky_index():
     assert_series_equal(out, expected)
 
 
-@fail_on_pvlib_version("0.13")
+@fail_on_pvlib_version("0.14")
 def test_clearsky_index_clearsky_ghi_deprecation():
     with pytest.warns(pvlibDeprecationWarning, match='ghi_clear'):
         ghi, clearsky_ghi = 200, 300


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

We deprecated some parameter names in v0.11.2 (December 2024) and marked them for removal in 0.13.0.  Since 0.13.0 came earlier than expected, this PR bumps those deprecations to 0.14.0.  