### PR TITLE
Add longwave_down to ERA5 variable map

### DIFF
--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -12,6 +12,7 @@ VARIABLE_MAP = {
     'sp': 'pressure',
     'ssrd': 'ghi',
     'tp': 'precipitation',
+    'strd': 'longwave_down',
 
     # long names
     '2m_dewpoint_temperature': 'temp_dew',
@@ -19,6 +20,7 @@ VARIABLE_MAP = {
     'surface_pressure': 'pressure',
     'surface_solar_radiation_downwards': 'ghi',
     'total_precipitation': 'precipitation',
+    'surface_thermal_radiation_downwards': 'longwave_down',
 }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
Adding the longwave downwelling irradiance to the ERA5 variable map. This is not a breaking change as the ERA5 function has not been publicly released yet.

<img width="315" height="342" alt="image" src="https://github.com/user-attachments/assets/826ba683-f7f7-46fe-8d15-d76cca76cffd" />
