### PR TITLE
Add location class functions to location documentation section

### DIFF
--- a/docs/sphinx/source/reference/location.rst
+++ b/docs/sphinx/source/reference/location.rst
@@ -18,6 +18,7 @@ Classes
    location.Location
 A :py:class:`~pvlib.location.Location` object may be created from the
 metadata returned by these file types:
+
 .. autosummary::
    :toctree: generated/
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The location section of the documentation currently only list one function. As a user I would like to see all the possible functions that can be used with a location object in this section of the documentation.

Therefore, this PR adds the various location object functions to to the location documentation section. Note that these functions are already included in other parts of the documentation (e.g., ``pvlib.location.Location.get_solarposition`` is included in the solar position doc section), but we have a history of including functions in two places where it makes sense.