### PR TITLE
Fix typo in GitHub username: solphie → sophie

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.12.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.12.0.rst
@@ -94,7 +94,7 @@ Contributors
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
 * Ioannis Sifnaios (:ghuser:`IoannisSifnaios`)
 * Will Holmgren (:ghuser:`wholmgren`)
-* Sophie Pelland (:ghuser:`solphie-pelland`)
+* Sophie Pelland (:ghuser:`sophie-pelland`)
 * Will Hobbs (:ghuser:`williamhobbs`)
 * Karel De Brabandere (:ghuser:`kdebrab`)
 * Kenneth J. Sauer (:ghuser:`kjsauer`)


### PR DESCRIPTION
### Fix typo in contributor GitHub username

this PR corrects a minor typo in the v0.12.0 release notes:
`solphie-pelland` → `sophie-pelland`.

No other usernames are modified.
