### PR TITLE
publish.yml: use trusted publishing instead of API token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish distributions to PyPI
+name: Package build
 
 on:
   pull_request:


### PR DESCRIPTION
 - [x] Closes #2511
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This guide is helpful: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

I also separated the PyPI publishing portion to a separate job.  This is so that the additional permissions required for Trusted Publishing are only accessible to the actual upload, not the build steps (which run often, on PRs).  With separate steps, the dist files have to be stored as artifacts.  I think that will also make them accessible for manual download as a job output if desired, which might be handy someday.