### PR TITLE
Fix meteonorm tests

### DIFF
--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -72,9 +72,9 @@ def expected_meteonorm_data():
         [0.0, 0.0],
         [0.0, 0.0],
         [2.5, 2.68],
-        [77.5, 77.47],
-        [165.0, 164.98],
-        [210.75, 210.74],
+        [77.5, 77.48],
+        [165.0, 164.99],
+        [210.75, 210.75],
         [221.0, 220.99],
     ]
     index = pd.date_range('2023-01-01 00:30', periods=12, freq='1h', tz='UTC')
@@ -207,7 +207,7 @@ def test_get_meteonorm_custom_horizon(demo_api_key, demo_url):
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_meteonorm_forecast_HTTPError(demo_api_key, demo_url):
     with pytest.raises(
-            HTTPError, match="unknown parameter: not_a_real_parameter"):
+            HTTPError, match='invalid parameter "not_a_real_parameter"'):
         _ = pvlib.iotools.get_meteonorm_forecast_basic(
             latitude=50, longitude=10,
             start=pd.Timestamp.now(tz='UTC'),
@@ -265,9 +265,9 @@ def expected_meteonorm_tmy_data():
         [0.],
         [0.],
         [0.],
-        [9.06],
-        [8.43],
-        [86.63],
+        [9.07],
+        [8.44],
+        [86.64],
         [110.44],
     ]
     index = pd.date_range(


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The meteonorm tests have been failing for a week or two because a few API responses changed slightly.  Fingers crossed it remains stable now?

FYI @maschwanden
