### PR TITLE
Update test_meteonorm expected values for new year

### DIFF
--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -53,7 +53,7 @@ def expected_meta():
 @pytest.fixture
 def expected_meteonorm_index():
     expected_meteonorm_index = \
-        pd.date_range('2023-01-01', '2023-12-31 23:59', freq='1h', tz='UTC') \
+        pd.date_range('2025-01-01', '2025-12-31 23:59', freq='1h', tz='UTC') \
         + pd.Timedelta(minutes=30)
     expected_meteonorm_index.freq = None
     return expected_meteonorm_index
@@ -71,13 +71,13 @@ def expected_meteonorm_data():
         [0.0, 0.0],
         [0.0, 0.0],
         [0.0, 0.0],
-        [2.5, 2.68],
-        [77.5, 77.48],
-        [165.0, 164.99],
-        [210.75, 210.75],
-        [221.0, 220.99],
+        [3.75, 3.74],
+        [57.25, 57.20],
+        [149.0, 148.96],
+        [242.25, 242.24],
+        [228.0, 227.98],
     ]
-    index = pd.date_range('2023-01-01 00:30', periods=12, freq='1h', tz='UTC')
+    index = pd.date_range('2025-01-01 00:30', periods=12, freq='1h', tz='UTC')
     index.freq = None
     expected = pd.DataFrame(expected, index=index, columns=columns)
     return expected
@@ -116,7 +116,7 @@ def test_get_meteonorm_training(
         expected_meteonorm_data):
     data, meta = pvlib.iotools.get_meteonorm_observation_training(
         latitude=50, longitude=10,
-        start='2023-01-01', end='2024-01-01',
+        start='2025-01-01', end='2026-01-01',
         api_key=demo_api_key,
         parameters=['ghi', 'global_horizontal_irradiance_with_shading'],
         time_step='1h',


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Latest `remote-data` tests are failing with (See https://github.com/pvlib/pvlib-python/actions/runs/21646769714/job/62400674396):
```
FAILED tests/iotools/test_meteonorm.py::test_get_meteonorm_training
requests.exceptions.HTTPError: Meteonorm API returned an error:
invalid time range: make sure 'start' and 'end' are in the range 2024-01-01T00:00:00Z ... 2026-01-27T20:37:28Z`
```

Meteonorm [docs](https://docs.meteonorm.com/api/observation#observation-training) say that "Available time period: the current year excluding the last 7 days, plus the latest two full calendar years."

This PR updates the requested dates and associated expected values to follow this requirement.



