### PR TITLE
Allows reading TMY data from a Path or file-like object

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.13.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.1.rst
@@ -29,6 +29,8 @@ Enhancements
   (:pull:`2500`)
 * :py:func:`pvlib.spectrum.spectral_factor_firstsolar` no longer emits warnings
   when airmass and precipitable water values fall out of range. (:pull:`2512`)
+* Allows reading TMY data from a Path or file-like object in :py:func:`~pvlib.iotools.read_tmy3`.
+  (:pull:`2544`, :ghuser:`jerluc`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/iotools/tmy.py
+++ b/pvlib/iotools/tmy.py
@@ -4,6 +4,8 @@ import datetime
 import re
 import pandas as pd
 
+from pvlib.tools import _file_context_manager
+
 # Dictionary mapping TMY3 names to pvlib names
 VARIABLE_MAP = {
     'GHI (W/m^2)': 'ghi',
@@ -22,7 +24,7 @@ VARIABLE_MAP = {
 }
 
 
-def read_tmy3(filename, coerce_year=None, map_variables=True, encoding=None):
+def read_tmy3(filename_or_obj, coerce_year=None, map_variables=True, encoding=None):
     """Read a TMY3 file into a pandas dataframe.
 
     Note that values contained in the metadata dictionary are unchanged
@@ -35,7 +37,7 @@ def read_tmy3(filename, coerce_year=None, map_variables=True, encoding=None):
 
     Parameters
     ----------
-    filename : str
+    filename_or_obj : str, Path, or file-like object
         A relative file path or absolute file path.
     coerce_year : int, optional
         If supplied, the year of the index will be set to ``coerce_year``, except
@@ -186,7 +188,7 @@ def read_tmy3(filename, coerce_year=None, map_variables=True, encoding=None):
     """  # noqa: E501
     head = ['USAF', 'Name', 'State', 'TZ', 'latitude', 'longitude', 'altitude']
 
-    with open(str(filename), 'r', encoding=encoding) as fbuf:
+    with _file_context_manager(filename_or_obj, mode="r", encoding=encoding) as fbuf:
         # header information on the 1st line (0 indexing)
         firstline = fbuf.readline()
         # use pandas to read the csv file buffer

--- a/pvlib/iotools/tmy.py
+++ b/pvlib/iotools/tmy.py
@@ -24,7 +24,7 @@ VARIABLE_MAP = {
 }
 
 
-def read_tmy3(filename_or_obj, coerce_year=None, map_variables=True, encoding=None):
+def read_tmy3(filename, coerce_year=None, map_variables=True, encoding=None):
     """Read a TMY3 file into a pandas dataframe.
 
     Note that values contained in the metadata dictionary are unchanged
@@ -37,7 +37,7 @@ def read_tmy3(filename_or_obj, coerce_year=None, map_variables=True, encoding=No
 
     Parameters
     ----------
-    filename_or_obj : str, Path, or file-like object
+    filename : str, Path, or file-like object
         A relative file path or absolute file path.
     coerce_year : int, optional
         If supplied, the year of the index will be set to ``coerce_year``, except
@@ -188,7 +188,7 @@ def read_tmy3(filename_or_obj, coerce_year=None, map_variables=True, encoding=No
     """  # noqa: E501
     head = ['USAF', 'Name', 'State', 'TZ', 'latitude', 'longitude', 'altitude']
 
-    with _file_context_manager(filename_or_obj, mode="r", encoding=encoding) as fbuf:
+    with _file_context_manager(filename, mode="r", encoding=encoding) as fbuf:
         # header information on the 1st line (0 indexing)
         firstline = fbuf.readline()
         # use pandas to read the csv file buffer

--- a/pvlib/tools.py
+++ b/pvlib/tools.py
@@ -562,7 +562,7 @@ def normalize_max2one(a):
     return res
 
 
-def _file_context_manager(filename_or_object, mode='r'):
+def _file_context_manager(filename_or_object, mode='r', encoding=None):
     """
     Open a filename/path for reading, or pass a file-like object
     through unchanged.
@@ -584,5 +584,5 @@ def _file_context_manager(filename_or_object, mode='r'):
         context = contextlib.nullcontext(filename_or_object)
     else:
         # otherwise, assume a filename or path
-        context = open(str(filename_or_object), mode=mode)
+        context = open(str(filename_or_object), mode=mode, encoding=encoding)
     return context

--- a/tests/iotools/test_tmy.py
+++ b/tests/iotools/test_tmy.py
@@ -18,6 +18,7 @@ TMY3_SOLARANYWHERE = TESTS_DATA_DIR / 'Burlington, United States SolarAnywhere T
 def test_read_tmy3():
     tmy.read_tmy3(TMY3_TESTFILE, map_variables=False)
 
+
 def test_read_tmy3_buffer():
     with open(TMY3_TESTFILE) as f:
         tmy.read_tmy3(f, map_variables=False)

--- a/tests/iotools/test_tmy.py
+++ b/tests/iotools/test_tmy.py
@@ -18,6 +18,10 @@ TMY3_SOLARANYWHERE = TESTS_DATA_DIR / 'Burlington, United States SolarAnywhere T
 def test_read_tmy3():
     tmy.read_tmy3(TMY3_TESTFILE, map_variables=False)
 
+def test_read_tmy3_buffer():
+    with open(TMY3_TESTFILE) as f:
+        tmy.read_tmy3(f, map_variables=False)
+
 
 def test_read_tmy3_norecolumn():
     data, _ = tmy.read_tmy3(TMY3_TESTFILE, map_variables=False)

--- a/tests/iotools/test_tmy.py
+++ b/tests/iotools/test_tmy.py
@@ -21,7 +21,9 @@ def test_read_tmy3():
 
 def test_read_tmy3_buffer():
     with open(TMY3_TESTFILE) as f:
-        tmy.read_tmy3(f, map_variables=False)
+        data, _ = tmy.read_tmy3(f, map_variables=False)
+        assert 'GHI source' in data.columns
+        assert len(data) == 8760
 
 
 def test_read_tmy3_norecolumn():


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Related to #2396
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Per some related discussion in #2396, this adds support for `pvlib.iotools.read_tmy3` to accept either a `str`, `PathLike`, or file-like object (text-only) as input. This patch reuses the `_file_context_manager` helper to remain consistent with how pvlib handles normalizing `str`/`PathLike`/file-like objects, while also introducing a minor backward-compatible improvement to the helper.