### PR TITLE
Add note in Hay-Davies model that horizon component is zero

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -796,7 +796,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
             * sky_diffuse: Total sky diffuse
             * isotropic
             * circumsolar
-            * horizon
+            * horizon (always zero, not accounted for by the Hay-Davies model)
 
     Notes
     ------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

I had some students ask why the Hay-Davies transposition model outputs a horizon component, when it's not part of the model. We of course do this to standardize the outputs from the various transposition models, but I think it would be helpful to note in the Hay-Davies documentation that the horizon component is always zero as it's not part of the model.

