### PR TITLE
Clean up some warnings in the tests: `ivtools/sdm/test__fit_desoto_pvsyst_sandia.py`

### DIFF
--- a/tests/ivtools/sdm/test__fit_desoto_pvsyst_sandia.py
+++ b/tests/ivtools/sdm/test__fit_desoto_pvsyst_sandia.py
@@ -56,7 +56,8 @@ def test__update_io(voc, iph, io, rs, rsh, nnsvth, expected):
     (2., 2., 2., 2., 2., 0.),
     (-1., -1., -1., -1., -1., -1.)])
 def test__update_io_nan(voc, iph, io, rs, rsh, nnsvth):
-    outio = _update_io(voc, iph, io, rs, rsh, nnsvth)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        outio = _update_io(voc, iph, io, rs, rsh, nnsvth)
     assert np.isnan(outio)
 
 
@@ -89,13 +90,14 @@ def test__calc_theta_phi_exact_one_nan():
 
 
 def test__calc_theta_phi_exact_vector():
-    theta, phi = _calc_theta_phi_exact(imp=np.array([1., -1.]),
-                                       iph=np.array([-1., 1.]),
-                                       vmp=np.array([1., -1.]),
-                                       io=np.array([-1., 1.]),
-                                       nnsvth=np.array([1., -1.]),
-                                       rs=np.array([-1., 1.]),
-                                       rsh=np.array([1., -1.]))
+    with np.errstate(invalid='ignore'):
+        theta, phi = _calc_theta_phi_exact(imp=np.array([1., -1.]),
+                                           iph=np.array([-1., 1.]),
+                                           vmp=np.array([1., -1.]),
+                                           io=np.array([-1., 1.]),
+                                           nnsvth=np.array([1., -1.]),
+                                           rs=np.array([-1., 1.]),
+                                           rsh=np.array([1., -1.]))
     assert np.isnan(theta[0])
     assert np.isnan(theta[1])
     assert np.isnan(phi[0])


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The tests have been emitting some nuisance numpy warnings for a while: https://github.com/pvlib/pvlib-python/actions/runs/16008866104/job/45161784994#step:9:73

This PR fixes several of them.  In the process of doing that, it made sense to refactor some code in `singlediode` to be a little easier to read, and likely marginally faster as well due to avoiding unnecessary repeated array subsetting.

I plan to address the remaining warnings in a separate PR.