### PR TITLE
Change refraction correction limit in ephemeris solar position algorithm

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -6,6 +6,9 @@ v0.13.1 (Anticipated September, 2025)
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
+* Change refraction for solar elevation angles between 85 and 90
+  degrees to be calculated rather than set to 0 in
+  :py:func:`~pvlib.solarposition.ephemeris`. (:pull:`2524`)
 
 
 Deprecations

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -828,7 +828,7 @@ def ephemeris(time, latitude, longitude, pressure=101325.0, temperature=12.0):
     TanEl = pd.Series(np.tan(np.radians(Elevation)), index=time_utc)
     Refract = pd.Series(0., index=time_utc)
 
-    Refract[(Elevation > 5) & (Elevation <= 85)] = (
+    Refract[(Elevation > 5) & (Elevation <= 90)] = (
         58.1/TanEl - 0.07/(TanEl**3) + 8.6e-05/(TanEl**5))
 
     Refract[(Elevation > -0.575) & (Elevation <= 5)] = (

--- a/tests/test_solarposition.py
+++ b/tests/test_solarposition.py
@@ -964,3 +964,15 @@ def test_spa_python_numba_physical_dst(expected_solpos, golden):
                                               temperature=11, delta_t=67,
                                               atmos_refract=0.5667,
                                               how='numpy', numthreads=1)
+
+
+def test_ephmeris_refraction_85_90_degrees():
+    # Test that refraction is calculated rather than set to zero
+    # for solar elevatoin angles between 85 and 90 degrees
+    # PR#2524
+    # The below example has a solar elevation angle of 87.9
+    result = solarposition.ephemeris(
+        time=pd.date_range('2020-03-23 12', periods=1, tz='UTC'),
+        latitude=0, longitude=0)
+    refraction = (result['apparent_zenith'] - result['zenith']).iloc[0]
+    assert refraction == -0.0005818446332597205


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2323
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

The refraction correction used by the Sandia empheris solar position algorithm sets refraction to zero above 85 degree elevation. This limit does not seem to configured in the reference, rather is is 90 degrees. Therefore, I propose that we change this to follow the reference. The 85 degree limit may come from the NOAA solar position algorithm which claims to use the Hughes refraction algorithm although deviating slightly from the original reference.

https://github.com/pvlib/pvlib-python/blob/b1fd3f70e0f3af11789950ba07e61d5e1f64f1f6/pvlib/solarposition.py#L831-L832


## From "Engineering Astronomy" by Grver W. Hughes, Sandia Laboratories
-  Interval -0.575 to 5 is inclusive both ends

<img width="573" height="487" alt="Image" src="https://github.com/user-attachments/assets/9dcc26bb-d72c-4fe0-8ea0-9c68fffc52ad" />

## Sun-Pointing Programs and Their Accuracy - John C. Zimmerman
> Grover Hughes developed a series of equations to correct for the' refraction errors. Input data for the correction are the ground level temperature (OF) and pressure (millibars) at the observation point. The algorithm for the refraction correction is included in the latter part of Appendix D and is marked for identification.
<img width="621" height="647" alt="Image" src="https://github.com/user-attachments/assets/5fb71825-3409-4f56-8d2d-d11af0fbcdf4" />

## [NOAA](https://gml.noaa.gov/grad/solcalc/calcdetails.html)

<img width="919" height="324" alt="Image" src="https://github.com/user-attachments/assets/2af61a0e-d0d8-4028-b9ee-0524c94c6388" />
