### PR TITLE
Fix minor RST rendering issue in Installation page

### DIFF
--- a/docs/sphinx/source/user_guide/getting_started/installation.rst
+++ b/docs/sphinx/source/user_guide/getting_started/installation.rst
@@ -185,7 +185,7 @@ With your conda/virtual environment still active...
    Consider installing pvlib using ``pip install -e .[all]`` so that
    you can run the unit tests and build the documentation.
    Your clone directory is probably similar to
-   ``C:\Users\%USER%\Documents\GitHub\pvlib-python``(Windows) or
+   ``C:\Users\%USER%\Documents\GitHub\pvlib-python`` (Windows) or
    ``/Users/%USER%/Documents/pvlib-python`` (Mac).
 #. **Test** your installation by running ``python -c 'import pvlib'``.
    You're good to go if it returns without an exception.


### PR DESCRIPTION
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The issue is on this page: https://pvlib-python.readthedocs.io/en/stable/user_guide/getting_started/installation.html

Screenshot:

<img width="703" height="137" alt="image" src="https://github.com/user-attachments/assets/f501237d-c0c3-40ec-8506-7925bbebc6a7" />


[With the fix](https://pvlib-python--2638.org.readthedocs.build/en/2638/user_guide/getting_started/installation.html):

<img width="714" height="137" alt="image" src="https://github.com/user-attachments/assets/0dbd6d65-3d51-4910-b110-510b90798c76" />

