### PR TITLE
Adapts irradiance.isotropic to return_components framework.

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -587,7 +587,7 @@ def get_ground_diffuse(surface_tilt, ghi, albedo=.25, surface_type=None):
     return diffuse_irrad
 
 
-def isotropic(surface_tilt, dhi):
+def isotropic(surface_tilt, dhi, return_components=False):
     r'''
     Determine diffuse irradiance from the sky on a tilted surface using
     the isotropic sky model.
@@ -613,10 +613,23 @@ def isotropic(surface_tilt, dhi):
     dhi : numeric
         Diffuse horizontal irradiance. [Wm⁻²] DHI must be >=0.
 
+    return_components : bool, default False
+        Flag used to decide whether to return the calculated diffuse components
+        or not. If `False`, ``sky_diffuse`` is returned. If `True`,
+        ``diffuse_components`` is returned.
+
     Returns
     -------
-    diffuse : numeric
-        The sky diffuse component of the solar radiation.
+    poa_sky_diffuse : numeric
+        The sky diffuse component of the solar radiation on a tilted
+        surface.
+
+    diffuse_components : OrderedDict (array input) or DataFrame (Series input)
+        Keys/columns are:
+            * sky_diffuse: Total sky diffuse
+            * isotropic
+            * circumsolar
+            * horizon
 
     References
     ----------
@@ -630,9 +643,20 @@ def isotropic(surface_tilt, dhi):
        Energy vol. 201. pp. 8-12
        :doi:`10.1016/j.solener.2020.02.067`
     '''
-    sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
+    poa_sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
 
-    return sky_diffuse
+    if return_components:
+        diffuse_components = OrderedDict()
+        diffuse_components['poa_sky_diffuse'] = poa_sky_diffuse
+
+        # Calculate the different components
+        diffuse_components['poa_isotropic'] = poa_sky_diffuse
+        diffuse_components['poa_circumsolar'] = 0
+        diffuse_components['poa_horizon'] = 0
+
+        return diffuse_components
+    else:
+        return poa_sky_diffuse
 
 
 def klucher(surface_tilt, surface_azimuth, dhi, ghi, solar_zenith,
@@ -782,8 +806,9 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         or supply ``projection_ratio``.
 
     return_components : bool, default `False`
-        If `False`, ``sky_diffuse`` is returned.
-        If `True`, ``diffuse_components`` is returned.
+       Flag used to decide whether to return the calculated diffuse components
+       or not. If `False`, ``sky_diffuse`` is returned. If `True`,
+       ``diffuse_components`` is returned.
 
     Returns
     --------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -653,7 +653,7 @@ def isotropic(surface_tilt, dhi, return_components=False):
 
     if return_components:
         diffuse_components = dict()
-        
+
         # original formatting (to be deprecated in v0.14.0)
         diffuse_components['sky_diffuse'] = poa_sky_diffuse # total
         diffuse_components['isotropic'] = poa_sky_diffuse

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -649,29 +649,29 @@ def isotropic(surface_tilt, dhi, return_components=False):
        Energy vol. 201. pp. 8-12
        :doi:`10.1016/j.solener.2020.02.067`
     '''
-    poa_sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
 
+    poa_sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5    
+        
     if return_components:
-        diffuse_components = dict()
+        is_pandas = isinstance(dhi, (pd.DataFrame,pd.Series))
+        
+        if is_pandas:
+            poa_sky_diffuse = poa_sky_diffuse.values    
 
-        # original formatting (to be deprecated in v0.14.0)
-        diffuse_components['sky_diffuse'] = poa_sky_diffuse # total
-        diffuse_components['isotropic'] = poa_sky_diffuse
-        diffuse_components['circumsolar'] = 0
-        diffuse_components['horizon'] = 0
+        diffuse_components = {
+            'poa_sky_diffuse': poa_sky_diffuse,
+            'poa_isotropic': poa_sky_diffuse,
+            'poa_circumsolar': 0,
+            'poa_horizon': 0,
+            }
 
-        # new formatting
-        diffuse_components['poa_sky_diffuse'] = poa_sky_diffuse
-        diffuse_components['poa_isotropic'] = poa_sky_diffuse
-        diffuse_components['poa_circumsolar'] = 0
-        diffuse_components['poa_horizon'] = 0
-
-        if isinstance(poa_sky_diffuse, pd.Series):
-            # follows `perez` worfklow
-            # shouldn't it include an argument `index=dhi.index`?
-            diffuse_components = pd.DataFrame(diffuse_components)
-
+        poa_sky_diffuse = pd.DataFrame(poa_sky_diffuse)        
+        if is_pandas:
+            # keeps original index
+            poa_sky_diffuse.index = dhi.index
+        
         return diffuse_components
+    
     else:
         return poa_sky_diffuse
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -615,7 +615,7 @@ def isotropic(surface_tilt, dhi, return_components=False):
 
     return_components : bool, default False
         Flag used to decide whether to return the calculated diffuse components
-        or not. If `False`, ``sky_diffuse`` is returned. If `True`,
+        or not. If `False`, ``poa_sky_diffuse`` is returned. If `True`,
         ``diffuse_components`` is returned.
 
     Returns

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -624,12 +624,18 @@ def isotropic(surface_tilt, dhi, return_components=False):
         The sky diffuse component of the solar radiation on a tilted
         surface.
 
-    diffuse_components : OrderedDict (array input) or DataFrame (Series input)
+    diffuse_components : dict (array input) or DataFrame (Series input)
         Keys/columns are:
-            * sky_diffuse: Total sky diffuse
+            * sky_diffuse (the sum of the components below)
             * isotropic
             * circumsolar
             * horizon
+            * poa_sky_diffuse (the sum of the components below)
+            * poa_isotropic
+            * poa_circumsolar
+            * poa_horizon
+        The first four elements will be deprecated in v0.14.0 and are kept
+        to avoit breaking changes.
 
     References
     ----------
@@ -646,13 +652,24 @@ def isotropic(surface_tilt, dhi, return_components=False):
     poa_sky_diffuse = dhi * (1 + tools.cosd(surface_tilt)) * 0.5
 
     if return_components:
-        diffuse_components = OrderedDict()
-        diffuse_components['poa_sky_diffuse'] = poa_sky_diffuse
+        diffuse_components = dict()
+        
+        # original formatting (to be deprecated in v0.14.0)
+        diffuse_components['sky_diffuse'] = poa_sky_diffuse # total
+        diffuse_components['isotropic'] = poa_sky_diffuse
+        diffuse_components['circumsolar'] = 0
+        diffuse_components['horizon'] = 0
 
-        # Calculate the different components
+        # new formatting
+        diffuse_components['poa_sky_diffuse'] = poa_sky_diffuse
         diffuse_components['poa_isotropic'] = poa_sky_diffuse
         diffuse_components['poa_circumsolar'] = 0
         diffuse_components['poa_horizon'] = 0
+
+        if isinstance(poa_sky_diffuse, pd.Series):
+            # follows `perez` worfklow
+            # shouldn't it include an argument `index=dhi.index`?
+            diffuse_components = pd.DataFrame(diffuse_components)
 
         return diffuse_components
     else:


### PR DESCRIPTION
 - [ ] Closes #1553
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
