### PR TITLE
Fix integer truncation in temperature.fuentes by forcing float dtype …

### DIFF
--- a/pvlib/temperature.py
+++ b/pvlib/temperature.py
@@ -6,7 +6,6 @@ PV modules and cells.
 import numpy as np
 import pandas as pd
 from pvlib.tools import sind
-from pvlib._deprecation import warn_deprecated
 from pvlib.tools import _get_sample_intervals
 import scipy
 import scipy.constants
@@ -883,7 +882,7 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
     windmod_array = wind_speed * (module_height/wind_height)**0.2 + 1e-4
 
     tmod0 = 293.15
-    tmod_array = np.zeros_like(poa_global)
+    tmod_array = np.zeros_like(poa_global, dtype=float)
 
     iterator = zip(tamb_array, sun_array, windmod_array, tsky_array,
                    timedelta_hours)

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -501,3 +501,51 @@ def test_glm_repr():
                 "'alpha': 0.9}")
 
     assert glm.__repr__() == expected
+
+
+@pytest.mark.parametrize('tz', [None, 'Etc/GMT+5'])
+def test_fuentes_timezone(tz):
+    index = pd.date_range('2019-01-01', freq='h', periods=3, tz=tz)
+
+    df = pd.DataFrame({'poa_global': 1000, 'temp_air': 20, 'wind_speed': 1},
+                      index)
+
+    out = temperature.fuentes(df['poa_global'], df['temp_air'],
+                              df['wind_speed'], noct_installed=45)
+
+    expected = pd.Series(
+        [48.041843, 51.845471, 51.846428],
+        index=index,
+        name='tmod'
+    )
+
+    assert_series_equal(out.round(6), expected.round(6))
+
+
+def test_fuentes_int_vs_float():
+    """Ensure integer and float inputs give identical results."""
+    index = pd.date_range("2019-01-01", freq="h", periods=2)
+
+    inputs = pd.DataFrame({
+        "poa_global": [1000, 500],
+        "temp_air": [25, 25],
+        "wind_speed": [1, 1],
+    }, index=index)
+
+    result_int = temperature.fuentes(
+        poa_global=inputs["poa_global"],
+        temp_air=inputs["temp_air"],
+        wind_speed=inputs["wind_speed"],
+        noct_installed=45
+    )
+
+    inputs_float = inputs.astype(float)
+
+    result_float = temperature.fuentes(
+        poa_global=inputs_float["poa_global"],
+        temp_air=inputs_float["temp_air"],
+        wind_speed=inputs_float["wind_speed"],
+        noct_installed=45
+    )
+
+    assert_allclose(result_int.values, result_float.values)


### PR DESCRIPTION


<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ x] Closes #2608 
 - [ x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x ] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

## Summary

Fix integer truncation in `pvlib.temperature.fuentes`.

The function created the internal array using `np.zeros_like(poa_global)`,
which inherits the dtype of the input. When integer inputs were provided,
intermediate floating-point temperatures were truncated when written into
the array.


This patch forces the internal array to use a floating-point dtype:
tmod_array = np.zeros_like(poa_global, dtype=float)

Updated expected values in test_fuentes_timezone to reflect the corrected
behavior and added a regression test test_fuentes_int_vs_float to ensure
integer and float inputs produce identical results.