### PR TITLE
Repair broken link in `get_pvgis_hourly` documentation

### DIFF
--- a/pvlib/modelchain.py
+++ b/pvlib/modelchain.py
@@ -447,7 +447,7 @@ class ModelChain:
 
         >>> pvwatts_losses = {'soiling': 2, 'shading': 3, 'snow': 0, 'mismatch': 2,
         >>>                   'wiring': 2, 'connections': 0.5, 'lid': 1.5,
-        >>>                   'nameplate_rating': 1, 'age': 0, 'availability': 3}
+        >>>                   'nameplate_rating': 1, 'age': 0, 'availability': 30}
         >>> system_with_custom_losses = pvsystem.PVSystem(
         >>>     surface_tilt=30, surface_azimuth=180,
         >>>     module_parameters=module_parameters,


### PR DESCRIPTION
 - [x] Closes #2508
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Repairs broken link in `pvlib.iotools.get_pvgis_hourly` identified #2508.