### PR TITLE
Address pandas deprecation warnings in test suite

### DIFF
--- a/tests/test_pvsystem.py
+++ b/tests/test_pvsystem.py
@@ -2422,10 +2422,10 @@ def test_PVSystem_single_array():
 
 
 def test_combine_loss_factors():
-    test_index = pd.date_range(start='1990/01/01T12:00', periods=365, freq='d')
+    test_index = pd.date_range(start='1990/01/01T12:00', periods=365, freq='D')
     loss_1 = pd.Series(.10, index=test_index)
     loss_2 = pd.Series(.05, index=pd.date_range(start='1990/01/01T12:00',
-                                                periods=365*2, freq='d'))
+                                                periods=365*2, freq='D'))
     loss_3 = pd.Series(.02, index=pd.date_range(start='1990/01/01',
                                                 periods=12, freq='MS'))
     expected = pd.Series(.1621, index=test_index)


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

A trivial PR to address these pandas warnings:

```
tests/test_pvsystem.py::test_combine_loss_factors
  /home/runner/work/pvlib-python/pvlib-python/tests/test_pvsystem.py:2425: Pandas4Warning: 'd' is deprecated and will be removed in a future version, please use 'D' instead.
    test_index = pd.date_range(start='1990/01/01T12:00', periods=365, freq='d')

tests/test_pvsystem.py::test_combine_loss_factors
  /home/runner/work/pvlib-python/pvlib-python/tests/test_pvsystem.py:2427: Pandas4Warning: 'd' is deprecated and will be removed in a future version, please use 'D' instead.
    loss_2 = pd.Series(.05, index=pd.date_range(start='1990/01/01T12:00',
```

https://github.com/pvlib/pvlib-python/actions/runs/27138420944/job/80096740936#step:9:90

