### PR TITLE
Fix failing meteonorm tests

### DIFF
--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -34,11 +34,11 @@ def expected_meta():
             'description': 'Global horizontal irradiance',
             'name': 'global_horizontal_irradiance',
             'unit': {
-                'description': 'Watt per square meter', 'name': 'W/m**2'}},
+                'description': 'watt per square meter', 'name': 'W/m**2'}},
            {'aggregation_method': 'average',
             'description': 'Global horizontal irradiance with shading taken into account',  # noqa: E501
             'name': 'global_horizontal_irradiance_with_shading',
-            'unit': {'description': 'Watt per square meter',
+            'unit': {'description': 'watt per square meter',
                      'name': 'W/m**2'}},
         ],
         'surface_azimuth': 180,
@@ -245,7 +245,7 @@ def expected_meteonorm_tmy_meta():
             'aggregation_method': 'average',
             'description': 'Diffuse horizontal irradiance',
             'name': 'diffuse_horizontal_irradiance',
-            'unit': {'description': 'Watt per square meter',
+            'unit': {'description': 'watt per square meter',
                      'name': 'W/m**2'},
         }],
         'surface_azimuth': 90,


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

The Meteonorm API slightly changed the return metadata text, causing our tests to fail.  Example log: https://github.com/pvlib/pvlib-python/actions/runs/26162296722/job/76957024449

This PR makes the required minor updates to conform to the updated text.
