### PR TITLE
Add whatsnew file for v0.13.2

### DIFF
--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.13.2.rst
 .. include:: whatsnew/v0.13.1.rst
 .. include:: whatsnew/v0.13.0.rst
 .. include:: whatsnew/v0.12.0.rst

--- a/docs/sphinx/source/whatsnew/v0.13.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.2.rst
@@ -1,0 +1,45 @@
+.. _whatsnew_0_13_2:
+
+
+v0.13.2 (Anticipated December, 2025)
+------------------------------------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Benchmarking
+~~~~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Maintenance
+~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+


### PR DESCRIPTION
Following our [release procedure](https://github.com/pvlib/pvlib-python/wiki/Release-procedures), this PR adds and links the what's new file for the next release (anticipated in December 2025).