### PR TITLE
Fix meteonorm tests, again

### DIFF
--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -308,7 +308,9 @@ def test_get_meteonorm_tmy(
         interval_index=True,
         map_variables=False,
         url=demo_url)
-    assert meta == expected_meteonorm_tmy_meta
+    assert meta.items() >= expected_meteonorm_tmy_meta.items()
+    for key in ['version', 'commit']:
+        assert key in meta  # value changes, so only check presence
     # meteonorm API only guarantees similar, not identical, results between
     # calls.  so we allow a small amount of variation with atol.
     pd.testing.assert_frame_equal(data.iloc[:12], expected_meteonorm_tmy_data,


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Yet another "fix meteonorm tests" PR... However, while previous PRs have been for the tests of the returned irradiance data, this one makes the metadata tests more robust.  New values have appeared in the metadata dict (`version` and `commit`) and are causing failures: https://github.com/pvlib/pvlib-python/actions/runs/20141604432/job/57810425789