### PR TITLE
Add ECMWF CDS and EarthData API keys to `pytest-remote-data.yml`

### DIFF
--- a/.github/workflows/pytest-remote-data.yml
+++ b/.github/workflows/pytest-remote-data.yml
@@ -100,6 +100,9 @@ jobs:
           SOLARANYWHERE_API_KEY: ${{ secrets.SOLARANYWHERE_API_KEY }}
           BSRN_FTP_USERNAME: ${{ secrets.BSRN_FTP_USERNAME }}
           BSRN_FTP_PASSWORD: ${{ secrets.BSRN_FTP_PASSWORD }}
+          ECMWF_API_KEY: ${{ secrets.ECMWF_API_KEY }}
+          EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+          EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: pytest tests/iotools --cov=./ --cov-report=xml --remote-data
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Similar to #1531, this makes new GitHub Secrets available to the pytest remote-data workflow.  This must be done separately from the PRs that want to use the secrets (#2572, #2573) because (quoting https://github.com/pvlib/pvlib-python/pull/1497#issuecomment-1217214190):

> I think it is just the annoying but secure behavior of pull-request-target not respecting yml changes in the PR -- your update to include the SA key in the environment isn't taking effect because the action is defined by the .github/workflows/pytest-remote-data.yml file on master, not this PR branch. I guess the cleanest workaround is to submit a separate PR to change pytest-remote-data.yml, merge that, then merge master into this PR?

