### PR TITLE
Denote Faiman default coefficients are for module temperature

### DIFF
--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -539,14 +539,14 @@ def faiman_rad(poa_global, temp_air, wind_speed=1.0, ir_down=None,
         surface. [W/m^2]
 
     u0 : numeric, default 25.0
-        Combined heat loss factor coefficient. The default value is one
-        determined by Faiman for 7 silicon modules
+        Combined heat loss factor coefficient. The default value is for module
+        temperature determined by Faiman for 7 silicon modules
         in the Negev desert on an open rack at 30.9° tilt.
         :math:`\left[\frac{\text{W}/{\text{m}^2}}{\text{C}}\right]`
 
     u1 : numeric, default 6.84
-        Combined heat loss factor influenced by wind. The default value is one
-        determined by Faiman for 7 silicon modules
+        Combined heat loss factor influenced by wind. The default value is for
+        module temperature determined by Faiman for 7 silicon modules
         in the Negev desert on an open rack at 30.9° tilt.
         :math:`\left[ \frac{\text{W}/\text{m}^2}{\text{C}\ \left( \text{m/s} \right)} \right]`
 

--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -456,14 +456,14 @@ def faiman(poa_global, temp_air, wind_speed=1.0, u0=25.0, u1=6.84):
         speed at module height used to determine NOCT. [m/s]
 
     u0 : numeric, default 25.0
-        Combined heat loss factor coefficient. The default value is one
-        determined by Faiman for 7 silicon modules
+        Combined heat loss factor coefficient. The default value is for module
+        temperature determined by Faiman for 7 silicon modules
         in the Negev desert on an open rack at 30.9° tilt.
         :math:`\left[\frac{\text{W}/{\text{m}^2}}{\text{C}}\right]`
 
     u1 : numeric, default 6.84
-        Combined heat loss factor influenced by wind. The default value is one
-        determined by Faiman for 7 silicon modules
+        Combined heat loss factor influenced by wind. The default value is
+        for module temperature determined by Faiman for 7 silicon modules
         in the Negev desert on an open rack at 30.9° tilt.
         :math:`\left[ \frac{\text{W}/\text{m}^2}{\text{C}\ \left( \text{m/s} \right)} \right]`
 


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.



Based on [Faiman's publication](https://doi.org/10.1002/pip.813), the default coefficients are for calculating module temperature (and not cell). This was added in the docstring as a comment.

Note that this is true for both `pvlib.temperature.faiman` and `pvlib.temperature.faiman_rad`