### PR TITLE
Change delta_t dtype to numeric

### DIFF
--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -308,7 +308,7 @@ def spa_python(time, latitude, longitude,
         avg. yearly air pressure in Pascals.
     temperature : int or float, optional, default 12.0
         avg. yearly air temperature in degrees C.
-    delta_t : float or array, optional, default 67.0
+    delta_t : numeric, optional, default 67.0
         Difference between terrestrial time and UT1.
         If delta_t is None, uses spa.calculate_deltat
         using time.year and time.month from pandas.DatetimeIndex.
@@ -414,7 +414,7 @@ def sun_rise_set_transit_spa(times, latitude, longitude, how='numpy',
         Options are 'numpy' or 'numba'. If numba >= 0.17.0
         is installed, how='numba' will compile the spa functions
         to machine code and run them multithreaded.
-    delta_t : float or array, optional, default 67.0
+    delta_t : numeric, optional, default 67.0
         Difference between terrestrial time and UT1.
         If delta_t is None, uses spa.calculate_deltat
         using times.year and times.month from pandas.DatetimeIndex.


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The dtype of the ``delta_t`` parameter in the solar position algorithm should be numeric as both floats, arrays, and Series can be passed.