### PR TITLE
Fix Fuentes int input truncation by forcing float dtype

### DIFF
--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -884,7 +884,7 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
     windmod_array = wind_speed * (module_height/wind_height)**0.2 + 1e-4
 
     tmod0 = 293.15
-    tmod_array = np.zeros_like(poa_global)
+    tmod_array = np.zeros_like(poa_global, dtype = float)
 
     iterator = zip(tamb_array, sun_array, windmod_array, tsky_array,
                    timedelta_hours)

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -260,6 +260,21 @@ def test_fuentes(filename, inoct):
     assert night_difference.max() < 6
     assert night_difference.min() > 0
 
+def test_fuentes_int_float_consistency():
+    """Test that int and float inputs give identical results after dtype fix."""
+    index = pd.date_range('2020-01-01', periods=3, freq='h')
+    
+    poa_int = pd.Series([800, 800, 800], index=index, dtype=int)
+    poa_float = pd.Series([800.0, 800.0, 800.0], index=index)
+    temp_air = pd.Series([25.0, 25.0, 25.0], index=index)
+    wind_speed = pd.Series([1.0, 1.0, 1.0], index=index)
+    
+    out_int = temperature.fuentes(poa_int, temp_air, wind_speed, noct_installed=45)
+    out_float = temperature.fuentes(poa_float, temp_air, wind_speed, noct_installed=45)
+    
+    # Check outputs are identical within floating-point tolerance
+    pd.testing.assert_series_equal(out_int, out_float, check_exact=False, rtol=1e-10)
+
 
 @pytest.mark.parametrize('tz', [None, 'Etc/GMT+5'])
 def test_fuentes_timezone(tz):


### PR DESCRIPTION
Closes #2608 

## Summary

This PR fixes a dtype-dependent bug in `pvlib.temperature.fuentes` where integer `poa_global` inputs could lead to truncated module temperatures and slightly different results compared to float inputs with the same numeric values.

## Changes

- In `pvlib.temperature.fuentes`:
  - Changed `tmod_array = np.zeros_like(poa_global)` to `tmod_array = np.zeros_like(poa_global, dtype=float)` so internal temperature calculations always use a float dtype.

- In `tests/test_temperature.py`:
  - Added `test_fuentes_int_float_consistency`, which calls `fuentes` with both integer and float `poa_global` series (same values, datetime index) and asserts that the results match within floating-point tolerance.

## Rationale

Previously, when `poa_global` was an integer Series, `tmod_array` was also integer, so intermediate temperatures such as `321.19 K` were truncated to `321` when stored. Converting to Celsius (`tmod_array - 273.15`) produced a different value than for float inputs.

This change ensures that physically identical inputs (`100` vs `100.0`) produce identical Fuentes outputs.

## Testing

- `pytest tests/test_temperature.py::test_fuentes -v`
- `pytest tests/test_temperature.py::test_fuentes_int_float_consistency -v`
