### PR TITLE
Correct ERA5 timestamp convention

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -22,6 +22,10 @@ Bug fixes
   introduced in v0.15.1 (:pull:`2702`) that caused a broadcasting
   ``ValueError`` when ``tracker_theta`` was a 2-D (or higher rank) array.
   (:issue:`2747`, :pull:`2749`)
+* Document that timestamps returned by :py:func:`~pvlib.iotools.get_era5`
+  represent the end of the averaging interval, consistent with ERA5
+  conventions. (:issue:`2772`, :pull:`2773`)
+
 
 Enhancements
 ~~~~~~~~~~~~
@@ -42,9 +46,6 @@ Documentation
 * Clarifies how Linke turbidity values can be provided to
  :py:func:`pvlib.clearsky.ineichen` via
  :py:func:`pvlib.clearsky.lookup_linke_turbidity` (:issue:`2598`, :pull:`2746`)
-* Documented that timestamps returned by :py:func:`~pvlib.iotools.get_era5`
-  represent the end of the averaging interval, consistent with ERA5
-  conventions. (:issue:`2772`, :pull:`2773`)
 
 
 Testing

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -42,6 +42,9 @@ Documentation
 * Clarifies how Linke turbidity values can be provided to
  :py:func:`pvlib.clearsky.ineichen` via
  :py:func:`pvlib.clearsky.lookup_linke_turbidity` (:issue:`2598`, :pull:`2746`)
+* Documented that timestamps returned by :py:func:`~pvlib.iotools.get_era5`
+  represent the end of the averaging interval, consistent with ERA5
+  conventions. (:issue:`2772`, :pull:`2773`)
 
 
 Testing

--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -102,7 +102,7 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
     Returns
     -------
     data : pd.DataFrame
-        Time series data. The index corresponds to the start of the interval.
+        Time series data. The index corresponds to the end of the interval.
     meta : dict
         Metadata.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2772
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

See discussion in #2772.