### PR TITLE
Add examples for run_model functions in v0.15.1

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.1.rst
@@ -24,6 +24,9 @@ Enhancements
 
 Documentation
 ~~~~~~~~~~~~~
+* Add examples for ``run_model_from_poa()`` and
+  ``run_model_from_effective_irradiance()``
+  (:issue:`1043`, :pull:`2621`)
 
 
 Testing


### PR DESCRIPTION
Added examples for run_model_from_poa() and run_model_from_effective_irradiance() in the documentation.

<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ x] Closes #1043
 - [x ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] Tests added
 - [x ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
