### PR TITLE
Simplify/DRY some infinite_sheds/bifacial.utils calculations

### DIFF
--- a/pvlib/bifacial/utils.py
+++ b/pvlib/bifacial/utils.py
@@ -37,8 +37,8 @@ def _solar_projection_tangent(solar_zenith, solar_azimuth, surface_azimuth):
     return tan_phi
 
 
-def _unshaded_ground_fraction(surface_tilt, surface_azimuth, solar_zenith,
-                              solar_azimuth, gcr, max_zenith=87):
+def _unshaded_ground_fraction(surface_tilt, tan_phi, gcr,
+                              solar_zenith, max_zenith=87):
     r"""
     Calculate the fraction of the ground with incident direct irradiance.
 
@@ -56,16 +56,14 @@ def _unshaded_ground_fraction(surface_tilt, surface_azimuth, solar_zenith,
         Surface tilt angle. The tilt angle is defined as
         degrees from horizontal, e.g., surface facing up = 0, surface facing
         horizon = 90. [degree]
-    surface_azimuth : numeric
-        Azimuth of the module surface, i.e., North=0, East=90, South=180,
-        West=270. [degree]
-    solar_zenith : numeric
-        Solar zenith angle. [degree].
-    solar_azimuth : numeric
-        Solar azimuth. [degree].
+    tan_phi : numeric
+        Tangent of the angle between vertical and the projection of the
+        sun direction onto the YZ plane. [unitless]
     gcr : float
         Ground coverage ratio, which is the ratio of row slant length to row
         spacing (pitch). [unitless]
+    solar_zenith : numeric
+        Solar zenith angle. [degree].
     max_zenith : numeric, default 87
         Maximum zenith angle. For solar_zenith > max_zenith, unshaded ground
         fraction is set to 0. [degree]
@@ -83,8 +81,6 @@ def _unshaded_ground_fraction(surface_tilt, surface_azimuth, solar_zenith,
        Photovoltaic Specialists Conference (PVSC), 2019, pp. 1282-1287.
        :doi:`10.1109/PVSC40753.2019.8980572`.
     """
-    tan_phi = _solar_projection_tangent(solar_zenith, solar_azimuth,
-                                        surface_azimuth)
     f_gnd_beam = 1.0 - np.minimum(
         1.0, gcr * np.abs(cosd(surface_tilt) + sind(surface_tilt) * tan_phi))
     # [1], Eq. 4

--- a/tests/bifacial/test_infinite_sheds.py
+++ b/tests/bifacial/test_infinite_sheds.py
@@ -60,20 +60,21 @@ def test__poa_ground_shadows():
 
 
 def test__shaded_fraction_floats():
+    # inputs correspond to solar_zenith=60, surface_azimuth=solar_azimuth=180
     result = infinite_sheds._shaded_fraction(
-        solar_zenith=60., solar_azimuth=180., surface_tilt=60.,
-        surface_azimuth=180., gcr=1.0)
+        surface_tilt=60., tan_phi=np.sqrt(3), aoi=0, gcr=1.0)
     assert np.isclose(result, 0.5)
 
 
 def test__shaded_fraction_array():
-    solar_zenith = np.array([0., 60., 90., 60.])
-    solar_azimuth = np.array([180., 180., 180., 180.])
-    surface_azimuth = np.array([180., 180., 180., 210.])
+    #solar_zenith = np.array([0., 60., 90., 60.])
+    #solar_azimuth = np.array([180., 180., 180., 180.])
+    #surface_azimuth = np.array([180., 180., 180., 210.])
     surface_tilt = np.array([30., 60., 0., 30.])
+    aoi = np.array([30, 0, 90, 36.09778103])
+    tan_phi = np.array([0, np.sqrt(3), 1e10, 1.5])
     gcr = 1.0
-    result = infinite_sheds._shaded_fraction(
-        solar_zenith, solar_azimuth, surface_tilt, surface_azimuth, gcr)
+    result = infinite_sheds._shaded_fraction(surface_tilt, tan_phi, aoi, gcr)
     x = 0.75 + np.sqrt(3) / 2
     expected = np.array([0.0, 0.5, 0., (x - 1) / x])
     assert np.allclose(result, expected)

--- a/tests/bifacial/test_utils.py
+++ b/tests/bifacial/test_utils.py
@@ -53,29 +53,27 @@ def test__solar_projection_tangent():
 
 
 @pytest.mark.parametrize(
-    "gcr,surface_tilt,surface_azimuth,solar_zenith,solar_azimuth,expected",
-    [(0.5, 0., 180., 0., 180., 0.5),
-     (1.0, 0., 180., 0., 180., 0.0),
-     (1.0, 90., 180., 0., 180., 1.0),
-     (0.5, 45., 180., 45., 270., 1.0 - np.sqrt(2) / 4),
-     (0.5, 45., 180., 90., 180., 0.),
-     (np.sqrt(2) / 2, 45, 180, 0, 180, 0.5),
-     (np.sqrt(2) / 2, 45, 180, 45, 180, 0.0),
-     (np.sqrt(2) / 2, 45, 180, 45, 90, 0.5),
-     (np.sqrt(2) / 2, 45, 180, 45, 0, 1.0),
-     (np.sqrt(2) / 2, 45, 180, 45, 135, 0.5 * (1 - np.sqrt(2) / 2)),
+    "gcr,surface_tilt,tan_phi,solar_zenith,expected",
+    [(0.5, 0., 0., 0., 0.5),
+     (1.0, 0., 0., 0., 0.0),
+     (1.0, 90., 0., 0., 1.0),
+     (0.5, 45., 0., 45., 1.0 - np.sqrt(2) / 4),
+     (0.5, 45., 1e10, 90., 0.),
+     (np.sqrt(2) / 2, 45, 0, 0, 0.5),
+     (np.sqrt(2) / 2, 45, 1, 45, 0.0),
+     (np.sqrt(2) / 2, 45, 0, 45, 0.5),
+     (np.sqrt(2) / 2, 45, -1, 45, 1.0),
+     (np.sqrt(2) / 2, 45, np.sqrt(2) / 2, 45, 0.5 * (1 - np.sqrt(2) / 2)),
      ])
 def test__unshaded_ground_fraction(
-        surface_tilt, surface_azimuth, solar_zenith, solar_azimuth, gcr,
-        expected):
+        surface_tilt, tan_phi, solar_zenith, gcr, expected):
     # frontside, same for both sides
     f_sky_beam_f = utils._unshaded_ground_fraction(
-        surface_tilt, surface_azimuth, solar_zenith, solar_azimuth, gcr)
+        surface_tilt, tan_phi, gcr, solar_zenith)
     assert np.allclose(f_sky_beam_f, expected)
     # backside, should be the same as frontside
     f_sky_beam_b = utils._unshaded_ground_fraction(
-        180. - surface_tilt, surface_azimuth - 180., solar_zenith,
-        solar_azimuth, gcr)
+        180. - surface_tilt, -tan_phi, gcr, solar_zenith)
     assert np.allclose(f_sky_beam_b, expected)
 
 
@@ -161,7 +159,7 @@ def test_vf_row_ground_2d(test_system_fixed_tilt):
     assert np.allclose(vf, expected)
 
 
-def test_vf_ground_2d_integ(test_system_fixed_tilt):
+def test_vf_row_ground_2d_integ(test_system_fixed_tilt):
     ts, _, _ = test_system_fixed_tilt
     # with float input, check end position
     with np.errstate(invalid='ignore'):


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Projected solar zenith angle (`tan_phi`) is calculated several times in the `infinite_sheds` workflow.  This PR calculates it once and passes it around, simplifying the relevant utility functions and their signatures.

For context, this is a step towards future enhancements I intend to make to `pvlib.bifacial`, which would benefit from working with `tan_phi` instead of the base solar position and module angles.