### PR TITLE
Fix quote characters in pytest GH Actions

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -103,7 +103,7 @@ jobs:
         run: pytest tests/iotools --cov=./ --cov-report=xml --remote-data
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == "3.10" && matrix.suffix == ''
+        if: matrix.python-version == '3.10' && matrix.suffix == ''
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,7 +83,7 @@ jobs:
           pytest tests --cov=./ --cov-report=xml --ignore=tests/iotools
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == "3.10" && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
+        if: matrix.python-version == '3.10' && matrix.suffix == '' && matrix.os == 'ubuntu-latest' && matrix.environment-type == 'conda'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
I accidentally used double quotation mark characters in #2547.  It seems that single quotation mark characters are required for the job to run.  My bad!