### PR TITLE
Deprecate `sky_diffuse_passias` and amend `plot_passias_diffuse_shading.py` gallery example

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.13.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.13.2.rst
@@ -10,6 +10,8 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
+* Deprecate :py:func:`~pvlib.shading.sky_diffuse_passias` in favor of
+:py:func:`~pvlib.bifacial.utils.vf_row_sky_2d_integ`. (:pull:`2584`)
 
 
 Bug fixes
@@ -33,7 +35,7 @@ Enhancements
 Documentation
 ~~~~~~~~~~~~~
 * Provide an overview of single-diode modeling functionality in :ref:`singlediode`. (:pull:`2565`)
-
+* Update gallery example of modeling diffuse shading loss with correct usage. (:pull:`2584`)
 
 Testing
 ~~~~~~~

--- a/pvlib/shading.py
+++ b/pvlib/shading.py
@@ -5,6 +5,8 @@ associated effects on PV module output
 
 import numpy as np
 import pandas as pd
+
+from pvlib._deprecation import deprecated
 from pvlib.tools import sind, cosd
 
 
@@ -126,6 +128,7 @@ def masking_angle_passias(surface_tilt, gcr):
     --------
     masking_angle
     sky_diffuse_passias
+    bifacial.utils.vf_row_sky_2d_integ
 
     Notes
     -----
@@ -191,6 +194,12 @@ def masking_angle_passias(surface_tilt, gcr):
     return np.degrees(psi_avg)
 
 
+@deprecated(
+    "0.13.2",
+    pending=True,
+    alternative="bifacial.utils.vf_row_sky_2d_integ",
+    addendum="See also the 'Diffuse Self-Shading' Example in the Gallery.",
+)
 def sky_diffuse_passias(masking_angle):
     r"""
     The diffuse irradiance loss caused by row-to-row sky diffuse shading.
@@ -198,10 +207,11 @@ def sky_diffuse_passias(masking_angle):
     Even when the sun is high in the sky, a row's view of the sky dome will
     be partially blocked by the row in front. This causes a reduction in the
     diffuse irradiance incident on the module. The reduction depends on the
-    masking angle, the elevation angle from a point on the shaded module to
-    the top of the shading row. In [1]_ the masking angle is calculated as
-    the average across the module height. SAM assumes the "worst-case" loss
-    where the masking angle is calculated for the bottom of the array [2]_.
+    masking angle, the surface tilt and the elevation angle from a point on
+    the shaded module to the top of the shading row. In [1]_ the masking
+    angle is calculated as the average across the module height. SAM assumes
+    the "worst-case" loss where the masking angle is calculated for the
+    bottom of the array [2]_.
 
     This function, as in [1]_, makes the assumption that sky diffuse
     irradiance is isotropic.
@@ -209,8 +219,8 @@ def sky_diffuse_passias(masking_angle):
     Parameters
     ----------
     masking_angle : numeric
-        The elevation angle below which diffuse irradiance is blocked
-        [degrees].
+        The sum of the surface tilt and the elevation angle below which
+        diffuse irradiance is blocked [degrees].
 
     Returns
     -------
@@ -221,6 +231,7 @@ def sky_diffuse_passias(masking_angle):
     --------
     masking_angle
     masking_angle_passias
+    bifacial.utils.vf_row_sky_2d_integ
 
     References
     ----------


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2584
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] ~~Tests added~~
 - [ ] ~~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] ~~New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
