### PR TITLE
Remove out-of-range warnings from `pvlib.spectrum.spectral_factor_firstsolar`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -19,7 +19,8 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-
+* :py:func:`pvlib.spectrum.spectral_factor_firstsolar` no longer emits warnings
+  when airmass and precipitable water values fall out of range. (:pull:`2512`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -45,3 +46,4 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 * Elijah Passmore (:ghuser:`eljpsm`)
+* Kevin Anderson (:ghuser:`kandersolar`)

--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -20,6 +20,7 @@ Bug fixes
 Enhancements
 ~~~~~~~~~~~~
 * :py:func:`pvlib.spectrum.spectral_factor_firstsolar` no longer emits warnings
+
   when airmass and precipitable water values fall out of range. (:pull:`2512`)
 
 Documentation

--- a/pvlib/spectrum/mismatch.py
+++ b/pvlib/spectrum/mismatch.py
@@ -239,27 +239,15 @@ def spectral_factor_firstsolar(precipitable_water, airmass_absolute,
     """
     pw = np.atleast_1d(precipitable_water)
     pw = pw.astype('float64')
-    if np.min(pw) < min_precipitable_water:
-        pw = np.maximum(pw, min_precipitable_water)
-        warn('Low precipitable water values replaced with '
-             f'{min_precipitable_water} cm in the calculation of spectral '
-             'mismatch.')
-
-    if np.max(pw) > max_precipitable_water:
-        pw[pw > max_precipitable_water] = np.nan
-        warn('High precipitable water values replaced with np.nan in '
-             'the calculation of spectral mismatch.')
+    pw = np.maximum(pw, min_precipitable_water)
+    pw[pw > max_precipitable_water] = np.nan
 
     airmass_absolute = np.minimum(airmass_absolute, max_airmass_absolute)
-
-    if np.min(airmass_absolute) < min_airmass_absolute:
-        airmass_absolute = np.maximum(airmass_absolute, min_airmass_absolute)
-        warn('Low airmass values replaced with 'f'{min_airmass_absolute} in '
-             'the calculation of spectral mismatch.')
-        # pvlib.atmosphere.get_absolute_airmass(1,
-        # pvlib.atmosphere.alt2pres(4340)) = 0.58 Elevation of
-        # Mina Pirquita, Argentian = 4340 m. Highest elevation city with
-        # population over 50,000.
+    # pvlib.atmosphere.get_absolute_airmass(1,
+    # pvlib.atmosphere.alt2pres(4340)) = 0.58 Elevation of
+    # Mina Pirquita, Argentian = 4340 m. Highest elevation city with
+    # population over 50,000.
+    airmass_absolute = np.maximum(airmass_absolute, min_airmass_absolute)
 
     _coefficients = {}
     _coefficients['cdte'] = (

--- a/tests/spectrum/test_mismatch.py
+++ b/tests/spectrum/test_mismatch.py
@@ -112,8 +112,6 @@ def test_spectral_factor_firstsolar_low_airmass():
     m_eq58 = spectrum.spectral_factor_firstsolar(1, 0.58, 'monosi')
     m_lt58 = spectrum.spectral_factor_firstsolar(1, 0.1, 'monosi')
     assert_allclose(m_eq58, m_lt58)
-    with pytest.warns(UserWarning, match='Low airmass values replaced'):
-        _ = spectrum.spectral_factor_firstsolar(1, 0.1, 'monosi')
 
 
 def test_spectral_factor_firstsolar_range():
@@ -122,23 +120,11 @@ def test_spectral_factor_firstsolar_range():
                                               module_type='monosi')
     expected = np.array([0.96080878, 1.03055092, np.nan])
     assert_allclose(out, expected, atol=1e-3)
-    with pytest.warns(UserWarning, match='High precipitable water values '
-                      'replaced'):
-        out = spectrum.spectral_factor_firstsolar(6, 1.5,
-                                                  max_precipitable_water=5,
-                                                  module_type='monosi')
-    with pytest.warns(UserWarning, match='Low precipitable water values '
-                      'replaced'):
-        out = spectrum.spectral_factor_firstsolar(np.array([0, 3, 8]),
-                                                  np.array([1, 3, 5]),
-                                                  module_type='monosi')
+    out = spectrum.spectral_factor_firstsolar(np.array([0, 3, 8]),
+                                              np.array([1, 3, 5]),
+                                              module_type='monosi')
     expected = np.array([0.96080878, 1.03055092, 1.04932727])
     assert_allclose(out, expected, atol=1e-3)
-    with pytest.warns(UserWarning, match='Low precipitable water values '
-                      'replaced'):
-        out = spectrum.spectral_factor_firstsolar(0.2, 1.5,
-                                                  min_precipitable_water=1,
-                                                  module_type='monosi')
 
 
 @pytest.mark.parametrize('airmass,expected', [


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The warnings emitted from `spectral_factor_firstsolar` were taken from the MATLAB version: https://github.com/sandialabs/MATLAB_PV_LIB/blob/master/pvl_FSspeccorr.m#L113

Such warnings are not present elsewhere in pvlib-python.  I've felt for a long time that they are out of place (see e.g. https://github.com/pvlib/pvlib-python/pull/1296#discussion_r716085592 and https://github.com/pvlib/pvlib-python/pull/2072#discussion_r1627863693).  This PR proposes to remove the warnings.