### PR TITLE
Deprecate `modelchain.get_orientation`

### DIFF
--- a/docs/sphinx/source/reference/modelchain.rst
+++ b/docs/sphinx/source/reference/modelchain.rst
@@ -115,12 +115,3 @@ on the information in the associated :py:class:`~pvsystem.PVSystem` object.
    modelchain.ModelChain.infer_temperature_model
    modelchain.ModelChain.infer_losses_model
 
-Functions
----------
-
-Functions for power modeling.
-
-.. autosummary::
-   :toctree: generated/
-
-   modelchain.get_orientation

--- a/docs/sphinx/source/reference/modelchain.rst
+++ b/docs/sphinx/source/reference/modelchain.rst
@@ -115,3 +115,12 @@ on the information in the associated :py:class:`~pvsystem.PVSystem` object.
    modelchain.ModelChain.infer_temperature_model
    modelchain.ModelChain.infer_losses_model
 
+Functions
+---------
+
+Functions for power modeling.
+
+.. autosummary::
+   :toctree: generated/
+
+   modelchain.get_orientation

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -10,6 +10,8 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
+* Deprecate :py:func:`~pvlib.modelchain.get_orientation`. Removal scheduled for
+  0.14.0. (:pull:`2691`)
 
 
 Bug fixes
@@ -26,9 +28,7 @@ Documentation
 
 Testing
 ~~~~~~~
-* Update test for :py:func:`~pvlib.modelchain.get_orientation` to check
-  whether the correct error message is raised when an invalid strategy is
-  provided. (:issue:`2492`, :pull:`2691`)
+
 
 Benchmarking
 ~~~~~~~~~~~~
@@ -46,3 +46,4 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 * Elijah Passmore (:ghuser:`eljpsm`)
+* Rajiv Daxini (:ghuser:`RDaxini`)

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -11,7 +11,7 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 * Deprecate :py:func:`~pvlib.modelchain.get_orientation`. Removal scheduled for
-  0.14.0. (:pull:`2691`)
+  ``v0.14.0``. (:pull:`2691`)
 
 
 Bug fixes

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -26,7 +26,9 @@ Documentation
 
 Testing
 ~~~~~~~
-
+* Update test for :py:func:`~pvlib.modelchain.get_orientation` to check
+  whether the correct error message is raised when an invalid strategy is
+  provided. (:issue:`2492`, :pull:`2691`)
 
 Benchmarking
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -10,8 +10,7 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
-* Deprecate :py:func:`~pvlib.modelchain.get_orientation`. Removal scheduled for
-  ``v0.14.0``. (:pull:`2691`)
+* Deprecate :py:func:`~pvlib.modelchain.get_orientation`. (:pull:`2691`)
 * Rename parameter name ``aparent_azimuth`` to ``solar_azimuth`` in :py:func:`~pvlib.tracking.singleaxis`.
   (:issue:`2479`, :pull:`2480`)
 

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -10,7 +10,7 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
-* Deprecate :py:func:`~pvlib.modelchain.get_orientation`. (:pull:`2691`)
+* Deprecate :py:func:`~pvlib.modelchain.get_orientation`. (:pull:`2495`)
 * Rename parameter name ``aparent_azimuth`` to ``solar_azimuth`` in :py:func:`~pvlib.tracking.singleaxis`.
   (:issue:`2479`, :pull:`2480`)
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -62,8 +62,8 @@ SAPM_CONFIG = dict(
 
 
 @deprecated(
-    since="0.13",
-    removal="0.14",
+    since="0.13.1",
+    removal="the next version",
     name="pvlib.modelchain.get_orientation",
     alternative=None,
     addendum=None,

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -31,7 +31,7 @@ POA_KEYS = ('poa_global', 'poa_direct', 'poa_diffuse')
 # 'cell_temperature' overrides ModelChain.temperature_model and sets
 # ModelChain.cell_temperature to the data. If 'module_temperature' is provided,
 # overrides ModelChain.temperature_model with
-# pvlib.temperature.sapm_celL_from_module
+# pvlib.temperature.sapm_cell_from_module
 TEMPERATURE_KEYS = ('module_temperature', 'cell_temperature')
 
 DATA_KEYS = WEATHER_KEYS + POA_KEYS + TEMPERATURE_KEYS
@@ -46,7 +46,7 @@ DATA_KEYS = WEATHER_KEYS + POA_KEYS + TEMPERATURE_KEYS
 # for Flat-Plate Photovoltaic Arrays. SAND85-0330. Albuquerque, NM:
 # Sandia National Laboratories. Accessed September 3, 2013:
 # http://prod.sandia.gov/techlib/access-control.cgi/1985/850330.pdf
-# pvlib python does not implement that model, so use the SAPM instead.
+# pvlib-python does not implement that model, so it uses the SAPM instead.
 PVWATTS_CONFIG = dict(
     dc_model='pvwatts', ac_model='pvwatts', losses_model='pvwatts',
     transposition_model='perez', aoi_model='physical',
@@ -84,7 +84,7 @@ def get_orientation(strategy, **kwargs):
         surface_tilt = 0
     else:
         raise ValueError('invalid orientation strategy. strategy must '
-                         'be one of south_at_latitude, flat,')
+                         'be one of south_at_latitude_tilt, flat,')
 
     return surface_tilt, surface_azimuth
 
@@ -162,8 +162,8 @@ class ModelChainResult:
     # per DC array information
     total_irrad: Optional[PerArray[pd.DataFrame]] = field(default=None)
     """ DataFrame (or tuple of DataFrame, one for each array) containing
-    columns ``'poa_global'``, ``'poa_direct'`` ``'poa_diffuse'``,
-    ``poa_sky_diffuse'``, ``'poa_ground_diffuse'`` (W/m2); see
+    columns ``'poa_global'``, ``'poa_direct'``, ``'poa_diffuse'``,
+    ``poa_sky_diffuse'``, and ``'poa_ground_diffuse'`` (Wm⁻²); see
     :py:func:`~pvlib.irradiance.get_total_irradiance` for details.
     """
 
@@ -190,12 +190,12 @@ class ModelChainResult:
 
     cell_temperature: Optional[PerArray[pd.Series]] = field(default=None)
     """Series (or tuple of Series, one for each array) containing cell
-    temperature (C).
+    temperature (°C).
     """
 
     effective_irradiance: Optional[PerArray[pd.Series]] = field(default=None)
     """Series (or tuple of Series, one for each array) containing effective
-    irradiance (W/m2) which is total plane-of-array irradiance adjusted for
+    irradiance (Wm⁻²) which is total plane-of-array irradiance adjusted for
     reflections and spectral content.
     """
 
@@ -215,12 +215,12 @@ class ModelChainResult:
 
     dc_ohmic_losses: Optional[PerArray[pd.Series]] = field(default=None)
     """Series (or tuple of Series, one for each array) containing DC ohmic
-    loss (W) calculated by ``ModelChain.dc_ohmic_model``.
+    losses (W) calculated by ``ModelChain.dc_ohmic_model``.
     """
 
     # copies of input data, for user convenience
     weather: Optional[PerArray[pd.DataFrame]] = None
-    """DataFrame (or tuple of DataFrame, one for each array) contains a
+    """DataFrame (or tuple of DataFrame, one for each array) containing a
     copy of the input weather data.
     """
 
@@ -806,7 +806,7 @@ class ModelChain:
                              'system.arrays[i].module_parameters. Check that '
                              'the module_parameters for all Arrays in '
                              'system.arrays contain parameters for the '
-                             'physical, aoi, ashrae, martin_ruiz or interp '
+                             'physical, sapm, ashrae, martin_ruiz or interp '
                              'model; explicitly set the model with the '
                              'aoi_model kwarg; or set aoi_model="no_loss".')
 

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -18,6 +18,8 @@ import pvlib.irradiance  # avoid name conflict with full import
 from pvlib.pvsystem import _DC_MODEL_PARAMS
 from pvlib.tools import _build_kwargs
 
+from pvlib._deprecation import deprecated
+
 # keys that are used to detect input data and assign data to appropriate
 # ModelChain attribute
 # for ModelChain.weather
@@ -59,6 +61,13 @@ SAPM_CONFIG = dict(
 )
 
 
+@deprecated(
+    since="0.13",
+    removal="0.14",
+    name="pvlib.modelchain.get_orientation",
+    alternative=None,
+    addendum=None,
+)
 def get_orientation(strategy, **kwargs):
     """
     Determine a PV system's surface tilt and surface azimuth

--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -63,7 +63,7 @@ SAPM_CONFIG = dict(
 
 @deprecated(
     since="0.13.1",
-    removal="the next version",
+    removal="",
     name="pvlib.modelchain.get_orientation",
     alternative=None,
     addendum=None,

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1785,9 +1785,11 @@ def test_invalid_models(model, sapm_dc_snl_ac_system, location):
         ModelChain(sapm_dc_snl_ac_system, location, **kwargs)
 
 
-def test_bad_get_orientation():
-    with pytest.raises(ValueError):
-        modelchain.get_orientation('bad value')
+def test_get_orientation_invalid_strategy():
+    with pytest.raises(ValueError, 
+                       match='invalid orientation strategy. strategy must '
+                             'be one of south_at_latitude_tilt, flat,'):
+        modelchain.get_orientation('invalid_strategy')
 
 
 # tests for PVSystem with multiple Arrays

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1786,7 +1786,7 @@ def test_invalid_models(model, sapm_dc_snl_ac_system, location):
 
 
 def test_get_orientation_invalid_strategy():
-    with pytest.raises(ValueError, 
+    with pytest.raises(ValueError,
                        match='invalid orientation strategy. strategy must '
                              'be one of south_at_latitude_tilt, flat,'):
         modelchain.get_orientation('invalid_strategy')

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1792,6 +1792,7 @@ def test_bad_get_orientation():
         with pytest.raises(ValueError):
             modelchain.get_orientation('bad value')
 
+
 # tests for PVSystem with multiple Arrays
 def test_with_sapm_pvsystem_arrays(sapm_dc_snl_ac_system_Array, location,
                                    weather):

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1785,13 +1785,6 @@ def test_invalid_models(model, sapm_dc_snl_ac_system, location):
         ModelChain(sapm_dc_snl_ac_system, location, **kwargs)
 
 
-def test_get_orientation_invalid_strategy():
-    with pytest.raises(ValueError,
-                       match='invalid orientation strategy. strategy must '
-                             'be one of south_at_latitude_tilt, flat,'):
-        modelchain.get_orientation('invalid_strategy')
-
-
 # tests for PVSystem with multiple Arrays
 def test_with_sapm_pvsystem_arrays(sapm_dc_snl_ac_system_Array, location,
                                    weather):

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1785,6 +1785,11 @@ def test_invalid_models(model, sapm_dc_snl_ac_system, location):
         ModelChain(sapm_dc_snl_ac_system, location, **kwargs)
 
 
+def test_bad_get_orientation():
+    with pytest.raises(ValueError):
+        modelchain.get_orientation('bad value')
+
+
 # tests for PVSystem with multiple Arrays
 def test_with_sapm_pvsystem_arrays(sapm_dc_snl_ac_system_Array, location,
                                    weather):

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -8,6 +8,8 @@ from pvlib.modelchain import ModelChain
 from pvlib.pvsystem import PVSystem
 from pvlib.location import Location
 
+from pvlib._deprecation import pvlibDeprecationWarning
+
 from .conftest import assert_series_equal, assert_frame_equal
 import pytest
 
@@ -1786,9 +1788,9 @@ def test_invalid_models(model, sapm_dc_snl_ac_system, location):
 
 
 def test_bad_get_orientation():
-    with pytest.raises(ValueError):
-        modelchain.get_orientation('bad value')
-
+    with pytest.warns(pvlibDeprecationWarning, match='will be removed soon'):
+        with pytest.raises(ValueError):
+            modelchain.get_orientation('bad value')
 
 # tests for PVSystem with multiple Arrays
 def test_with_sapm_pvsystem_arrays(sapm_dc_snl_ac_system_Array, location,


### PR DESCRIPTION
 - [X] Related discussion #2492
 - [X] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [X] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [X] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [X] Pull request is nearly complete and ready for detailed review.
 - [X] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

~See discussion in related #2492~

~Original test `test_bad_get_orientation():` only checked whether a value error was raised, the new test (with what I think is a clearer name) checks not only whether a value error is raised but also whether the error string matches~