### PR TITLE
Rename DNI Estimation Models to Decomposition Models

### DIFF
--- a/docs/sphinx/source/reference/irradiance/decomposition.rst
+++ b/docs/sphinx/source/reference/irradiance/decomposition.rst
@@ -2,8 +2,8 @@
 
 .. _dniestmodels:
 
-DNI estimation models
----------------------
+Decomposition models
+--------------------
 
 .. autosummary::
    :toctree: ../generated/


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

Many of the irradiance models in the documentation section "DNI Estimation Models" do not estimate DNI, but rather estimate diffuse fraction/diffuse irradiance (DHI). In PVsystem, the types of models are called "[Diffuse Irradiance Models](https://www.pvsyst.com/help/physical-models-used/irradiation-models/diffuse-irradiance-model.html)".

With this PR, I suggest changing the title of the documentation subsection to "Decomposition Models" instead of "DNI Estimation Models".