### PR TITLE
add modules_per_string to cec_dc_adr_ac_system test fixture

### DIFF
--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -139,7 +139,8 @@ def cec_dc_adr_ac_system(sam_data, cec_module_cs5p_220m,
                       module=module_parameters['Name'],
                       module_parameters=module_parameters,
                       temperature_model_parameters=temp_model_params,
-                      inverter_parameters=inverter)
+                      inverter_parameters=inverter,
+                      modules_per_string=14)
     return system
 
 


### PR DESCRIPTION
 - ~~[ ] Closes #xxxx~~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~~[ ] Tests added~~
 - ~~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - ~~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Corrects a test fixture used for the `adr` inverter model. The `cec_dc_adr_ac_system` fixture had a single 220W module paired with a 3kW inverter. The `adr` function returned `nan` for some valid input, due to unreasonably low DC:AC ratio.