### PR TITLE
Add albedo to get_nasa_power variable map

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -26,7 +26,7 @@ Bug fixes
 Enhancements
 ~~~~~~~~~~~~
 * Added mapping of the parameter ``"albedo"`` in
-  ~:py:func:``pvlib.iotools.get_nasa_power` when ``map_variables=True``
+  :py:func:`~pvlib.iotools.get_nasa_power` when ``map_variables=True``
   (:pull:`2753`)
 
 

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -25,6 +25,9 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
+* Added mapping of the parameter ``"albedo"`` in
+  ~:py:func:``pvlib.iotools.get_nasa_power` when ``map_variables=True``
+  (:pull:`2753`)
 
 
 Documentation
@@ -58,3 +61,4 @@ Contributors
 * :ghuser:`Omesh37`
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Arthur Onno (:ghuser:`ArthurOnnoTerabase`)
+* Adam R. Jensen (:ghuser:`AdamRJensen`)

--- a/pvlib/iotools/nasa_power.py
+++ b/pvlib/iotools/nasa_power.py
@@ -18,6 +18,7 @@ VARIABLE_MAP = {
     'T2M': 'temp_air',
     'WS2M': 'wind_speed_2m',
     'WS10M': 'wind_speed',
+    'ALLSKY_SRF_ALB': 'albedo',
 }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [ ] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

The NASA POWER dataset has four albedo parameters ([link](https://power.larc.nasa.gov/parameters/)). I believe the ``ALLSKY_SRF_ALB`` is the correct parameter for albedo for solar energy applications. This PR adds it to the variable map.

<img width="597" height="116" alt="image" src="https://github.com/user-attachments/assets/cfebd9c4-ad58-4961-9cc2-c53aa670df77" />
