### PR TITLE
`read_nsrdb_psm4`: parse header with the `csv` module to keep quoted commas

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -26,6 +26,10 @@ Bug fixes
   represent the end of the averaging interval, consistent with ERA5
   conventions. (:issue:`2772`, :pull:`2773`)
 
+* :py:func:`pvlib.iotools.read_nsrdb_psm4` now parses the file header with the
+  :py:mod:`csv` module instead of a naive ``str.split(',')``, so quoted column
+  names containing commas (e.g. the material names in spectral-on-demand files)
+  are no longer split into spurious columns. (:issue:`2736`, :pull:`2771`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -67,6 +71,7 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 * :ghuser:`Omesh37`
+* :ghuser:`gaoflow`
 * Cliff Hansen (:ghuser:`cwhanse`)
 * :ghuser:`shethkajal7`
 * Arthur Onno (:ghuser:`ArthurOnnoTerabase`)

--- a/pvlib/iotools/psm4.py
+++ b/pvlib/iotools/psm4.py
@@ -6,6 +6,7 @@ https://developer.nlr.gov/docs/solar/nsrdb/nsrdb-GOES-conus-v4-0-0-download/
 https://developer.nlr.gov/docs/solar/nsrdb/nsrdb-GOES-full-disc-v4-0-0-download/
 """
 
+import csv
 import io
 from urllib.parse import urljoin
 import requests
@@ -723,11 +724,16 @@ def read_nsrdb_psm4(filename, map_variables=True):
        <https://web.archive.org/web/20170207203107/https://sam.nrel.gov/sites/default/files/content/documents/pdf/wfcsv.pdf>`_
     """
     with tools._file_context_manager(filename) as fbuf:
+        # The first 3 header lines are parsed with the csv module rather than a
+        # naive str.split(',') so that quoted fields containing commas are kept
+        # intact.  Spectral-on-demand files, for instance, have column names
+        # like '"GaAs (Bauhuis et al., 2009)"' whose embedded commas would
+        # otherwise be split into spurious columns (see GH #2736).
         # The first 2 lines of the response are headers with metadata
-        metadata_fields = fbuf.readline().split(',')
-        metadata_values = fbuf.readline().split(',')
+        metadata_fields = next(csv.reader([fbuf.readline()]))
+        metadata_values = next(csv.reader([fbuf.readline()]))
         # get the column names so we can set the dtypes
-        columns = fbuf.readline().split(',')
+        columns = next(csv.reader([fbuf.readline()]))
         columns[-1] = columns[-1].strip()  # strip trailing newline
         # Since the header has so many columns, excel saves blank cols in the
         # data below the header lines.

--- a/tests/iotools/test_psm4.py
+++ b/tests/iotools/test_psm4.py
@@ -185,6 +185,31 @@ def test_read_nsrdb_psm4_map_variables():
     assert_index_equal(data.columns, pd.Index(columns_mapped))
 
 
+def test_read_nsrdb_psm4_quoted_columns_with_commas():
+    """spectral-on-demand files have quoted column names containing commas;
+    these must not be split into spurious columns (GH #2736)"""
+    # Minimal NSRDB file whose column header (3rd line) has quoted material
+    # names with embedded commas, which is valid CSV. A naive str.split(',')
+    # would break these into extra columns and raise on read.
+    content = (
+        "Source,Location ID,City,State,Country,Latitude,Longitude,Time Zone,"
+        "Elevation,Local Time Zone,Version\n"
+        "NSRDB,1,-,-,-,40.0,-105.0,-7,1600,-7,4.0.1\n"
+        'Year,Month,Day,Hour,Minute,GHI,"GaAs (Bauhuis et al., 2009)",'
+        '"InGaP (Gray, 2008)"\n'
+        "2023,1,1,0,0,0,0.1,0.2\n"
+        "2023,1,1,1,0,5,0.3,0.4\n"
+    )
+    data, metadata = psm4.read_nsrdb_psm4(StringIO(content),
+                                          map_variables=False)
+    assert list(data.columns) == [
+        'Year', 'Month', 'Day', 'Hour', 'Minute', 'GHI',
+        'GaAs (Bauhuis et al., 2009)', 'InGaP (Gray, 2008)']
+    assert data.shape == (2, 8)
+    # the embedded-comma data columns round-trip as floats
+    assert data['GaAs (Bauhuis et al., 2009)'].tolist() == [0.1, 0.3]
+
+
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_nsrdb_psm4_aggregated_parameter_mapping(nlr_api_key):


### PR DESCRIPTION
- [x] Closes #2736
- [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
- [x] Tests added
- [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes. *(n/a — no API change)*
- [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes.
- [x] New code is fully documented. *(behavior unchanged for existing files; no public-API docstring change)*
- [x] Pull request is nearly complete and ready for detailed review.

**What this fixes**

`read_nsrdb_psm4` parsed its three header lines with a naive `str.split(',')`:

```python
metadata_fields = fbuf.readline().split(',')
metadata_values = fbuf.readline().split(',')
columns        = fbuf.readline().split(',')
```

The NSRDB spectral-on-demand CSVs reported in #2736 have **quoted** column
names that contain commas, e.g.

```
..., "GaAs (Bauhuis et al., 2009)","InGaP (Gray, 2008)", ...
```

These are valid CSV (the commas are inside quotes), and `pandas.read_csv`
parses the data rows correctly — but `str.split(',')` splits each quoted name
into multiple fragments, inflating the column count. The mismatch between the
mis-split `names`/`usecols` and the correctly-parsed data then raises on read.

**The change**

Parse the three header lines with the `csv` module (which honors quoting)
instead of `str.split(',')`. For ordinary (unquoted) files this is identical
to the previous behavior, so the existing readers are unaffected.

This addresses the parsing crash that @kandersolar confirmed should be
supported. The further `map_variables=True` unit handling for spectral files
(W/m²/µm → W/m²/nm) mentioned in the issue is a separate enhancement and is
left out of scope here.

**Reproduction (before this PR)**

```python
from io import StringIO
from pvlib.iotools import psm4

content = (
    "Source,Location ID,City,State,Country,Latitude,Longitude,Time Zone,"
    "Elevation,Local Time Zone,Version\n"
    "NSRDB,1,-,-,-,40.0,-105.0,-7,1600,-7,4.0.1\n"
    'Year,Month,Day,Hour,Minute,GHI,"GaAs (Bauhuis et al., 2009)",'
    '"InGaP (Gray, 2008)"\n'
    "2023,1,1,0,0,0,0.1,0.2\n"
    "2023,1,1,1,0,5,0.3,0.4\n"
)
psm4.read_nsrdb_psm4(StringIO(content), map_variables=False)
# ParserError: Too many columns specified: expected 10 and found 8
```

After the fix the quoted columns survive intact
(`'GaAs (Bauhuis et al., 2009)'`, `'InGaP (Gray, 2008)'`).

A regression test (`test_read_nsrdb_psm4_quoted_columns_with_commas`) is added
that fails on `main` and passes with this change; the existing
`read_nsrdb_psm4` tests continue to pass.
