### PR TITLE
[DEVOPS] Deprecation warning wrapper for dict-like object renamed keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ pvlib/spa_c_files/spa.h
 pvlib/spa_c_files/spa_tester.c
 
 # generated documentation
+docs/sphinx/source/contributing/generated
 docs/sphinx/source/reference/generated
-docs/sphinx/source/reference/*/generated
 docs/sphinx/source/savefig
 docs/sphinx/source/gallery
 docs/sphinx/source/sg_execution_times.rst

--- a/docs/sphinx/source/contributing/devops.rst
+++ b/docs/sphinx/source/contributing/devops.rst
@@ -1,0 +1,73 @@
+.. _devops:
+
+Development Operations
+======================
+
+This page provides information on specific development needs found in the pvlib-python ecosystem. Some specific Python concepts may be used in this section.
+
+Deprecations
+------------
+Let's start by what is a deprecation: sometimes, a feature in the library is no longer needed because it has been superceded by better altenatives, or because better practices are considred beneficial. In this case, just doing that change (a removal, a rename) will probably be a **breaking change** for a number of users. Both developers and users desire to not get their code broken after a release in normal circumstances. There are a number of approaches to make these changes gradually, so at least there is some time in-between to warn about upcoming changes and to allow users to adapt their code.
+
+There are two ways to warn about upcoming changes:
+
+- Passively, by expecting users to read whatsnew entries, new version announcements on the mailing list, or by keeping a close eye on the repo activity.
+- Actively, via raising warnings with specific instructions when any of these deprecated features are used.
+
+While the pros for the latter are almost obvious, there is a main weakness; it imposes a number of extra steps to take and more code to maintain by the developers. This guide strives to close that gap.
+
+pvlib's submodule :py:mod:`pvlib._deprecation` has some utilities to ease the implementation of deprecations.
+
+Deprecation Warnings and Messages
+---------------------------------
+This is about the ``Exception`` that gets raised, but quickly dismished by the interpreter after logging. They automatically leave a text trace in the output buffer (console) so it can be seen by the user. In code terms, the following line raises a warning:
+
+.. code-block::
+
+    import warnings
+
+    warnings.warn("This feature is deprecated!")
+
+As a general rule, try to be concise on what the problem is and how to fix that. By default, Python will automatically inform about where the issue was found (although that can be modified, again in code terms, by setting a custom ``stacklevel`` in the warning factory).
+
+List of pvlib deprecation helpers
+---------------------------------
+
+.. py:module:: pvlib._deprecation
+
+.. currentmodule:: pvlib
+
+.. autosummary::
+   :toctree: generated/
+
+   _deprecation.deprecated
+   _deprecation.renamed_kwarg_warning
+   _deprecation.renamed_key_items_warning
+
+Know your deprecation helper
+----------------------------
+Remember to import the submodule.
+
+.. code-block::
+
+    from pvlib import _deprecation
+
+.. contents:: Table of Contents
+    :local:
+
+Deprecate a function
+~~~~~~~~~~~~~~~~~~~~
+See :py:func:`pvlib._deprecation.deprecated`.
+
+Rename keyword parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Applies both to *positional-or-keyword* parameters and *keyword-only* parameters.
+You can check out the differences at the `Python docs glossary <https://docs.python.org/3/glossary.html#term-parameter>`_.
+
+See :py:func:`pvlib._deprecation.renamed_kwarg_warning`.
+
+Rename an item from a collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For example, the key an item uses in a dictionary, the column in a ``pandas.DataFrame`` or any key-indexed object. Intended for objects returned by pvlib functions in the public API.
+
+See :py:func:`pvlib._deprecation.renamed_key_items_warning`

--- a/docs/sphinx/source/contributing/index.rst
+++ b/docs/sphinx/source/contributing/index.rst
@@ -12,3 +12,4 @@ Contributing
    how_to_contribute_new_code
    style_guide
    testing
+   devops

--- a/pvlib/_deprecation.py
+++ b/pvlib/_deprecation.py
@@ -169,14 +169,15 @@ def warn_deprecated(
         obj_type='attribute', addendum='', removal=''):
     """
     Used to display deprecation in a standard way.
+
     Parameters
     ----------
     since : str
         The release at which this API became deprecated.
     message : str, optional
         Override the default deprecation message.  The format
-        specifier `%(name)s` may be used for the name of the function,
-        and `%(alternative)s` may be used in the deprecation message
+        specifier ``%(name)s`` may be used for the name of the function,
+        and ``%(alternative)s`` may be used in the deprecation message
         to insert the name of an alternative to the deprecated
         function.  `%(obj_type)s` may be used to insert a friendly name
         for the type of object being deprecated.
@@ -198,12 +199,14 @@ def warn_deprecated(
         The object type being deprecated.
     addendum : str, optional
         Additional text appended directly to the final message.
+
     Examples
     --------
-        Basic example::
-            # To warn of the deprecation of "matplotlib.name_of_module"
-            warn_deprecated('1.4.0', name='matplotlib.name_of_module',
-                            obj_type='module')
+    Basic example:
+
+    >>> # To warn of the deprecation of "pvlib.name_of_module"
+    >>> warn_deprecated('1.4.0', name='pvlib.name_of_module',
+    >>>                 obj_type='module')
     """
     message = '\n' + _generate_deprecation_message(
         since, message, name, alternative, pending, obj_type, addendum,
@@ -217,6 +220,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                addendum='', removal=''):
     """
     Decorator to mark a function or a class as deprecated.
+
     Parameters
     ----------
     since : str
@@ -224,8 +228,8 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         required.
     message : str, optional
         Override the default deprecation message.  The format
-        specifier `%(name)s` may be used for the name of the object,
-        and `%(alternative)s` may be used in the deprecation message
+        specifier ``%(name)s`` may be used for the name of the object,
+        and ``%(alternative)s`` may be used in the deprecation message
         to insert the name of an alternative to the deprecated
         object.
     name : str, optional
@@ -234,9 +238,11 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         though this is useful in the case of renamed functions, where
         the new function is just assigned to the name of the
         deprecated function.  For example::
+
             def new_function():
                 ...
             oldFunction = new_function
+
     alternative : str, optional
         An alternative API that the user may use in place of the deprecated
         API.  The deprecation warning will tell the user about this alternative
@@ -251,12 +257,14 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         with *pending*.
     addendum : str, optional
         Additional text appended directly to the final message.
+
     Examples
     --------
-        Basic example::
-            @deprecated('1.4.0')
-            def the_function_to_deprecate():
-                pass
+    Basic example:
+
+    >>> @deprecated('1.4.0')
+    >>> def the_function_to_deprecate():
+    >>>     pass
     """
 
     def deprecate(obj, message=message, name=name, alternative=alternative,
@@ -335,7 +343,7 @@ def renamed_kwarg_warning(since, old_param_name, new_param_name, removal=""):
 
     .. note::
         Documentation for the function may updated to reflect the new parameter
-        name; it is suggested to add a |.. versionchanged::| directive.
+        name; it is suggested to add a ``.. versionchanged::`` directive.
 
     Parameters
     ----------

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -6,7 +6,6 @@ PV modules and cells.
 import numpy as np
 import pandas as pd
 from pvlib.tools import sind
-from pvlib._deprecation import warn_deprecated
 from pvlib.tools import _get_sample_intervals
 import scipy
 import scipy.constants

--- a/tests/test__deprecation.py
+++ b/tests/test__deprecation.py
@@ -3,6 +3,7 @@ Test the _deprecation module.
 """
 
 import pytest
+import pandas as pd
 
 from pvlib import _deprecation
 from .conftest import fail_on_pvlib_version
@@ -95,3 +96,65 @@ def test_renamed_kwarg_warning(renamed_kwarg_func):
         TypeError, match="missing 1 required positional argument"
     ):
         renamed_kwarg_func()
+
+
+def test_renamed_key_items_warning():
+    """Test the renamed_key_items_warning decorator."""
+    # Test on a dictionary
+    data_dict = {
+        "new_key1": [1, 2, 3],
+        "new_key2": [4, 5, 6],
+        "another_key": [7, 8, 9],
+    }
+    data_dict_wrapped = _deprecation.renamed_key_items_warning(
+        "0.1.0", {"old_key1": "new_key1"}, "0.2.0"
+    )(data_dict)
+
+    # Check that the new key is present in the wrapped object
+    assert "new_key1" in data_dict_wrapped
+    assert "new_key2" in data_dict_wrapped
+    assert "another_key" in data_dict_wrapped
+    assert "old_key1" not in data_dict_wrapped
+    # Check that the old key still exists in the wrapped object
+    assert data_dict_wrapped["new_key1"] == [1, 2, 3]
+    assert data_dict_wrapped["new_key2"] == [4, 5, 6]
+    assert data_dict_wrapped["another_key"] == [7, 8, 9]
+    with pytest.warns(Warning, match="use `new_key1` instead of `old_key1`."):
+        assert data_dict_wrapped["old_key1"] == [1, 2, 3]
+    # check yet again, to ensure there is no weird persistences
+    with pytest.warns(Warning, match="use `new_key1` instead of `old_key1`."):
+        assert data_dict_wrapped["old_key1"] == [1, 2, 3]
+
+    # Test on a DataFrame
+    data_df = pd.DataFrame(data_dict)
+    data_df = _deprecation.renamed_key_items_warning(
+        "0.1.0", {"old_key1": "new_key1", "old_key2": "new_key2"}, "0.2.0"
+    )(data_df)
+
+    assert "new_key1" in data_df.columns
+    assert data_df.new_key1 is not None  # ensure attribute access works
+    assert "new_key2" in data_df.columns
+    assert "old_key1" not in data_df.columns
+    assert "old_key2" not in data_df.columns
+    # Check that the old key still exists in the DataFrame
+    assert data_df["new_key1"].tolist() == [1, 2, 3]
+    with pytest.warns(Warning, match="use `new_key1` instead of `old_key1`."):
+        assert data_df["old_key1"].tolist() == [1, 2, 3]
+    with pytest.warns(Warning, match="use `new_key1` instead of `old_key1`."):
+        assert data_df["old_key1"].tolist() == [1, 2, 3]
+
+    # Test chaining decorators, on a dict, first new_key1, then new_key2
+    data_dict_wrapped = _deprecation.renamed_key_items_warning(
+        "0.1.0", {"old_key1": "new_key1"}, "0.2.0"
+    )(data_dict)
+    data_dict_wrapped = _deprecation.renamed_key_items_warning(
+        "0.3.0", {"old_key2": "new_key2"}, "0.4.0"
+    )(data_dict_wrapped)
+    # Check that the new keys are present in the wrapped object
+    assert "new_key1" in data_dict_wrapped
+    assert "new_key2" in data_dict_wrapped
+
+    with pytest.warns(Warning, match="use `new_key1` instead of `old_key1`."):
+        assert data_dict_wrapped["old_key1"] == [1, 2, 3]
+    with pytest.warns(Warning, match="use `new_key2` instead of `old_key2`."):
+        assert data_dict_wrapped["old_key2"] == [4, 5, 6]


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Partially helps with #2529 (see for other relevant comments, in pvlib threads)
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Threatening my mail inbox again, duh? Just kidding.

But let's give us the opportunity to make the renaming of all and any keys in returned dictionaries and dataframes be not a super, duper, user-angering, developer-exhausting, breaking change.

## Key changes that come with this PR:
- [ ] A generator function of wrappers to apply to dict-like objects.
- [ ] A bunch of tests that, if you feel can be improved, please go ahead.
- [ ] A new contributing section, Python-proficient-contributors oriented, with the `pvlib._deprecation` functions listing. I've named it devops for now.

I understand if there are objections to the new doc page. Suggestions, like whole removal, etc welcome. Just wanted to propose making the docstrings the first place to check, rather than finding past or current uses to see how to use the utilities in that deprecation submodule. I was unsure of the best fit for that, so in the contributing section it went..

Regarding, the new func / wrapper, I doubt there are no doubts. Let me know any objections, concerns, or ways to improve either the implementation or the tests, not covered by the documentation.

As always, a friendly proposal. If you want, I can also add an example of how this would look like for #2529 (quick search didn't give any useful results of other issues that may benefit from this).


### Handy links for every1
- New doc page: linking later
   - Doc page for the new utility: linking later
