### PR TITLE
Update fuentes function to ensure floating-point dtype for temperatur…

### DIFF
--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -883,7 +883,9 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
     windmod_array = wind_speed * (module_height/wind_height)**0.2 + 1e-4
 
     tmod0 = 293.15
-    tmod_array = np.zeros_like(poa_global)
+    # ensure floating dtype so intermediate values aren't truncated when the
+    # inputs are integer-typed (see GH-2608)
+    tmod_array = np.zeros_like(poa_global, dtype=float)
 
     iterator = zip(tamb_array, sun_array, windmod_array, tsky_array,
                    timedelta_hours)

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -271,8 +271,10 @@ def test_fuentes_timezone(tz):
     out = temperature.fuentes(df['poa_global'], df['temp_air'],
                               df['wind_speed'], noct_installed=45)
 
-    assert_series_equal(out, pd.Series([47.85, 50.85, 50.85], index=index,
-                                       name='tmod'))
+    expected = pd.Series([48.04184255985865, 51.84547131312195,
+                          51.846427911242756],
+                         index=index, name='tmod')
+    assert_series_equal(out, expected)
 
 
 def test_noct_sam():


### PR DESCRIPTION
Initialize tmod_array with dtype=float in temperature.fuentes to avoid integer truncation when inputs are integer-typed.
Update test_fuentes_timezone expected outputs to the correct float values.

[x] Closes #2618 
[x] I am familiar with the contributing guidelines
[ ] Tests added (no new tests; we updated existing expectations)
[ ] Updates entries in docs reference (none needed; no API change)
[ ] Adds description/name in whatsnew (optional; could add a short note under bug fixes)
[x] New code is fully documented (no new API; inline comment added for dtype reason)
[x] Pull request is nearly complete and ready for detailed review
[ ] Maintainer labels/milestone (for maintainers)
Tests
python -m pytest tests/test_temperature.py -k fuente