### PR TITLE
Rename `ghi_from_poa_driesse_2023` to `ghi_from_poa_driesse_2024`

### DIFF
--- a/docs/examples/irradiance-transposition/plot_rtranpose_limitations.py
+++ b/docs/examples/irradiance-transposition/plot_rtranpose_limitations.py
@@ -28,7 +28,7 @@ Author: Anton Driesse
 #
 # In this example we look at a single point in time and consider a full range
 # of possible GHI and POA global values as shown in figures 3 and 4 of [1]_.
-# Then we use :py:meth:`pvlib.irradiance.ghi_from_poa_driesse_2023` to estimate
+# Then we use :py:meth:`pvlib.irradiance.ghi_from_poa_driesse_2024` to estimate
 # the original GHI from POA global.
 #
 # References
@@ -45,7 +45,7 @@ import matplotlib.pyplot as plt
 
 from pvlib.irradiance import (erbs_driesse,
                               get_total_irradiance,
-                              ghi_from_poa_driesse_2023,
+                              ghi_from_poa_driesse_2024,
                               )
 
 matplotlib.rcParams['axes.grid'] = True
@@ -92,7 +92,7 @@ poa_global = irrads['poa_global']
 
 poa_test = 200
 
-ghi_hat = ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
+ghi_hat = ghi_from_poa_driesse_2024(surface_tilt, surface_azimuth,
                                     solar_zenith, solar_azimuth,
                                     poa_test,
                                     dni_extra,
@@ -156,7 +156,7 @@ poa_global = irrads['poa_global']
 # out, other times not.
 #
 
-result = ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
+result = ghi_from_poa_driesse_2024(surface_tilt, surface_azimuth,
                                    solar_zenith, solar_azimuth,
                                    poa_global,
                                    dni_extra,

--- a/docs/examples/irradiance-transposition/plot_rtranpose_year.py
+++ b/docs/examples/irradiance-transposition/plot_rtranpose_year.py
@@ -21,7 +21,7 @@ Author: Anton Driesse
 # Recovering GHI from POA irradiance is termed "reverse transposition."
 #
 # In this example we start with a TMY file and calculate POA global irradiance.
-# Then we use :py:meth:`pvlib.irradiance.ghi_from_poa_driesse_2023` to estimate
+# Then we use :py:meth:`pvlib.irradiance.ghi_from_poa_driesse_2024` to estimate
 # the original GHI from POA global.  Details of the method found in [1]_.
 #
 # Another method for reverse tranposition called GTI-DIRINT is also
@@ -49,7 +49,7 @@ import pvlib
 from pvlib import iotools, location
 from pvlib.irradiance import (get_extra_radiation,
                               get_total_irradiance,
-                              ghi_from_poa_driesse_2023,
+                              ghi_from_poa_driesse_2024,
                               aoi,
                               )
 
@@ -114,7 +114,7 @@ solpos = solpos.reindex(df.index)
 
 start = time.process_time()
 
-df['ghi_rev'] = ghi_from_poa_driesse_2023(TILT, ORIENT,
+df['ghi_rev'] = ghi_from_poa_driesse_2024(TILT, ORIENT,
                                           solpos.apparent_zenith,
                                           solpos.azimuth,
                                           df.poa_global,

--- a/docs/sphinx/source/reference/irradiance/reverse-transposition.rst
+++ b/docs/sphinx/source/reference/irradiance/reverse-transposition.rst
@@ -6,5 +6,5 @@ Reverse transposition models
 .. autosummary::
    :toctree: ../generated/
 
-   irradiance.ghi_from_poa_driesse_2023
+   irradiance.ghi_from_poa_driesse_2024
    irradiance.gti_dirint

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -10,6 +10,11 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
+* Rename :py:func:`~pvlib.irradiance.ghi_from_poa_driesse_2023` to
+  :py:func:`~pvlib.irradiance.ghi_from_poa_driesse_2024`. The year now reflects
+  the publication data. The old name will be removed in v0.17.0.
+  (:issue:`2774`, :pull:`2777`)
+
 
 
 Bug fixes
@@ -62,3 +67,4 @@ Contributors
 * Cliff Hansen (:ghuser:`cwhanse`)
 * Arthur Onno (:ghuser:`ArthurOnnoTerabase`)
 * Adam R. Jensen (:ghuser:`AdamRJensen`)
+* Rajiv Daxini (:ghuser:`RDaxini`)

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -10,11 +10,10 @@ Breaking Changes
 
 Deprecations
 ~~~~~~~~~~~~
-* Rename :py:func:`~pvlib.irradiance.ghi_from_poa_driesse_2023` to
+* Rename :py:func:`!pvlib.irradiance.ghi_from_poa_driesse_2023` to
   :py:func:`~pvlib.irradiance.ghi_from_poa_driesse_2024`. The year now reflects
-  the publication data. The old name will be removed in v0.17.0.
+  the publication date. The old name will be removed in v0.17.0.
   (:issue:`2774`, :pull:`2777`)
-
 
 
 Bug fixes

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -16,7 +16,7 @@ from scipy.optimize import bisect
 from pvlib import atmosphere, solarposition, tools
 import pvlib  # used to avoid dni name collision in complete_irradiance
 
-from pvlib._deprecation import pvlibDeprecationWarning
+from pvlib._deprecation import pvlibDeprecationWarning, deprecated
 import warnings
 
 
@@ -1442,7 +1442,7 @@ def _poa_from_ghi(surface_tilt, surface_azimuth,
     Transposition function that includes decomposition of GHI using the
     continuous Erbs-Driesse model.
 
-    Helper function for ghi_from_poa_driesse_2023.
+    Helper function for ghi_from_poa_driesse_2024.
     '''
     # Contributed by Anton Driesse (@adriesse), PV Performance Labs. Nov., 2023
 
@@ -1468,7 +1468,7 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
     '''
     Reverse transposition function that uses the scalar bisection from scipy.
 
-    Helper function for ghi_from_poa_driesse_2023.
+    Helper function for ghi_from_poa_driesse_2024.
     '''
     # Contributed by Anton Driesse (@adriesse), PV Performance Labs. Nov., 2023
 
@@ -1512,7 +1512,7 @@ def _ghi_from_poa(surface_tilt, surface_azimuth,
     return ghi, conv, niter
 
 
-def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
+def ghi_from_poa_driesse_2024(surface_tilt, surface_azimuth,
                               solar_zenith, solar_azimuth,
                               poa_global,
                               dni_extra, airmass=None, albedo=0.25,
@@ -1612,6 +1612,14 @@ def ghi_from_poa_driesse_2023(surface_tilt, surface_azimuth,
         return ghi, conv, niter
     else:
         return ghi
+
+
+ghi_from_poa_driesse_2023 = deprecated(
+    since="0.15.2",
+    name="pvlib.irradiance.ghi_from_poa_driesse_2023",
+    alternative="pvlib.irradiance.ghi_from_poa_driesse_2024",
+    removal="0.17.0",
+)(ghi_from_poa_driesse_2024)
 
 
 def clearsky_index(ghi, ghi_clear, max_clearsky_index=2.0):

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -841,6 +841,13 @@ def test_ghi_from_poa_driesse(mocker):
     assert bisect_spy.call_args[1]["xtol"] == xtol
 
 
+def test_ghi_from_poa_driesse_2023_deprecated():
+    with pytest.warns(pvlibDeprecationWarning,
+                      match="ghi_from_poa_driesse_2024"):
+        irradiance.ghi_from_poa_driesse_2023(
+            30, 180, 20, 180, 500, dni_extra=1366.1)
+
+
 def test_gti_dirint():
     times = pd.DatetimeIndex(
         ['2014-06-24T06-0700', '2014-06-24T09-0700', '2014-06-24T12-0700'])

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -828,7 +828,7 @@ def test_ghi_from_poa_driesse(mocker):
     poa_global = pd.Series([20, 300, 1000], index=times)
     # test exception
     xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
-    with pytest.raises(ValueError, match=rf"xtol too small \({xtol:g} <= 0\)"):
+    with pytest.raises(ValueError, match=rf"xtol too small \({xtol} <= 0\)"):
         output = irradiance.ghi_from_poa_driesse_2024(
             surface_tilt, surface_azimuth, zenith, azimuth,
             poa_global, dni_extra=1366.1, xtol=xtol)

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -792,7 +792,7 @@ def test_ghi_from_poa_driesse(mocker):
     surface_azimuth = 180
 
     # test core function
-    output = irradiance.ghi_from_poa_driesse_2023(
+    output = irradiance.ghi_from_poa_driesse_2024(
         surface_tilt, surface_azimuth, zenith, azimuth,
         poa_global, dni_extra=1366.1)
 
@@ -802,7 +802,7 @@ def test_ghi_from_poa_driesse(mocker):
     # test series output
     poa_global = pd.Series([20, 300, 1000], index=times)
 
-    output = irradiance.ghi_from_poa_driesse_2023(
+    output = irradiance.ghi_from_poa_driesse_2024(
         surface_tilt, surface_azimuth, zenith, azimuth,
         poa_global, dni_extra=1366.1)
 
@@ -811,7 +811,7 @@ def test_ghi_from_poa_driesse(mocker):
     # test full_output option and special cases
     poa_global = np.array([0, 1500, np.nan])
 
-    ghi, conv, niter = irradiance.ghi_from_poa_driesse_2023(
+    ghi, conv, niter = irradiance.ghi_from_poa_driesse_2024(
         surface_tilt, surface_azimuth, zenith, azimuth,
         poa_global, dni_extra=1366.1, full_output=True)
 
@@ -829,13 +829,13 @@ def test_ghi_from_poa_driesse(mocker):
     # test exception
     xtol = -3.14159  # negative value raises exception in scipy.optimize.bisect
     with pytest.raises(ValueError, match=rf"xtol too small \({xtol:g} <= 0\)"):
-        output = irradiance.ghi_from_poa_driesse_2023(
+        output = irradiance.ghi_from_poa_driesse_2024(
             surface_tilt, surface_azimuth, zenith, azimuth,
             poa_global, dni_extra=1366.1, xtol=xtol)
     # test propagation
     xtol = 3.141592
     bisect_spy = mocker.spy(irradiance, "bisect")
-    output = irradiance.ghi_from_poa_driesse_2023(
+    output = irradiance.ghi_from_poa_driesse_2024(
         surface_tilt, surface_azimuth, zenith, azimuth,
         poa_global, dni_extra=1366.1, xtol=xtol)
     assert bisect_spy.call_args[1]["xtol"] == xtol


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2774 
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
