### PR TITLE
Add dataset option to get_era5

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -39,12 +39,13 @@ Enhancements
 ~~~~~~~~~~~~
 * Add the ``front_side_fraction`` parameter to
   :py:func:`pvlib.snow.loss_townsend` to support Townsend snow-loss
-  workflows for bifacial systems. (:issue:`2755`, :pull:`2756`)
-  
-* Added mapping of the parameter ``"albedo"`` in
+  workflows for bifacial systems. (:issue:`2755`, :pull:`2756`)  
+* Add mapping of the parameter ``"albedo"`` in
   :py:func:`~pvlib.iotools.get_nasa_power` when ``map_variables=True``
   (:pull:`2753`)
-
+* Add ``dataset`` parameter to :py:func:`~pvlib.iotools.get_era5`
+  allowing for choosing between ERA5 and ERA5-Land datasets.
+  (pull:`2780`)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -69,7 +69,7 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
     This API [2]_ provides a subset of parameters of the full ERA5 datasets,
     see [3]_ for available variables. A comparison of ERA5 and ERA5-land is
     available in [4]_.
-    
+
     Parameters
     ----------
     latitude : float

--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -66,9 +66,10 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
 
     A CDS API key is needed to access this API.  Register for one at [1]_.
 
-    This API [2]_ provides a subset of the full ERA5 dataset.  See [3]_ for
-    the available variables.  Data are available on a 0.25° x 0.25° grid.
-
+    This API [2]_ provides a subset of parameters of the full ERA5 datasets,
+    see [3]_ for available variables. A comparison of ERA5 and ERA5-land is
+    available in [4]_.
+    
     Parameters
     ----------
     latitude : float
@@ -116,6 +117,7 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
     .. [1] https://cds.climate.copernicus.eu/
     .. [2] https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-timeseries?tab=overview
     .. [3] https://confluence.ecmwf.int/pages/viewpage.action?pageId=505390919
+    .. [4] https://confluence.ecmwf.int/display/CKB/The+family+of+ERA5+datasets
     """  # noqa: E501
 
     def _to_utc_dt_notz(dt):

--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -58,6 +58,7 @@ UNITS = {
 
 
 def get_era5(latitude, longitude, start, end, variables, api_key,
+             dataset="reanalysis-era5-single-levels-timeseries",
              map_variables=True, timeout=60,
              url='https://cds.climate.copernicus.eu/api/retrieve/v1/'):
     """
@@ -84,6 +85,10 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
         See [1]_ for additional options.
     api_key : str
         ECMWF CDS API key.
+    dataset : str, default "reanalysis-era5-single-levels-timeseries"
+        The dataset to query.  May be either
+        "reanalysis-era5-single-levels-timeseries" or
+        "reanalysis-era5-land-timeseries".
     map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. Also converts units of some variables. See variable
@@ -137,7 +142,7 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
             "data_format": "csv"
         }
     }
-    slug = "processes/reanalysis-era5-single-levels-timeseries/execution"
+    slug = f"processes/{dataset}/execution"
     response = requests.post(url + slug, json=params, headers=headers,
                              timeout=timeout)
     submission_response = response.json()

--- a/pvlib/iotools/era5.py
+++ b/pvlib/iotools/era5.py
@@ -86,10 +86,10 @@ def get_era5(latitude, longitude, start, end, variables, api_key,
         See [1]_ for additional options.
     api_key : str
         ECMWF CDS API key.
-    dataset : str, default "reanalysis-era5-single-levels-timeseries"
+    dataset : str, default ``"reanalysis-era5-single-levels-timeseries"``
         The dataset to query.  May be either
-        "reanalysis-era5-single-levels-timeseries" or
-        "reanalysis-era5-land-timeseries".
+        ``"reanalysis-era5-single-levels-timeseries"`` or
+        ``"reanalysis-era5-land-timeseries"``. See [4]_ for details.
     map_variables : bool, default True
         When true, renames columns of the DataFrame to pvlib variable names
         where applicable. Also converts units of some variables. See variable

--- a/tests/iotools/test_era5.py
+++ b/tests/iotools/test_era5.py
@@ -3,6 +3,7 @@ tests for pvlib/iotools/era5.py
 """
 
 import pandas as pd
+import numpy as np
 import pytest
 import pvlib
 import requests

--- a/tests/iotools/test_era5.py
+++ b/tests/iotools/test_era5.py
@@ -55,8 +55,8 @@ def test_get_era5(params, expected):
 def test_get_era5_land(params, expected):
     params['dataset'] = "reanalysis-era5-land-timeseries"
     df, meta = pvlib.iotools.get_era5(**params)
-    assert meta['longitude'] == -80.0
-    assert meta['latitude'] == 40.0
+    assert np.isclose(meta['longitude'], -80.0)
+    assert np.isclose(meta['latitude'], 40.0)
     assert pd.testing.assert_index_equal(df.index, expected.index)
 
 

--- a/tests/iotools/test_era5.py
+++ b/tests/iotools/test_era5.py
@@ -51,6 +51,17 @@ def test_get_era5(params, expected):
 @requires_ecmwf_credentials
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
+def test_get_era5_land(params, expected):
+    params['dataset'] = "reanalysis-era5-land-timeseries"
+    df, meta = pvlib.iotools.get_era5(**params)
+    assert meta['longitude'] == -80.0
+    assert meta['latitude'] == 40.0
+    assert pd.testing.assert_index_equal(df.index, expected.index)
+
+
+@requires_ecmwf_credentials
+@pytest.mark.remote_data
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_era5_timezone(params, expected):
     params['start'] = pd.to_datetime(params['start']).tz_localize('Etc/GMT+8')
     params['end'] = pd.to_datetime(params['end']).tz_localize('Etc/GMT+8')

--- a/tests/iotools/test_era5.py
+++ b/tests/iotools/test_era5.py
@@ -43,8 +43,8 @@ def expected():
 def test_get_era5(params, expected):
     df, meta = pvlib.iotools.get_era5(**params)
     pd.testing.assert_frame_equal(df, expected, check_freq=False, atol=0.1)
-    assert meta['longitude'] == -80.0
-    assert meta['latitude'] == 40.0
+    assert np.isclose(meta['longitude'], -80.0)
+    assert np.isclose(meta['latitude'], 40.0)
     assert isinstance(meta['jobID'], str)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

This PR adds a new parameter to the ``get_era5`` function, such that users can change the dataset to be ERA5-land instead of ERA5.