### PR TITLE
Clarify rh_from_tdew variable naming, comments and references

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -53,6 +53,14 @@ Documentation
 * Clarify how Linke turbidity values can be provided to
   :py:func:`pvlib.clearsky.ineichen` via
   :py:func:`pvlib.clearsky.lookup_linke_turbidity`. (:issue:`2598`, :pull:`2746`)
+* Clarifies how Linke turbidity values can be provided to
+ :py:func:`pvlib.clearsky.ineichen` via
+ :py:func:`pvlib.clearsky.lookup_linke_turbidity` (:issue:`2598`, :pull:`2746`)
+* Clarifies the variable naming, comments and references in
+  :py:func:`pvlib.atmosphere.rh_from_tdew` (and the related comments in
+  :py:func:`pvlib.atmosphere.tdew_from_rh`) so the actual and saturation vapor
+  pressures are no longer swapped in the source. The returned values are
+  unchanged. (:issue:`2734`, :pull:`2782`)
 
 
 Testing

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -58,8 +58,8 @@ Documentation
  :py:func:`pvlib.clearsky.lookup_linke_turbidity` (:issue:`2598`, :pull:`2746`)
 * Clarifies the variable naming, comments and references in
   :py:func:`pvlib.atmosphere.rh_from_tdew` (and the related comments in
-  :py:func:`pvlib.atmosphere.tdew_from_rh`) so the actual and saturation vapor
-  pressures are no longer swapped in the source. The returned values are
+  :py:func:`pvlib.atmosphere.tdew_from_rh`) related to the actual
+  and saturation vapor pressures. Function output is
   unchanged. (:issue:`2734`, :pull:`2782`)
 
 

--- a/docs/sphinx/source/whatsnew/v0.15.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.2.rst
@@ -53,14 +53,6 @@ Documentation
 * Clarify how Linke turbidity values can be provided to
   :py:func:`pvlib.clearsky.ineichen` via
   :py:func:`pvlib.clearsky.lookup_linke_turbidity`. (:issue:`2598`, :pull:`2746`)
-* Clarifies how Linke turbidity values can be provided to
- :py:func:`pvlib.clearsky.ineichen` via
- :py:func:`pvlib.clearsky.lookup_linke_turbidity` (:issue:`2598`, :pull:`2746`)
-* Clarifies the variable naming, comments and references in
-  :py:func:`pvlib.atmosphere.rh_from_tdew` (and the related comments in
-  :py:func:`pvlib.atmosphere.tdew_from_rh`) related to the actual
-  and saturation vapor pressures. Function output is
-  unchanged. (:issue:`2734`, :pull:`2782`)
 
 
 Testing

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -41,6 +41,11 @@ Documentation
   example; the correct parameter name is ``time_step``. (:issue:`2791`)
 * Standardized diffuse component names and descriptions in the docstrings of
   multiple functions in :py:mod:`pvlib.irradiance`. (:pull:`2827`)
+* Clarifies the variable naming, comments and references in
+  :py:func:`pvlib.atmosphere.rh_from_tdew` (and the related comments in
+  :py:func:`pvlib.atmosphere.tdew_from_rh`) related to the actual
+  and saturation vapor pressures. Function output is
+  unchanged. (:issue:`2734`, :pull:`2782`)
 
 
 Testing

--- a/pvlib/atmosphere.py
+++ b/pvlib/atmosphere.py
@@ -365,9 +365,9 @@ def rh_from_tdew(temp_air, temp_dew, coeff=(6.112, 17.62, 243.12)):
 
     Notes
     -----
-    Relative humidity is computed as ``100 * e / es``, where the actual vapor
-    pressure ``e`` is the saturation vapor pressure at the dew point and the
-    saturation vapor pressure ``es`` is evaluated at the air temperature, both
+    Relative humidity is computed as ``100 * e / es``, where ``e`` is the
+    saturation vapor pressure at the dew point temperature, and ``es``
+    is the saturation vapor pressure at the air temperature, both
     from the Magnus equation ``A * exp(B * T / (C + T))``. The default
     coefficients ``(A, B, C) = (6.112, 17.62, 243.12)`` are the WMO-recommended
     Magnus form for saturation over liquid water, valid for temperatures from

--- a/pvlib/atmosphere.py
+++ b/pvlib/atmosphere.py
@@ -370,8 +370,8 @@ def rh_from_tdew(temp_air, temp_dew, coeff=(6.112, 17.62, 243.12)):
     saturation vapor pressure ``es`` is evaluated at the air temperature, both
     from the Magnus equation ``A * exp(B * T / (C + T))``. The default
     coefficients ``(A, B, C) = (6.112, 17.62, 243.12)`` are the WMO-recommended
-    Magnus form [1]_, valid for saturation over liquid water (see [2]_ for the
-    approximation and its temperature range).
+    Magnus form for saturation over liquid water, valid for temperatures from
+    -45 to +60 °C [1]_; see [2]_ for the approximation and its accuracy.
 
     References
     ----------

--- a/pvlib/atmosphere.py
+++ b/pvlib/atmosphere.py
@@ -363,19 +363,34 @@ def rh_from_tdew(temp_air, temp_dew, coeff=(6.112, 17.62, 243.12)):
     numeric
         Relative humidity (0.0-100.0). [%]
 
+    Notes
+    -----
+    Relative humidity is computed as ``100 * e / es``, where the actual vapor
+    pressure ``e`` is the saturation vapor pressure at the dew point and the
+    saturation vapor pressure ``es`` is evaluated at the air temperature, both
+    from the Magnus equation ``A * exp(B * T / (C + T))``. The default
+    coefficients ``(A, B, C) = (6.112, 17.62, 243.12)`` are the WMO-recommended
+    Magnus form [1]_, valid for saturation over liquid water (see [2]_ for the
+    approximation and its temperature range).
+
     References
     ----------
     .. [1] "Guide to Instruments and Methods of Observation",
        World Meteorological Organization, WMO-No. 8, 2023.
        https://library.wmo.int/idurl/4/68695
+    .. [2] O. A. Alduchov and R. E. Eskridge, "Improved Magnus Form
+       Approximation of Saturation Vapor Pressure", Journal of Applied
+       Meteorology, 35(4), pp. 601-609, 1996.
     """
 
-    # Calculate vapor pressure (e) and saturation vapor pressure (es)
-    e = coeff[0] * np.exp((coeff[1] * temp_air) / (coeff[2] + temp_air))
-    es = coeff[0] * np.exp((coeff[1] * temp_dew) / (coeff[2] + temp_dew))
+    # Actual vapor pressure ``e`` is the saturation vapor pressure at the dew
+    # point; the saturation vapor pressure ``es`` is taken at the air
+    # temperature. Both come from the Magnus equation.
+    e = coeff[0] * np.exp((coeff[1] * temp_dew) / (coeff[2] + temp_dew))
+    es = coeff[0] * np.exp((coeff[1] * temp_air) / (coeff[2] + temp_air))
 
-    # Calculate relative humidity as percentage
-    relative_humidity = 100 * (es / e)
+    # Relative humidity is their ratio, as a percentage.
+    relative_humidity = 100 * (e / es)
 
     return relative_humidity
 
@@ -406,17 +421,14 @@ def tdew_from_rh(temp_air, relative_humidity, coeff=(6.112, 17.62, 243.12)):
        World Meteorological Organization, WMO-No. 8, 2023.
        https://library.wmo.int/idurl/4/68695
     """
-    # Calculate the term inside the log
-    # From RH = 100 * (es/e), we get es = (RH/100) * e
-    # Substituting the Magnus equation and solving for dewpoint
-
-    # First calculate ln(es/A)
+    # Invert RH = 100 * (e / es): the actual vapor pressure is
+    # e = (RH / 100) * es, and the dew point is the temperature at which the
+    # saturation vapor pressure equals e. Substituting the Magnus equation for
+    # both and solving for the dew point gives the expression below.
     ln_term = (
         (coeff[1] * temp_air) / (coeff[2] + temp_air)
-        + np.log(relative_humidity/100)
+        + np.log(relative_humidity / 100)
     )
-
-    # Then solve for dewpoint
     dewpoint = coeff[2] * ln_term / (coeff[1] - ln_term)
 
     return dewpoint

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -175,6 +175,19 @@ def test_rh_from_tdew():
     assert np.isclose(rh_float, relative_humidity_wmo.iloc[0])
 
 
+def test_rh_from_tdew_physical_bounds():
+    # The dew point cannot exceed the air temperature: equal values mean the
+    # air is saturated (100% RH), and a lower dew point gives a lower RH. This
+    # pins the direction of the calculation so it cannot silently invert.
+    assert atmosphere.rh_from_tdew(
+        temp_air=20.0, temp_dew=20.0
+    ) == pytest.approx(100.0)
+    assert atmosphere.rh_from_tdew(temp_air=20.0, temp_dew=10.0) < 100.0
+    assert atmosphere.rh_from_tdew(
+        temp_air=20.0, temp_dew=5.0
+    ) < atmosphere.rh_from_tdew(temp_air=20.0, temp_dew=15.0)
+
+
 # Unit tests
 def test_tdew_from_rh():
 


### PR DESCRIPTION
 - [x] Closes #2734
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

**This is a clarity change with no change to the returned values.** As noted in #2734 and independently confirmed by @echedey-ls (cross-checked against an online calculator and NREL's pvdeg), `rh_from_tdew` already returns correct relative humidity — e.g. `rh_from_tdew(20, 10) == 52.56 %`, `rh_from_tdew(25, 25) == 100 %`, and it round-trips with `tdew_from_rh`. What confused the report is that the two intermediate variables were named backwards: `e` was computed from `temp_air` (so it was really the *saturation* pressure) and `es` from `temp_dew` (the *actual* pressure), and `100 * es/e` with those swapped names happens to equal the conventional `100 * e/es`.

Changes:
- Compute `e` from the dew point (actual vapor pressure) and `es` from the air temperature (saturation) so the source matches the usual convention, and write `100 * e/es`. **Numerically identical** — the existing value-pinning tests (`test_rh_from_tdew`, `test_tdew_from_rh`, `test_tdew_to_rh_to_tdew`) pass unchanged.
- Fix the now-inaccurate derivation comment in `tdew_from_rh` (it referenced `es/e`).
- Add a short `Notes` section and the Alduchov & Eskridge (1996) reference for the Magnus form, since the WMO guide alone doesn't name it (per @echedey-ls).
- Add a physical-bounds regression test: saturation when dew point == air temperature, RH below 100 % otherwise and monotonic in the dew point, so the direction can't silently invert.

I left the `exp`-division micro-optimisation @echedey-ls mentioned out of this first pass since he flagged maintainers may differ on it — happy to add it (or expand the applicability notes with a max-error / valid-range figure) if wanted.
