### PR TITLE
Deprecate and disable `data_version` parameter in `get_meteonorm_tmy`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -37,9 +37,9 @@ Bug fixes
   :py:mod:`csv` module instead of a naive ``str.split(',')``, so quoted column
   names containing commas (e.g. the material names in spectral-on-demand files)
   are no longer split into spurious columns. (:issue:`2736`, :pull:`2771`)
-* Deprecate ``data_version`` parameter of
-  :py:func:`~pvlib.iotools.get_meteonorm_tmy` as this parameter is no longer
-  supported by the Meteonorm API. (:pull:`2781`)
+* Update :py:func:`~pvlib.iotools.get_meteonorm_tmy` to comply
+  with the updated Meteonorm API.  As part of this, the ``data_version``
+  parameter now has no effect and will be removed in the future. (:pull:`2781`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -37,6 +37,9 @@ Bug fixes
   :py:mod:`csv` module instead of a naive ``str.split(',')``, so quoted column
   names containing commas (e.g. the material names in spectral-on-demand files)
   are no longer split into spurious columns. (:issue:`2736`, :pull:`2771`)
+* Remove ``data_version`` parameter from
+  :py:func:`~pvlib.iotools.get_meteonorm_tmy` as this parameter is no longer
+  supported and results in an error. (:pull:`2781`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -37,9 +37,9 @@ Bug fixes
   :py:mod:`csv` module instead of a naive ``str.split(',')``, so quoted column
   names containing commas (e.g. the material names in spectral-on-demand files)
   are no longer split into spurious columns. (:issue:`2736`, :pull:`2771`)
-* Remove ``data_version`` parameter from
+* Deprecate ``data_version`` parameter of
   :py:func:`~pvlib.iotools.get_meteonorm_tmy` as this parameter is no longer
-  supported and results in an error. (:pull:`2781`)
+  supported by the Meteonorm API. (:pull:`2781`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pvlib/iotools/meteonorm.py
+++ b/pvlib/iotools/meteonorm.py
@@ -402,8 +402,8 @@ def get_meteonorm_tmy(
         surface_tilt=0, surface_azimuth=180,
         time_step="1h", horizon="auto", terrain_situation="open",
         albedo=None, turbidity="auto", random_seed=None,
-        clear_sky_radiation_model="esra", future_scenario=None,
-        future_year=None, interval_index=False,
+        clear_sky_radiation_model="esra", data_version=None,
+        future_scenario=None, future_year=None, interval_index=False,
         map_variables=True, url=URL):
     """
     Retrieve TMY irradiance and weather data from Meteonorm.
@@ -448,6 +448,8 @@ def get_meteonorm_tmy(
         with the same random seed will yield identical results.
     clear_sky_radiation_model : str, default : 'esra'
         Which clearsky model to use. Must be either `'esra'` or `'solis'`.
+    data_version : str, optional
+        Deprecated parameter.  Has no effect.
     future_scenario : str, optional
         Future climate scenario.
     future_year : int, optional
@@ -491,7 +493,13 @@ def get_meteonorm_tmy(
        <https://docs.meteonorm.com/docs/getting-started>`_
     .. [3] `Meteonorm API reference
        <https://docs.meteonorm.com/api>`_
-    """
+    if data_version is not None:
+        msg = (
+            "This parameter was removed from the Meteonorm API "
+            "and now has no effect."
+        )
+        warn_deprecated(since="0.15.2", removal="0.16.0", name="data_version",
+                        addendum=msg)
     additional_params = {
         "situation": terrain_situation,
         "turbidity": turbidity,

--- a/pvlib/iotools/meteonorm.py
+++ b/pvlib/iotools/meteonorm.py
@@ -493,6 +493,7 @@ def get_meteonorm_tmy(
        <https://docs.meteonorm.com/docs/getting-started>`_
     .. [3] `Meteonorm API reference
        <https://docs.meteonorm.com/api>`_
+    """
     if data_version is not None:
         msg = (
             "This parameter was removed from the Meteonorm API "

--- a/pvlib/iotools/meteonorm.py
+++ b/pvlib/iotools/meteonorm.py
@@ -402,8 +402,8 @@ def get_meteonorm_tmy(
         surface_tilt=0, surface_azimuth=180,
         time_step="1h", horizon="auto", terrain_situation="open",
         albedo=None, turbidity="auto", random_seed=None,
-        clear_sky_radiation_model="esra", data_version="latest",
-        future_scenario=None, future_year=None, interval_index=False,
+        clear_sky_radiation_model="esra", future_scenario=None,
+        future_year=None, interval_index=False,
         map_variables=True, url=URL):
     """
     Retrieve TMY irradiance and weather data from Meteonorm.
@@ -448,8 +448,6 @@ def get_meteonorm_tmy(
         with the same random seed will yield identical results.
     clear_sky_radiation_model : str, default : 'esra'
         Which clearsky model to use. Must be either `'esra'` or `'solis'`.
-    data_version : str, default : 'latest'
-        Version of Meteonorm climatological data to be used.
     future_scenario : str, optional
         Future climate scenario.
     future_year : int, optional
@@ -498,7 +496,6 @@ def get_meteonorm_tmy(
         "situation": terrain_situation,
         "turbidity": turbidity,
         "clear_sky_radiation_model": clear_sky_radiation_model,
-        "data_version": data_version,
         "random_seed": random_seed,
         "future_scenario": future_scenario,
         "future_year": future_year,

--- a/pvlib/iotools/meteonorm.py
+++ b/pvlib/iotools/meteonorm.py
@@ -5,6 +5,8 @@ import requests
 from urllib.parse import urljoin
 from pandas._libs.tslibs.parsing import DateParseError
 
+from pvlib._deprecation import warn_deprecated
+
 URL = "https://api.meteonorm.com/v1/"
 
 VARIABLE_MAP = {

--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -321,11 +321,12 @@ def test_get_meteonorm_tmy(
 @fail_on_pvlib_version('0.17.0')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
-def test_get_meteonorm_tmy_data_version_deprecation(demo_api_key):
+def test_get_meteonorm_tmy_data_version_deprecation(demo_url, demo_api_key):
     with pytest.warns(pvlibDeprecationWarning):
         _ = pvlib.iotools.get_meteonorm_tmy(
             latitude=50,
             longitude=10,
             api_key=demo_api_key,
             data_version="latest",
+            url=demo_url
         )

--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import pytest
 import pvlib
-from tests.conftest import RERUNS, RERUNS_DELAY
+from tests.conftest import RERUNS, RERUNS_DELAY, fail_on_pvlib_version
 from requests.exceptions import HTTPError
 
 from pvlib._deprecation import pvlibDeprecationWarning
@@ -319,11 +319,13 @@ def test_get_meteonorm_tmy(
 
 
 @fail_on_pvlib_version('0.17.0')
+@pytest.mark.remote_data
+@pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_meteonorm_tmy_data_version_deprecation(demo_api_key):
     with pytest.warns(pvlibDeprecationWarning):
         _ = pvlib.iotools.get_meteonorm_tmy(
-            latitude,
-            longitude,
+            latitude=50,
+            longitude=10,
             api_key=demo_api_key,
             data_version="latest",
         )

--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -318,7 +318,7 @@ def test_get_meteonorm_tmy(
                                   check_exact=False, atol=1)
 
 
-@fail_on_pvlib_version('0.17.0')
+@fail_on_pvlib_version('0.16.0')
 @pytest.mark.remote_data
 @pytest.mark.flaky(reruns=RERUNS, reruns_delay=RERUNS_DELAY)
 def test_get_meteonorm_tmy_data_version_deprecation(demo_url, demo_api_key):

--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -302,7 +302,6 @@ def test_get_meteonorm_tmy(
         turbidity=[5.2, 4, 3, 3.1, 3.0, 2.8, 3.14, 3.0, 3, 3, 4, 5],
         random_seed=100,
         clear_sky_radiation_model='solis',
-        data_version='v9.0',  # fix version
         future_scenario='ssp1_26',
         future_year=2030,
         interval_index=True,

--- a/tests/iotools/test_meteonorm.py
+++ b/tests/iotools/test_meteonorm.py
@@ -5,6 +5,8 @@ import pvlib
 from tests.conftest import RERUNS, RERUNS_DELAY
 from requests.exceptions import HTTPError
 
+from pvlib._deprecation import pvlibDeprecationWarning
+
 
 @pytest.fixture
 def demo_api_key():
@@ -314,3 +316,14 @@ def test_get_meteonorm_tmy(
     # calls.  so we allow a small amount of variation with atol.
     pd.testing.assert_frame_equal(data.iloc[:12], expected_meteonorm_tmy_data,
                                   check_exact=False, atol=1)
+
+
+@fail_on_pvlib_version('0.17.0')
+def test_get_meteonorm_tmy_data_version_deprecation(demo_api_key):
+    with pytest.warns(pvlibDeprecationWarning):
+        _ = pvlib.iotools.get_meteonorm_tmy(
+            latitude,
+            longitude,
+            api_key=demo_api_key,
+            data_version="latest",
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
The remote data tests are currently failing due to the ``get_meteonorm_tmy`` function no longer supporting the ``data_version`` parameter.