### PR TITLE
Note in contributing guide that PRs must include the template checklist

### DIFF
--- a/docs/sphinx/source/contributing/how_to_contribute_new_code.rst
+++ b/docs/sphinx/source/contributing/how_to_contribute_new_code.rst
@@ -40,6 +40,16 @@ information on these aspects.
 Pull requests (PRs)
 ~~~~~~~~~~~~~~~~~~~
 
+.. _pull-request-checklist:
+
+PR checklist
+------------
+
+Every pull request description must include the
+`PR checklist <https://github.com/pvlib/pvlib-python/blob/main/.github/PULL_REQUEST_TEMPLATE.md>`_.
+If your workflow overrides the default PR template (e.g. ``gh pr create
+--body "..."``) make sure to copy the checklist into the description.
+
 .. _pull-request-scope:
 
 Scope


### PR DESCRIPTION
 - [x] Closes #2706
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [ ] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with ` :issue:`num` ` or this Pull Request with ` :pull:`num` `. Includes contributor name and/or GitHub username (link with ` :ghuser:`user` `).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

While working on #2705, a coding agent created the PR using `gh pr create --body "..."`, which replaced the default PR template and omitted the checklist. This adds a short note to the contributing guide reminding contributors to include the checklist when their workflow overrides the template.