### PR TITLE
Add test coverage for `irradiance.dirint` for array and series inputs

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -14,6 +14,9 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+* Fixed :py:func:`pvlib.irradiance.dirint` raising ``KeyError`` with
+  scalar inputs on pandas >= 2.0. (:pull:`XXXX`, :issue:`2751`)
+  By :ghuser:`Omesh37`.
 * Corrects a bug in :py:func:`pvlib.temperature.fuentes`. If inputs were
   data type integer, users can expect modeled cell temperature values to
   increase slightly.

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -15,7 +15,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 * Fixed :py:func:`pvlib.irradiance.dirint` raising ``KeyError`` with
-  scalar inputs on pandas >= 2.0. (:pull:`XXXX`, :issue:`2751`)
+  scalar inputs on pandas >= 2.0. (:pull:`2752`, :issue:`2751`)
   By :ghuser:`Omesh37`.
 * Corrects a bug in :py:func:`pvlib.temperature.fuentes`. If inputs were
   data type integer, users can expect modeled cell temperature values to

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -14,9 +14,9 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-* Fixed :py:func:`pvlib.irradiance.dirint` raising ``KeyError`` with
-  scalar inputs on pandas >= 2.0. (:pull:`2752`, :issue:`2751`)
-  By :ghuser:`Omesh37`.
+* Added test coverage for :py:func:`pvlib.irradiance.dirint` with
+  ``np.array`` and ``pd.Series`` inputs. 
+  (:issue:`2751`, :pull:`2752`)
 * Corrects a bug in :py:func:`pvlib.temperature.fuentes`. If inputs were
   data type integer, users can expect modeled cell temperature values to
   increase slightly.

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1965,8 +1965,7 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
     Returns
     -------
     dni : pd.Series
-        Estimated direct normal irradiance. Returns float if all inputs
-        are scalar, pd.Series otherwise. [Wm⁻²]
+        Estimated direct normal irradiance. [Wm⁻²]
 
     Notes
     -----

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2109,6 +2109,14 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     -------
     tuple of kt_prime_bin, zenith_bin, w_bin, delta_kt_prime_bin
     """
+    # Ensure scalar inputs are converted to Series so that boolean masks
+    # produce a boolean Series rather than a scalar bool.
+    # Scalar bools cause KeyError in pandas >= 2.0. GH #XXXX
+    kt_prime = pd.Series(kt_prime, index=times, dtype=float)
+    zenith = pd.Series(zenith, index=times, dtype=float)
+    w = pd.Series(w, index=times, dtype=float)
+    delta_kt_prime = pd.Series(delta_kt_prime, index=times, dtype=float)
+
     # @wholmgren: the following bin assignments use MATLAB's 1-indexing.
     # Later, we'll subtract 1 to conform to Python's 0-indexing.
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1970,7 +1970,8 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
     Notes
     -----
     DIRINT model requires time series data (ie. one of the inputs must
-    be a vector of length > 2).
+   The DIRINT model was developed for time series data with length > 2. The implementation
+   in pvlib assumes the data are periodic which may affect the first and last DNI values.
 
     References
     ----------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1983,6 +1983,9 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
 
+    if use_delta_kt_prime and len(times) < 2:
+        raise ValueError('The DIRINT model requires at least two times')
+
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)
     airmass = disc_out['airmass']

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1984,8 +1984,6 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
 
-    if use_delta_kt_prime and len(times) < 2:
-        raise ValueError('The DIRINT model requires at least two times')
 
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1927,10 +1927,10 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     Parameters
     ----------
-    ghi : array-like
+    ghi : numeric
         Global horizontal irradiance. See :term:`ghi`. [Wm⁻²]
 
-    solar_zenith : array-like
+    solar_zenith : numeric
         True (not refraction-corrected) solar zenith angles. See
         :term:`solar_zenith`. [°]
 
@@ -1964,9 +1964,9 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     Returns
     -------
-    dni : array-like
-        The modeled direct normal irradiance, as provided by the
-        DIRINT model. [Wm⁻²]
+    dni : numeric or pd.Series
+        Estimated direct normal irradiance. Returns float if all inputs
+        are scalar, pd.Series otherwise. [Wm⁻²]
 
     Notes
     -----
@@ -1983,7 +1983,8 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        Global Horizontal to Direct Normal Insolation", Technical Report No.
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
-
+    scalar_input = np.isscalar(solar_zenith)
+    
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)
     airmass = disc_out['airmass']
@@ -1998,9 +1999,12 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
     dirint_coeffs = _dirint_coeffs(times, kt_prime, solar_zenith, w,
                                    delta_kt_prime)
 
+
     # Perez eqn 5
     dni = disc_out['dni'] * dirint_coeffs
 
+    if scalar_input:
+        return float(dni.iloc[0])
     return dni
 
 
@@ -2160,6 +2164,7 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     return kt_prime_bin, zenith_bin, w_bin, delta_kt_prime_bin
 
 
+    
 def dirindex(ghi, ghi_clear, dni_clear, zenith, times, pressure=101325.,
              use_delta_kt_prime=True, temp_dew=None, min_cos_zenith=0.065,
              max_zenith=87):

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1927,10 +1927,10 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     Parameters
     ----------
-    ghi : numeric
+    ghi : array-like
         Global horizontal irradiance. See :term:`ghi`. [Wm⁻²]
 
-    solar_zenith : numeric
+    solar_zenith : array-like
         True (not refraction-corrected) solar zenith angles. See
         :term:`solar_zenith`. [°]
 
@@ -1964,7 +1964,7 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     Returns
     -------
-    dni : numeric or pd.Series
+    dni : pd.Series
         Estimated direct normal irradiance. Returns float if all inputs
         are scalar, pd.Series otherwise. [Wm⁻²]
 
@@ -1983,7 +1983,6 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        Global Horizontal to Direct Normal Insolation", Technical Report No.
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
-    scalar_input = np.isscalar(solar_zenith)
 
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)
@@ -2002,8 +2001,6 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
     # Perez eqn 5
     dni = disc_out['dni'] * dirint_coeffs
 
-    if scalar_input:
-        return float(dni.iloc[0])
     return dni
 
 
@@ -2115,10 +2112,6 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     # Ensure scalar inputs are converted to Series so that boolean masks
     # produce a boolean Series rather than a scalar bool.
     # Scalar bools cause KeyError in pandas >= 2.0. GH #XXXX
-    kt_prime = pd.Series(kt_prime, index=times, dtype=float)
-    zenith = pd.Series(zenith, index=times, dtype=float)
-    w = pd.Series(w, index=times, dtype=float)
-    delta_kt_prime = pd.Series(delta_kt_prime, index=times, dtype=float)
 
     # @wholmgren: the following bin assignments use MATLAB's 1-indexing.
     # Later, we'll subtract 1 to conform to Python's 0-indexing.

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -132,7 +132,9 @@ def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
     # a better way to do it.
     if isinstance(datetime_or_doy, pd.DatetimeIndex):
         to_doy = tools._pandas_to_doy  # won't be evaluated unless necessary
-        def to_datetimeindex(x): return x                       # noqa: E306
+
+        def to_datetimeindex(x):
+            return x                       # noqa: E306
         to_output = partial(pd.Series, index=datetime_or_doy)
     elif isinstance(datetime_or_doy, pd.Timestamp):
         to_doy = tools._pandas_to_doy
@@ -146,12 +148,14 @@ def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
             tools._datetimelike_scalar_to_datetimeindex
         to_output = tools._scalar_out
     elif np.isscalar(datetime_or_doy):  # ints and floats of various types
-        def to_doy(x): return x                                 # noqa: E306
+        def to_doy(x):
+            return x                                 # noqa: E306
         to_datetimeindex = partial(tools._doy_to_datetimeindex,
                                    epoch_year=epoch_year)
         to_output = tools._scalar_out
     else:  # assume that we have an array-like object of doy
-        def to_doy(x): return x                                 # noqa: E306
+        def to_doy(x):
+            return x                                 # noqa: E306
         to_datetimeindex = partial(tools._doy_to_datetimeindex,
                                    epoch_year=epoch_year)
         to_output = tools._array_out
@@ -1969,9 +1973,9 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     Notes
     -----
-    DIRINT model requires time series data (ie. one of the inputs must
-   The DIRINT model was developed for time series data with length > 2. The implementation
-   in pvlib assumes the data are periodic which may affect the first and last DNI values.
+    The DIRINT model was developed for time series data with length > 2.
+    The implementation in pvlib assumes the data are periodic which may
+    affect the first and last DNI values.
 
     References
     ----------
@@ -1983,7 +1987,6 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        Global Horizontal to Direct Normal Insolation", Technical Report No.
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
-
 
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1984,7 +1984,7 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
        SERI/TR-215-3087, Golden, CO: Solar Energy Research Institute, 1987.
     """
     scalar_input = np.isscalar(solar_zenith)
-    
+
     disc_out = disc(ghi, solar_zenith, times, pressure=pressure,
                     min_cos_zenith=min_cos_zenith, max_zenith=max_zenith)
     airmass = disc_out['airmass']
@@ -1998,7 +1998,6 @@ def dirint(ghi, solar_zenith, times, pressure=101325., use_delta_kt_prime=True,
 
     dirint_coeffs = _dirint_coeffs(times, kt_prime, solar_zenith, w,
                                    delta_kt_prime)
-
 
     # Perez eqn 5
     dni = disc_out['dni'] * dirint_coeffs
@@ -2164,7 +2163,6 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     return kt_prime_bin, zenith_bin, w_bin, delta_kt_prime_bin
 
 
-    
 def dirindex(ghi, ghi_clear, dni_clear, zenith, times, pressure=101325.,
              use_delta_kt_prime=True, temp_dew=None, min_cos_zenith=0.065,
              max_zenith=87):

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -2108,9 +2108,6 @@ def _dirint_bins(times, kt_prime, zenith, w, delta_kt_prime):
     -------
     tuple of kt_prime_bin, zenith_bin, w_bin, delta_kt_prime_bin
     """
-    # Ensure scalar inputs are converted to Series so that boolean masks
-    # produce a boolean Series rather than a scalar bool.
-    # Scalar bools cause KeyError in pandas >= 2.0. GH #XXXX
 
     # @wholmgren: the following bin assignments use MATLAB's 1-indexing.
     # Later, we'll subtract 1 to conform to Python's 0-indexing.

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1139,6 +1139,34 @@ def test_dirindex_min_cos_zenith_max_zenith():
     expected = pd.Series([nan, 5.], index=times)
     assert_series_equal(out, expected)
 
+def test_dirint_scalar_inputs():
+    """Scalar numeric inputs return scalar float output. GH #2751"""
+    times = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
+
+    # scalar int input → should return float (not Series)
+    result = irradiance.dirint(
+        ghi=500, solar_zenith=45, times=times
+    )
+    assert np.isscalar(result), "scalar input should return scalar output"
+    assert isinstance(result, float)
+
+    # scalar float with delta_kt_prime disabled → non-NaN value check
+    result = irradiance.dirint(
+        ghi=500.0, solar_zenith=45.0, times=times,
+        use_delta_kt_prime=False
+    )
+    assert np.isscalar(result)
+    assert isinstance(result, float)
+    assert result > 0  # should be positive DNI
+
+    # Series input → should still return Series (regression check)
+    times2 = pd.date_range('2023-06-21 10:00', periods=3, freq='h', tz='UTC')
+    result_series = irradiance.dirint(
+        ghi=pd.Series([400, 500, 300], index=times2),
+        solar_zenith=pd.Series([50, 40, 60], index=times2),
+        times=times2
+    )
+    assert isinstance(result_series, pd.Series)
 
 def test_dni():
     ghi = pd.Series([90, 100, 100, 100, 100])

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1165,16 +1165,6 @@ def test_dirint_array_inputs():
     assert (result2 >= 0).all()
 
 
-    # single time point + use_delta_kt_prime=False → no error
-    result3 = irradiance.dirint(
-        ghi=np.array([500.0]),
-        solar_zenith=np.array([45.0]),
-        times=times_single,
-        use_delta_kt_prime=False
-    )
-    assert isinstance(result3, pd.Series)
-
-
 def test_dni():
     ghi = pd.Series([90, 100, 100, 100, 100])
     dhi = pd.Series([100, 90, 50, 50, 50])

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1140,34 +1140,29 @@ def test_dirindex_min_cos_zenith_max_zenith():
     assert_series_equal(out, expected)
 
 
-def test_dirint_scalar_inputs():
-    """Scalar numeric inputs return scalar float output. GH #2751"""
+def test_dirint_array_inputs():
+    """np.array inputs work correctly. GH #2751"""
     times = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
 
-    # scalar int input → should return float (not Series)
+    # np.array input (1-element) -- return pd.Series
     result = irradiance.dirint(
-        ghi=500, solar_zenith=45, times=times
-    )
-    assert np.isscalar(result), "scalar input should return scalar output"
-    assert isinstance(result, float)
-
-    # scalar float with delta_kt_prime disabled → non-NaN value check
-    result = irradiance.dirint(
-        ghi=500.0, solar_zenith=45.0, times=times,
+        ghi=np.array([500.0]),
+        solar_zenith=np.array([45.0]),
+        times=times,
         use_delta_kt_prime=False
     )
-    assert np.isscalar(result)
-    assert isinstance(result, float)
-    assert result > 0  # should be positive DNI
+    assert isinstance(result, pd.Series)
+    assert result.iloc[0] > 0
 
-    # Series input → should still return Series (regression check)
+    # pd.Series input -- return pd.Series
     times2 = pd.date_range('2023-06-21 10:00', periods=3, freq='h', tz='UTC')
-    result_series = irradiance.dirint(
+    result2 = irradiance.dirint(
         ghi=pd.Series([400, 500, 300], index=times2),
         solar_zenith=pd.Series([50, 40, 60], index=times2),
         times=times2
     )
-    assert isinstance(result_series, pd.Series)
+    assert isinstance(result2, pd.Series)
+    assert (result2 >= 0).all()
 
 
 def test_dni():

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1139,6 +1139,7 @@ def test_dirindex_min_cos_zenith_max_zenith():
     expected = pd.Series([nan, 5.], index=times)
     assert_series_equal(out, expected)
 
+
 def test_dirint_scalar_inputs():
     """Scalar numeric inputs return scalar float output. GH #2751"""
     times = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
@@ -1167,6 +1168,7 @@ def test_dirint_scalar_inputs():
         times=times2
     )
     assert isinstance(result_series, pd.Series)
+
 
 def test_dni():
     ghi = pd.Series([90, 100, 100, 100, 100])

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1141,20 +1141,21 @@ def test_dirindex_min_cos_zenith_max_zenith():
 
 
 def test_dirint_array_inputs():
-    """np.array inputs work correctly. GH #2751"""
-    times = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
+    """np.array and pd.Series inputs work correctly. GH #2751"""
+    # dirint requires >= 2 time points
+    times = pd.date_range('2023-06-21 10:00', periods=2, freq='h', tz='UTC')
 
-    # np.array input (1-element) -- return pd.Series
+    # np.array input → should return pd.Series
     result = irradiance.dirint(
-        ghi=np.array([500.0]),
-        solar_zenith=np.array([45.0]),
+        ghi=np.array([500.0, 400.0]),
+        solar_zenith=np.array([45.0, 50.0]),
         times=times,
         use_delta_kt_prime=False
     )
     assert isinstance(result, pd.Series)
     assert result.iloc[0] > 0
 
-    # pd.Series input -- return pd.Series
+    # pd.Series input → should return pd.Series
     times2 = pd.date_range('2023-06-21 10:00', periods=3, freq='h', tz='UTC')
     result2 = irradiance.dirint(
         ghi=pd.Series([400, 500, 300], index=times2),
@@ -1163,6 +1164,15 @@ def test_dirint_array_inputs():
     )
     assert isinstance(result2, pd.Series)
     assert (result2 >= 0).all()
+
+    # single time point → ValueError regardless of use_delta_kt_prime
+    times_single = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
+    with pytest.raises(ValueError, match="requires at least two times"):
+        irradiance.dirint(
+            ghi=np.array([500.0]),
+            solar_zenith=np.array([45.0]),
+            times=times_single
+        )
 
 
 def test_dni():

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1142,7 +1142,6 @@ def test_dirindex_min_cos_zenith_max_zenith():
 
 def test_dirint_array_inputs():
     """np.array and pd.Series inputs work correctly. GH #2751"""
-    # dirint requires >= 2 time points
     times = pd.date_range('2023-06-21 10:00', periods=2, freq='h', tz='UTC')
 
     # np.array input → should return pd.Series
@@ -1165,14 +1164,24 @@ def test_dirint_array_inputs():
     assert isinstance(result2, pd.Series)
     assert (result2 >= 0).all()
 
-    # single time point → ValueError regardless of use_delta_kt_prime
+    # single time point + use_delta_kt_prime=True → ValueError
     times_single = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
     with pytest.raises(ValueError, match="requires at least two times"):
         irradiance.dirint(
             ghi=np.array([500.0]),
             solar_zenith=np.array([45.0]),
-            times=times_single
+            times=times_single,
+            use_delta_kt_prime=True
         )
+
+    # single time point + use_delta_kt_prime=False → no error
+    result3 = irradiance.dirint(
+        ghi=np.array([500.0]),
+        solar_zenith=np.array([45.0]),
+        times=times_single,
+        use_delta_kt_prime=False
+    )
+    assert isinstance(result3, pd.Series)
 
 
 def test_dni():

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -1164,15 +1164,6 @@ def test_dirint_array_inputs():
     assert isinstance(result2, pd.Series)
     assert (result2 >= 0).all()
 
-    # single time point + use_delta_kt_prime=True → ValueError
-    times_single = pd.DatetimeIndex(['2023-06-21 12:00'], tz='UTC')
-    with pytest.raises(ValueError, match="requires at least two times"):
-        irradiance.dirint(
-            ghi=np.array([500.0]),
-            solar_zenith=np.array([45.0]),
-            times=times_single,
-            use_delta_kt_prime=True
-        )
 
     # single time point + use_delta_kt_prime=False → no error
     result3 = irradiance.dirint(


### PR DESCRIPTION
## Description
`pvlib.irradiance.dirint` crashed with `KeyError: 'cannot use a single bool to index into setitem'` when called with scalar inputs on pandas >= 2.0.

In `_dirint_bins`, scalar inputs like `solar_zenith=90` cause comparisons such as `(zenith >= 0) & (zenith < 25)` to return a plain Python `bool`. pandas >= 2.0 treats scalar bools as label lookups on `setitem`, raising `KeyError`.

**Fix:** Convert all four scalar-or-array inputs to `pd.Series` at the top of `_dirint_bins`, ensuring boolean masks are always a boolean `Series`.

## Checklist
- [ ] Closes 
- [x] I am familiar with the contributing guidelines
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [x] Tests added
- [x] Adds description and name entries in the appropriate "what's new" file in `docs/sphinx/source/whatsnew`
- [x] New code is fully documented
- [x] Pull request is nearly complete and ready for detailed review