### PR TITLE
Add missing `fit_desoto_batzelis` documentation references

### DIFF
--- a/docs/sphinx/source/reference/pv_modeling/parameters.rst
+++ b/docs/sphinx/source/reference/pv_modeling/parameters.rst
@@ -14,6 +14,7 @@ Functions for fitting single diode models
     ivtools.sdm.fit_pvsyst_sandia
     ivtools.sdm.fit_pvsyst_iec61853_sandia_2025
     ivtools.sdm.fit_desoto_sandia
+    ivtools.sdm.fit_desoto_batzelis
 
 Functions for fitting the single diode equation
 

--- a/docs/sphinx/source/user_guide/modeling_topics/singlediode.rst
+++ b/docs/sphinx/source/user_guide/modeling_topics/singlediode.rst
@@ -95,6 +95,8 @@ from various datasources:
 +---------------------------------------------------------------+---------+--------------------+
 | :py:func:`~pvlib.ivtools.sdm.fit_desoto`                      | De Soto | datasheet          |
 +---------------------------------------------------------------+---------+--------------------+
+| :py:func:`~pvlib.ivtools.sdm.fit_desoto_batzelis`             | De Soto | datasheet          |
++---------------------------------------------------------------+---------+--------------------+
 | :py:func:`~pvlib.ivtools.sdm.fit_desoto_sandia`               | De Soto | I-V curves         |
 +---------------------------------------------------------------+---------+--------------------+
 | :py:func:`~pvlib.ivtools.sdm.fit_pvsyst_sandia`               | PVsyst  | I-V curves         |


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - ~[ ] Tests added~
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Adds references to this function in a couple useful places in the docs.  