### PR TITLE
Add simple_efficiency tests for numpy array inputs

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.1.rst
@@ -30,7 +30,7 @@ Testing
 ~~~~~~~
 * Add test to verify that :py:func:`~pvlib.transformer.simple_efficiency`
   produces consistent results for vectorized and scalar inputs.
-  (:pull:`2661`)
+  (:issue:`2649`, :pull:`2661`)
 
 Benchmarking
 ~~~~~~~~~~~~

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -43,24 +43,32 @@ def test_simple_efficiency():
     assert_allclose(calculated_output_power, expected_output_power)
 
 
-def test_simple_efficiency_known_values():
-    no_load_loss = 0.005
-    load_loss = 0.01
-    rating = 1000
-    args = (no_load_loss, load_loss, rating)
+@pytest.mark.parametrize(
+    "input_power, no_load_loss, load_loss, rating, expected",
+    [
+        # no-load condition
+        (0.005 * 1000, 0.005, 0.01, 1000, 0.0),
 
-    # verify correct behavior at no-load condition
-    assert_allclose(
-        transformer.simple_efficiency(no_load_loss*rating, *args),
-        0.0
+        # rated condition
+        (1000 * (1 + 0.005 + 0.01), 0.005, 0.01, 1000, 1000),
+
+        # zero load_loss case
+        # for load_loss = 0, the model reduces to:
+        # P_out = P_in - L_no_load * P_nom
+        (1000.0, 0.01, 0.0, 1000.0, 990.0),
+    ],
+)
+def test_simple_efficiency_numeric_cases(
+    input_power, no_load_loss, load_loss, rating, expected
+):
+    result = transformer.simple_efficiency(
+        input_power=input_power,
+        no_load_loss=no_load_loss,
+        load_loss=load_loss,
+        transformer_rating=rating,
     )
 
-    # verify correct behavior at rated condition
-    assert_allclose(
-        transformer.simple_efficiency(rating*(1 + no_load_loss + load_loss),
-                                      *args),
-        rating,
-    )
+    assert_allclose(result, expected)
 
 
 def test_simple_efficiency_vector_equals_scalar():
@@ -73,7 +81,7 @@ def test_simple_efficiency_vector_equals_scalar():
         input_power=input_power,
         no_load_loss=no_load_loss,
         load_loss=load_loss,
-        transformer_rating=rating
+        transformer_rating=rating,
     )
 
     scalar_result = np.array([
@@ -82,24 +90,3 @@ def test_simple_efficiency_vector_equals_scalar():
     ])
 
     assert_allclose(vector_result, scalar_result)
-
-
-@pytest.mark.parametrize(
-    "input_power, no_load_loss, load_loss, transformer_rating, expected",
-    [
-        (1000.0, 0.01, 0.0, 1000.0, 990.0),
-    ],
-)
-def test_simple_efficiency_zero_load_loss(
-    input_power, no_load_loss, load_loss, transformer_rating, expected
-):
-    # for load_loss = 0, the model reduces to:
-    # P_out = P_in - L_no_load * P_nom
-    result = transformer.simple_efficiency(
-        input_power=input_power,
-        no_load_loss=no_load_loss,
-        load_loss=load_loss,
-        transformer_rating=transformer_rating,
-    )
-
-    assert_allclose(result, expected)


### PR DESCRIPTION
this PR adds test coverage for vectorized use of `pvlib.transformer.simple_efficiency` with `numpy.ndarray` inputs.

the tests verify:
- support for NumPy array inputs for `input_power`, `load_loss`,
  and `no_load_loss`
- consistency between vectorized and scalar evaluations

No functional changes are introduced.

fixes #2649