### PR TITLE
Add bifacial scaling to Townsend snow loss model

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -21,7 +21,10 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-
+* Added the ``front_side_fraction`` parameter to
+  :py:func:`pvlib.snow.loss_townsend` to support bifacial Townsend snow-loss
+  workflows where the calculated loss is scaled by the front-side energy
+  fraction. (:pull:`2756`) (:ghuser:`shethkajal7`)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -53,3 +56,4 @@ Contributors
 ~~~~~~~~~~~~
 * :ghuser:`Omesh37`
 * Cliff Hansen (:ghuser:`cwhanse`)
+* :ghuser:`shethkajal7`

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -22,9 +22,8 @@ Bug fixes
 Enhancements
 ~~~~~~~~~~~~
 * Add the ``front_side_fraction`` parameter to
-  :py:func:`pvlib.snow.loss_townsend` to support bifacial Townsend snow-loss
-  workflows where the calculated loss is scaled by the front-side energy
-  fraction. (:issue:`2755`, :pull:`2756`)
+  :py:func:`pvlib.snow.loss_townsend` to support Townsend snow-loss
+  workflows for bifacial systems. (:issue:`2755`, :pull:`2756`)
   
 
 Documentation

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -21,10 +21,11 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-* Added the ``front_side_fraction`` parameter to
+* Add the ``front_side_fraction`` parameter to
   :py:func:`pvlib.snow.loss_townsend` to support bifacial Townsend snow-loss
   workflows where the calculated loss is scaled by the front-side energy
-  fraction. (:pull:`2756`) (:ghuser:`shethkajal7`)
+  fraction. (:issue:`2755`, :pull:`2756`)
+  
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/snow.py
+++ b/pvlib/snow.py
@@ -295,7 +295,7 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
         25°-55° avalanching slope angles. [deg]
 
     front_side_fraction : numeric or array-like, default 1.0
-        Fraction of monthly energy from front-side insolation (unitless).
+        Fraction of monthly energy from front-side insolation. [unitless]
         Multiplies the calculated loss fraction. For example,
         use 0.9 when 90% of monthly energy is from the front side
         of a bifacial system and 10% is from the rear side.

--- a/pvlib/snow.py
+++ b/pvlib/snow.py
@@ -249,7 +249,7 @@ def _townsend_effective_snow(snow_total, snow_events):
 def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
                   temp_air, poa_global, slant_height, lower_edge_height,
                   string_factor=1.0, angle_of_repose=40,
-                  front_side_fraction=None):
+                  front_side_fraction=1.0):
     '''
     Calculates monthly snow loss based on the Townsend monthly snow loss
     model.
@@ -294,13 +294,12 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
         Piled snow angle, assumed to stabilize at 40°, the midpoint of
         25°-55° avalanching slope angles. [deg]
 
-    front_side_fraction : numeric or array-like, default None
-        Optional multiplier applied to the calculated loss fraction. For
-        bifacial systems, this can be used to scale the snow loss by the
-        front-side energy fraction from a no-soiling simulation. For example,
-        use 0.9 when 90% of monthly energy is from the front side and 10% is
-        from the rear side. If None, no bifacial adjustment is applied. [-]
-        
+    front_side_fraction : numeric or array-like, default 1.0
+        Fraction of monthly energy from front-side insolation (unitless).
+        Multiplies the calculated loss fraction. For example,
+        use 0.9 when 90% of monthly energy is from the front side
+        of a bifacial system and 10% is from the rear side.
+
     Returns
     -------
     loss : array-like
@@ -319,8 +318,8 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
     The definition for snow events documented above is based on [3]_.
 
     For bifacial systems, [2]_ recommends including both front-side and
-    rear-side insolation in ``poa_global``. The resulting loss may then be
-    scaled by the front-side energy fraction using ``front_side_fraction``.
+    rear-side insolation in ``poa_global``. The resulting loss is
+    scaled by the front-side energy fraction ``front_side_fraction``.
 
     References
     ----------
@@ -396,8 +395,6 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
         * string_factor
     )
 
-    if front_side_fraction is not None:
-        front_side_fraction = np.asarray(front_side_fraction)
-        loss_fraction = loss_fraction * front_side_fraction
+    loss_fraction = loss_fraction * front_side_fraction
 
     return np.clip(loss_fraction, 0, 1)

--- a/pvlib/snow.py
+++ b/pvlib/snow.py
@@ -248,7 +248,8 @@ def _townsend_effective_snow(snow_total, snow_events):
 
 def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
                   temp_air, poa_global, slant_height, lower_edge_height,
-                  string_factor=1.0, angle_of_repose=40):
+                  string_factor=1.0, angle_of_repose=40,
+                  front_side_fraction=None):
     '''
     Calculates monthly snow loss based on the Townsend monthly snow loss
     model.
@@ -293,6 +294,13 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
         Piled snow angle, assumed to stabilize at 40°, the midpoint of
         25°-55° avalanching slope angles. [deg]
 
+    front_side_fraction : numeric or array-like, default None
+        Optional multiplier applied to the calculated loss fraction. For
+        bifacial systems, this can be used to scale the snow loss by the
+        front-side energy fraction from a no-soiling simulation. For example,
+        use 0.9 when 90% of monthly energy is from the front side and 10% is
+        from the rear side. If None, no bifacial adjustment is applied. [-]
+        
     Returns
     -------
     loss : array-like
@@ -309,6 +317,10 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
     The parameter `string_factor` is an enhancement added to the model after
     publication of [1]_, as described in [2]_.
     The definition for snow events documented above is based on [3]_.
+
+    For bifacial systems, [2]_ recommends including both front-side and
+    rear-side insolation in ``poa_global``. The resulting loss may then be
+    scaled by the front-side energy fraction using ``front_side_fraction``.
 
     References
     ----------
@@ -383,5 +395,9 @@ def loss_townsend(snow_total, snow_events, surface_tilt, relative_humidity,
         / poa_global_kWh**0.67
         * string_factor
     )
+
+    if front_side_fraction is not None:
+        front_side_fraction = np.asarray(front_side_fraction)
+        loss_fraction = loss_fraction * front_side_fraction
 
     return np.clip(loss_fraction, 0, 1)

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -247,6 +247,8 @@ def test_loss_townsend_cases(poa_global, surface_tilt, slant_height,
         poa_global, slant_height, lower_edge_height, string_factor)
     actual = np.around(actual * 100)
     assert np.allclose(expected, actual)
+
+
 def test_loss_townsend_front_side_fraction():
     snow_total = np.array([25.4, 25.4, 12.7, 2.54, 0, 0, 0, 0, 0, 0, 12.7,
                            25.4])

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -247,3 +247,29 @@ def test_loss_townsend_cases(poa_global, surface_tilt, slant_height,
         poa_global, slant_height, lower_edge_height, string_factor)
     actual = np.around(actual * 100)
     assert np.allclose(expected, actual)
+
+    
+def test_loss_townsend_front_side_fraction():
+    snow_total = np.array([25.4, 25.4, 12.7, 2.54, 0, 0, 0, 0, 0, 0, 12.7,
+                           25.4])
+    snow_events = np.array([2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 2, 3])
+    surface_tilt = 20
+    relative_humidity = np.array([80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
+                                  80, 80])
+    temp_air = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    poa_global = np.array([350000, 350000, 350000, 350000, 350000, 350000,
+                           350000, 350000, 350000, 350000, 350000, 350000])
+    slant_height = 2.54
+    lower_edge_height = 0.254
+    front_side_fraction = 0.9
+
+    unadjusted = snow.loss_townsend(
+        snow_total, snow_events, surface_tilt, relative_humidity, temp_air,
+        poa_global, slant_height, lower_edge_height)
+
+    adjusted = snow.loss_townsend(
+        snow_total, snow_events, surface_tilt, relative_humidity, temp_air,
+        poa_global, slant_height, lower_edge_height,
+        front_side_fraction=front_side_fraction)
+
+    np.testing.assert_allclose(adjusted, unadjusted * front_side_fraction)

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -271,3 +271,4 @@ def test_loss_townsend_front_side_fraction():
         front_side_fraction=front_side_fraction)
 
     np.testing.assert_allclose(adjusted, unadjusted * front_side_fraction)
+

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -247,8 +247,6 @@ def test_loss_townsend_cases(poa_global, surface_tilt, slant_height,
         poa_global, slant_height, lower_edge_height, string_factor)
     actual = np.around(actual * 100)
     assert np.allclose(expected, actual)
-
-    
 def test_loss_townsend_front_side_fraction():
     snow_total = np.array([25.4, 25.4, 12.7, 2.54, 0, 0, 0, 0, 0, 0, 12.7,
                            25.4])

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -254,11 +254,9 @@ def test_loss_townsend_front_side_fraction():
                            25.4])
     snow_events = np.array([2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 2, 3])
     surface_tilt = 20
-    relative_humidity = np.array([80, 80, 80, 80, 80, 80, 80, 80, 80, 80,
-                                  80, 80])
-    temp_air = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-    poa_global = np.array([350000, 350000, 350000, 350000, 350000, 350000,
-                           350000, 350000, 350000, 350000, 350000, 350000])
+    relative_humidity = np.full(12, 80)
+    temp_air = np.full(12, 0)
+    poa_global = np.full(12, 350000)
     slant_height = 2.54
     lower_edge_height = 0.254
     front_side_fraction = 0.9


### PR DESCRIPTION
Add optional `front_side_fraction` argument to `loss_townsend` for bifacial snow loss adjustment. Includes test coverage for the scaling behavior.

## Description

This PR adds an optional `front_side_fraction` argument to `pvlib.snow.loss_townsend`.

The new argument allows users to scale the calculated Townsend snow loss by the front-side energy fraction for bifacial systems. This follows the bifacial guidance in Townsend and Previtali (2023), where bifacial snow modeling uses total front + rear POA in the Townsend calculation and then scales the resulting loss by the front-side energy contribution.

The default value is `None`, so existing behavior is unchanged.

## Changes

- Add optional `front_side_fraction` keyword argument to `loss_townsend`
- Document bifacial usage in the function docstring
- Add test coverage confirming that `front_side_fraction` scales the existing Townsend result correctly

## Backward compatibility

This change is backward compatible. When `front_side_fraction=None`, the function follows the existing behavior.

## Tests

Ran locally:

```bash
python -m pytest tests/test_snow.py -k townsend
python -m ruff check pvlib/snow.py tests/test_snow.py
```

Both passed.

## Checklist

- [ ] Closes #2755
- [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [x] Tests added
- [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
- [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`shethkajal7` ``).
- [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.
