### PR TITLE
Add documentation section on reverse transposition

### DIFF
--- a/docs/sphinx/source/reference/irradiance/decomposition.rst
+++ b/docs/sphinx/source/reference/irradiance/decomposition.rst
@@ -16,6 +16,4 @@ DNI estimation models
    irradiance.orgill_hollands
    irradiance.boland
    irradiance.campbell_norman
-   irradiance.gti_dirint
    irradiance.louche
-

--- a/docs/sphinx/source/reference/irradiance/index.rst
+++ b/docs/sphinx/source/reference/irradiance/index.rst
@@ -9,6 +9,7 @@ Irradiance
    class-methods
    components
    transposition
+   reverse-transposition
    decomposition
    clearness-index
    albedo

--- a/docs/sphinx/source/reference/irradiance/reverse-transposition.rst
+++ b/docs/sphinx/source/reference/irradiance/reverse-transposition.rst
@@ -1,0 +1,10 @@
+.. currentmodule:: pvlib
+
+Reverse transposition models
+----------------------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   irradiance.ghi_from_poa_driesse_2023
+   irradiance.gti_dirint

--- a/docs/sphinx/source/reference/irradiance/transposition.rst
+++ b/docs/sphinx/source/reference/irradiance/transposition.rst
@@ -15,4 +15,3 @@ Transposition models
    irradiance.klucher
    irradiance.reindl
    irradiance.king
-   irradiance.ghi_from_poa_driesse_2023


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
pvlib has two models for reverse transposition, i.e., estimating GHI from POA. The two models are currently listed in different parts of the documentation:
- DNI estimation models <- [pvlib.irradiance.gti_dirint](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.gti_dirint.html)
- Transposition models <- [irradiance.ghi_from_poa_driesse_2023](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.ghi_from_poa_driesse_2023.html#pvlib.irradiance.ghi_from_poa_driesse_2023)

In this PR, I propose to add a new subsection under the Irradiance documentation section called "Reverse transposition".

In any case, it seems that these two models should be in the same part of the documentation.