### PR TITLE
Update units formatting on SDM pages (°C, Wm⁻²)

### DIFF
--- a/pvlib/ivtools/sdm/cec.py
+++ b/pvlib/ivtools/sdm/cec.py
@@ -27,7 +27,7 @@ def fit_cec_sam(celltype, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc,
     cells_in_series : int
         Number of cells in series
     temp_ref : float, default 25
-        Reference temperature condition [C]
+        Reference temperature condition, [°C]
 
     Returns
     -------

--- a/pvlib/ivtools/sdm/desoto.py
+++ b/pvlib/ivtools/sdm/desoto.py
@@ -58,7 +58,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
     dEgdT: float, default -0.0002677 - value for silicon
         Variation of bandgap according to temperature. [1/K]
     temp_ref: float, default 25
-        Reference temperature condition. [C]
+        Reference temperature condition. [°C]
     irrad_ref: float, default 1000
         Reference irradiance condition. [Wm⁻²]
     init_guess: dict, optional
@@ -93,7 +93,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
         irrad_ref: float
             Reference irradiance condition. [Wm⁻²]
         temp_ref: float
-            Reference temperature condition. [C]
+            Reference temperature condition. [°C]
 
     scipy.optimize.OptimizeResult
         Optimization result of scipy.optimize.root().
@@ -110,7 +110,7 @@ def fit_desoto(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, cells_in_series,
     """
 
     # Constants
-    k = constants.value('Boltzmann constant in eV/K')  # in eV/K
+    k = constants.value('Boltzmann constant in eV/K')
     Tref = temp_ref + 273.15  # [K]
 
     # initial guesses of variables for computing convergence:
@@ -234,7 +234,7 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
             effective irradiance for each IV curve, i.e., POA broadband
             irradiance adjusted by solar spectrum modifier [W / m^2]
         tc : array
-            cell temperature for each IV curve [C]
+            cell temperature for each IV curve. [°C]
         i_sc : array
             short circuit current for each IV curve [A]
         v_oc : array
@@ -254,9 +254,9 @@ def fit_desoto_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
 
     const : dict
         E0 : float
-            effective irradiance at STC, default 1000 [W/m^2]
+            effective irradiance at STC, default 1000 [Wm⁻²]
         T0 : float
-            cell temperature at STC, default 25 [C]
+            cell temperature at STC, default 25°C. [°C]
         k : float
             Boltzmann's constant [J/K]
         q : float

--- a/pvlib/ivtools/sdm/pvsyst.py
+++ b/pvlib/ivtools/sdm/pvsyst.py
@@ -38,7 +38,7 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
             effective irradiance for each IV curve, i.e., POA broadband
             irradiance adjusted by solar spectrum modifier [W / m^2]
         tc : array
-            cell temperature for each IV curve [C]
+            cell temperature for each IV curve [°C]
         i_sc : array
             short circuit current for each IV curve [A]
         v_oc : array
@@ -56,9 +56,9 @@ def fit_pvsyst_sandia(ivcurves, specs, const=None, maxiter=5, eps1=1.e-3):
 
     const : dict
         E0 : float
-            effective irradiance at STC, default 1000 [W/m^2]
+            effective irradiance at STC, default 1000 [Wm⁻²]
         T0 : float
-            cell temperature at STC, default 25 [C]
+            cell temperature at STC, default 25°C. [°C]
         k : float
             Boltzmann's constant [J/K]
         q : float
@@ -272,10 +272,10 @@ def pvsyst_temperature_coeff(alpha_sc, gamma_ref, mu_gamma, I_L_ref, I_o_ref,
         Default of 1.121 eV is for crystalline silicon. Must be positive. [eV]
 
     irrad_ref : float, default 1000
-        Reference irradiance. [W/m^2].
+        Reference irradiance. [Wm⁻²].
 
     temp_ref : float, default 25
-        Reference cell temperature. [C]
+        Reference cell temperature. [°C]
 
 
     Returns
@@ -327,7 +327,7 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     effective_irradiance : array
         Effective irradiance for each test condition [W/m²]
     temp_cell : array
-        Cell temperature for each test condition [C]
+        Cell temperature for each test condition. [°C]
     i_sc : array
         Short circuit current for each test condition [A]
     v_oc : array
@@ -366,7 +366,7 @@ def fit_pvsyst_iec61853_sandia_2025(effective_irradiance, temp_cell,
     temperature_tolerance : float, default 1
         Tolerance for temperature variation around the STC value.
         The default value corresponds to a +/- 1 degree interval around the STC
-        value of 25 degrees. [C]
+        value of 25°C. [°C]
 
     Returns
     -------


### PR DESCRIPTION
Just a quick one to update the formatting of (and correct some) units on a couple of the ivtools SDM pages.

 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] ~Tests added~
 - [ ] ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.
