### PR TITLE
Convert SPA native python loops to numpy operations

### DIFF
--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -461,8 +461,11 @@ def sum_mult_cos_add_mult(arr, x):
         for row in range(arr.shape[0]):
             s += arr[row, 0] * np.cos(arr[row, 1] + arr[row, 2] * x)
     else:
-        s = (arr[:, [0]] * np.cos(arr[:, [1]] + arr[:, [2]] * np.expand_dims(x, axis=0))).sum(axis=0)
+        s = (arr[:, [0]] * np.cos(
+            arr[:, [1]] + arr[:, [2]] * np.expand_dims(x, axis=0)
+        )).sum(axis=0)
     return s
+
 
 @jcompile('float64(float64)', nopython=True)
 def heliocentric_longitude(jme):
@@ -562,7 +565,6 @@ def moon_ascending_longitude(julian_ephemeris_century):
     nopython=True)
 def longitude_obliquity_nutation(julian_ephemeris_century, x0, x1, x2, x3, x4,
                                  out):
-    
     if USE_NUMBA:
         delta_psi_sum = 0.0
         delta_eps_sum = 0.0
@@ -594,9 +596,13 @@ def longitude_obliquity_nutation(julian_ephemeris_century, x0, x1, x2, x3, x4,
             NUTATION_YTERM_ARRAY[:, [4]]*np.expand_dims(x4, axis=0)
         )
 
-        delta_psi_sum = ((a + b * julian_ephemeris_century) * np.sin(arg)).sum(axis=0)
-        delta_eps_sum = ((c + d * julian_ephemeris_century) * np.cos(arg)).sum(axis=0)
-    
+        delta_psi_sum = (
+            (a + b * julian_ephemeris_century) * np.sin(arg)
+        ).sum(axis=0)
+        delta_eps_sum = (
+            (c + d * julian_ephemeris_century) * np.cos(arg)
+        ).sum(axis=0)
+
     delta_psi = delta_psi_sum*1.0/36000000
     delta_eps = delta_eps_sum*1.0/36000000
     # seems like we ought to be able to return a tuple here instead

--- a/pvlib/spa.py
+++ b/pvlib/spa.py
@@ -456,7 +456,12 @@ def julian_ephemeris_millennium(julian_ephemeris_century):
 @jcompile(nopython=True)
 def sum_mult_cos_add_mult(arr, x):
     # shared calculation used for heliocentric longitude, latitude, and radius
-    s = (arr[:, [0]] * np.cos(arr[:, [1]] + arr[:, [2]] * np.expand_dims(x, axis=0))).sum(axis=0)
+    if USE_NUMBA:
+        s = 0.
+        for row in range(arr.shape[0]):
+            s += arr[row, 0] * np.cos(arr[row, 1] + arr[row, 2] * x)
+    else:
+        s = (arr[:, [0]] * np.cos(arr[:, [1]] + arr[:, [2]] * np.expand_dims(x, axis=0))).sum(axis=0)
     return s
 
 @jcompile('float64(float64)', nopython=True)
@@ -557,20 +562,41 @@ def moon_ascending_longitude(julian_ephemeris_century):
     nopython=True)
 def longitude_obliquity_nutation(julian_ephemeris_century, x0, x1, x2, x3, x4,
                                  out):
-    a = NUTATION_ABCD_ARRAY[:, [0]]
-    b = NUTATION_ABCD_ARRAY[:, [1]]
-    c = NUTATION_ABCD_ARRAY[:, [2]]
-    d = NUTATION_ABCD_ARRAY[:, [3]]
-    arg = np.radians(
-        NUTATION_YTERM_ARRAY[:, [0]]*np.expand_dims(x0, axis=0) +
-        NUTATION_YTERM_ARRAY[:, [1]]*np.expand_dims(x1, axis=0) +
-        NUTATION_YTERM_ARRAY[:, [2]]*np.expand_dims(x2, axis=0) +
-        NUTATION_YTERM_ARRAY[:, [3]]*np.expand_dims(x3, axis=0) +
-        NUTATION_YTERM_ARRAY[:, [4]]*np.expand_dims(x4, axis=0)
-    )
+    
+    if USE_NUMBA:
+        delta_psi_sum = 0.0
+        delta_eps_sum = 0.0
+        for row in range(NUTATION_YTERM_ARRAY.shape[0]):
+            a = NUTATION_ABCD_ARRAY[row, 0]
+            b = NUTATION_ABCD_ARRAY[row, 1]
+            c = NUTATION_ABCD_ARRAY[row, 2]
+            d = NUTATION_ABCD_ARRAY[row, 3]
+            arg = np.radians(
+                NUTATION_YTERM_ARRAY[row, 0]*x0 +
+                NUTATION_YTERM_ARRAY[row, 1]*x1 +
+                NUTATION_YTERM_ARRAY[row, 2]*x2 +
+                NUTATION_YTERM_ARRAY[row, 3]*x3 +
+                NUTATION_YTERM_ARRAY[row, 4]*x4
+            )
+            delta_psi_sum += (a + b * julian_ephemeris_century) * np.sin(arg)
+            delta_eps_sum += (c + d * julian_ephemeris_century) * np.cos(arg)
 
-    delta_psi_sum = ((a + b * julian_ephemeris_century) * np.sin(arg)).sum(axis=0)
-    delta_eps_sum = ((c + d * julian_ephemeris_century) * np.cos(arg)).sum(axis=0)
+    else:
+        a = NUTATION_ABCD_ARRAY[:, [0]]
+        b = NUTATION_ABCD_ARRAY[:, [1]]
+        c = NUTATION_ABCD_ARRAY[:, [2]]
+        d = NUTATION_ABCD_ARRAY[:, [3]]
+        arg = np.radians(
+            NUTATION_YTERM_ARRAY[:, [0]]*np.expand_dims(x0, axis=0) +
+            NUTATION_YTERM_ARRAY[:, [1]]*np.expand_dims(x1, axis=0) +
+            NUTATION_YTERM_ARRAY[:, [2]]*np.expand_dims(x2, axis=0) +
+            NUTATION_YTERM_ARRAY[:, [3]]*np.expand_dims(x3, axis=0) +
+            NUTATION_YTERM_ARRAY[:, [4]]*np.expand_dims(x4, axis=0)
+        )
+
+        delta_psi_sum = ((a + b * julian_ephemeris_century) * np.sin(arg)).sum(axis=0)
+        delta_eps_sum = ((c + d * julian_ephemeris_century) * np.cos(arg)).sum(axis=0)
+    
     delta_psi = delta_psi_sum*1.0/36000000
     delta_eps = delta_eps_sum*1.0/36000000
     # seems like we ought to be able to return a tuple here instead


### PR DESCRIPTION
Hi, 

I'd like to make this proposal  to speed up the `"nrel_numpy"` version of `pvlib.solarposition.get_solarposition()`

In this PR I just replace some of the native python loops with numpy equivalent slicing and sums. In my local testing (using order 10 input times) I have found that this version take about 45% less time than the current version. It is also takes about 20% less time than the  current`"nrel_numba"` version. 

When I modified the `sum_mult_cos_add_mult()` and `longitude_obliquity_nutation()` functions could no longer infer the datatypes of these functions. Hence these functions now use the global `USE_NUMBA` setting. This allows numba to infer the dataypes whilst allowing the numpy version to avoid the native python loops.


 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
