### PR TITLE
Fix meteonorm tests for older pandas versions

### DIFF
--- a/pvlib/iotools/meteonorm.py
+++ b/pvlib/iotools/meteonorm.py
@@ -532,6 +532,8 @@ def _get_meteonorm(
 
     # Check for None type in case of TMY request
     # Check for DateParseError in case of relative times, e.g., '+3hours'
+    # TODO: remove ValueError when our minimum pandas version is high enough
+    # to make it unnecessary (2.0?)
     if (start is not None) & (start != 'now'):
         try:
             start = pd.Timestamp(start)


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Evaluating `pd.Timestamp('+3hours')` produces different Exception types depending on the pandas version:
- pandas 1.5.3: `ValueError: could not convert string to Timestamp`
- pandas 2.3.0: `DateParseError: Unknown datetime string format, unable to parse: +3hours`

The meteonorm functions assume the latter.  This PR makes it work for both types.