### PR TITLE
Increase test coverage for simple_efficiency and clarify loss parameter docs

### DIFF
--- a/pvlib/transformer.py
+++ b/pvlib/transformer.py
@@ -27,12 +27,11 @@ def simple_efficiency(
     input_power : numeric
         The real AC power input to the transformer. [W]
 
-    no_load_loss : numeric
+    no_load_loss : float
         The constant losses experienced by a transformer, even
-        when the transformer is not under load. Fraction of transformer rating,
-        value from 0 to 1. [unitless]
+        when the transformer is not under load. Fraction of transformer rating, value from 0 to 1. [unitless]
 
-    load_loss:  numeric
+    load_loss:  float
         The load dependent losses experienced by the transformer.
         Fraction of transformer rating, value from 0 to 1. [unitless]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. -->

- [x] Closes #2649
- [x] I am familiar with the contributing guidelines
- [x] Tests added
- [ ] Updates entries in `docs/sphinx/source/reference` for API changes.
- [ ] Adds description and name entries in the appropriate "what's new" file.
- [x] New code is fully documented.
- [x] Pull request is nearly complete and ready for detailed review.
- [ ] Maintainer: Appropriate GitHub Labels and Milestone are assigned.

<!-- Brief description of the problem and proposed solution -->

This PR increases test coverage for `pvlib.transformer.simple_efficiency` by
adding tests that explicitly exercise NumPy array inputs, including the edge
case where `load_loss = 0`. The tests document the current behavior when
`load_loss` is zero without changing the implementation.

In addition, the docstring parameter types for `load_loss` and `no_load_loss`
are updated from `numeric` to `float` to better reflect their intended usage,
as discussed in the linked issue.
