### PR TITLE
Fix delta_kt_prime calculation for series with internal NaN values

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.1.rst
@@ -19,7 +19,7 @@ Bug fixes
   values (e.g. multi-day data with nighttime gaps). Edge positions with
   only one valid neighbor now correctly use that single delta value
   (Perez eqn 3) instead of halving it.
-  (:issue:`1847`, :pull:`xxxx`)
+  (:issue:`1847`, :pull:`2698`)
 * Fix a division-by-zero condition in
   :py:func:`pvlib.transformer.simple_efficiency` when ``load_loss = 0``.
   (:issue:`2645`, :pull:`2646`)
@@ -63,6 +63,7 @@ Maintenance
 
 Contributors
 ~~~~~~~~~~~~
+* Ishaan Arora (:ghuser:`ishaan-arora-1`)
 * Aman Srivastava (:ghuser:`aman-coder03`)
 * Rajiv Daxini (:ghuser:`RDaxini`)
 * Echedey Luis (:ghuser:`echedey-ls`)

--- a/docs/sphinx/source/whatsnew/v0.15.1.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.1.rst
@@ -14,6 +14,12 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+* Fix incorrect ``delta_kt_prime`` calculation in
+  :py:func:`pvlib.irradiance.dirint` for series containing internal NaN
+  values (e.g. multi-day data with nighttime gaps). Edge positions with
+  only one valid neighbor now correctly use that single delta value
+  (Perez eqn 3) instead of halving it.
+  (:issue:`1847`, :pull:`xxxx`)
 * Fix a division-by-zero condition in
   :py:func:`pvlib.transformer.simple_efficiency` when ``load_loss = 0``.
   (:issue:`2645`, :pull:`2646`)


### PR DESCRIPTION
 - [x] Closes #1847
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `:issue:`num`` or this Pull Request with `:pull:`num``. Includes contributor name and/or GitHub username (link with `:ghuser:`user``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

## Problem

`_delta_kt_prime_dirint` incorrectly calculates `delta_kt_prime` for time series containing internal NaN values (e.g., multi-day data with nighttime gaps).

The previous implementation only handled NaN at the very first and last positions of the series (lines 2034-2035). For multi-day input, nighttime NaN values create internal boundaries that were not accounted for. At these boundaries, the `fill_value=0` in the `.add()` call caused one of the two delta terms to contribute 0, but the `0.5` factor was still applied — effectively halving the delta value. This violates Perez eqn 3, which specifies that when only one neighbor is available, the full (unhalved) delta should be used.

## Solution

Replace the manual NaN-filling logic with `pd.DataFrame.mean(axis=1)`, as [suggested by @cwhanse](https://github.com/pvlib/pvlib-python/issues/1847#issuecomment-1708734814):

```python
delta_kt_prime = pd.DataFrame({
    'next': (kt_prime - kt_next).abs(),
    'prev': (kt_prime - kt_previous).abs(),
}).mean(axis=1)
```

`DataFrame.mean(axis=1)` naturally skips NaN values, so:
- **Both neighbors valid** → average of both deltas (Perez eqn 2)
- **One neighbor valid** → that single delta value (Perez eqn 3)
- **No neighbors valid** → NaN

This is simpler, correct, and handles all edge cases including the first/last positions of the series, internal NaN gaps, and single-element series.

## Testing

Added `test_delta_kt_prime_dirint_multiday` which uses the exact scenario from the bug report (a series with leading/trailing NaN values simulating nighttime gaps) and verifies:
- Edge positions use the full single-neighbor delta (Perez eqn 3)
- Interior positions use the mean of both deltas (Perez eqn 2)
- NaN positions remain NaN

All 121 existing irradiance tests continue to pass.