### PR TITLE
Update broken links in get_solaranywhere

### DIFF
--- a/pvlib/iotools/solaranywhere.py
+++ b/pvlib/iotools/solaranywhere.py
@@ -128,7 +128,7 @@ def get_solaranywhere(latitude, longitude, api_key, start=None, end=None,
     .. [1] `SolarAnywhere API
        <https://www.solaranywhere.com/support/using-solaranywhere/api/>`_
     .. [2] `SolarAnywhere irradiance and weather API requests
-       https://apidocs.solaranywhere.com/>`_
+       <https://apidocs.solaranywhere.com/>`_
     .. [3] `SolarAnywhere variable definitions
        <https://www.solaranywhere.com/support/data-fields/definitions/>`_
     """  # noqa: E501

--- a/pvlib/iotools/solaranywhere.py
+++ b/pvlib/iotools/solaranywhere.py
@@ -52,8 +52,7 @@ def get_solaranywhere(latitude, longitude, api_key, start=None, end=None,
                       url=URL, map_variables=True, timeout=300):
     """Retrieve historical irradiance time series data from SolarAnywhere.
 
-    The SolarAnywhere API is described in [1]_ and [2]_. A detailed list of
-    API options can be found in [3]_.
+    The SolarAnywhere API is described in [1]_ and [2]_.
 
     Parameters
     ----------
@@ -74,7 +73,7 @@ def get_solaranywhere(latitude, longitude, api_key, start=None, end=None,
         'SolarAnywhereTGYLatest' (TMY for GHI), 'SolarAnywhereTDYLatest' (TMY
         for DNI), or 'SolarAnywherePOELatest' for probability of exceedance.
         Specific dataset versions can also be specified, e.g.,
-        'SolarAnywhere3_2' (see [3]_ for a full list of options).
+        'SolarAnywhere3_2' (see [2]_ for a full list of options).
     time_resolution: {60, 30, 15, 5}, default: 60
         Time resolution in minutes. For TMY data, time resolution has to be 60
         minutes (hourly).
@@ -87,7 +86,7 @@ def get_solaranywhere(latitude, longitude, api_key, start=None, end=None,
         Probability of exceedance in the range of 1 to 99. Only relevant when
         requesting probability of exceedance (POE) time series. [%]
     variables: list-like, default: :const:`DEFAULT_VARIABLES`
-        Variables to retrieve (described in [4]_), must include
+        Variables to retrieve (described in [3]_), must include
         'ObservationTime'. Available variables depend on whether historical or
         TMY data is requested.
     missing_data: {'Omit', 'FillAverage'}, default: 'FillAverage'
@@ -129,10 +128,8 @@ def get_solaranywhere(latitude, longitude, api_key, start=None, end=None,
     .. [1] `SolarAnywhere API
        <https://www.solaranywhere.com/support/using-solaranywhere/api/>`_
     .. [2] `SolarAnywhere irradiance and weather API requests
-       <https://developers.cleanpower.com/irradiance-and-weather-data/irradiance-and-weather-requests/>`_
-    .. [3] `SolarAnywhere API options
-       <https://developers.cleanpower.com/irradiance-and-weather-data/complete-schema/createweatherdatarequest/options/>`_
-    .. [4] `SolarAnywhere variable definitions
+       https://apidocs.solaranywhere.com/>`_
+    .. [3] `SolarAnywhere variable definitions
        <https://www.solaranywhere.com/support/data-fields/definitions/>`_
     """  # noqa: E501
     headers = {'content-type': "application/json; charset=utf-8",


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
This PR replaces two broken links in the ``pvlib.iotools.get_solaranywhere`` documentation.