### PR TITLE
Fix indentation in `pvlib.irradiance.louche` docstring

### DIFF
--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -3817,11 +3817,11 @@ def louche(ghi, solar_zenith, datetime_or_doy, max_zenith=90):
         Contains the following keys/columns:
 
         * ``dni``: the modeled direct normal irradiance, see :term:`dni`.
-            [Wm⁻²]
+          [Wm⁻²]
         * ``dhi``: the modeled diffuse horizontal irradiance, see :term:`dhi`.
-            [Wm⁻²]
+          [Wm⁻²]
         * ``kt``: Clearness index. Ratio of global to
-            extraterrestrial irradiance on a horizontal plane. [unitless]
+          extraterrestrial irradiance on a horizontal plane. [unitless]
 
     References
     -------


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fix this bad rendering:


<img width="697" height="283" alt="image" src="https://github.com/user-attachments/assets/f403f87d-7575-437a-80d2-1625b6c781db" />