### PR TITLE
Remove empty horizon component from `irradiance.haydavies`

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.16.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.16.0.rst
@@ -7,7 +7,7 @@ v0.16.0
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 * Remove empty ``poa_horizon`` key from the ``diffuse_components`` output of
-  :py:func:`pvlib.irradiance.haydavies` when ``return_components=True``.
+  :py:func:`pvlib.irradiance.haydavies`.
   (:pull:`2788`)
 
 

--- a/docs/sphinx/source/whatsnew/v0.16.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.16.0.rst
@@ -6,7 +6,7 @@ v0.16.0
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-* Remove empty ``poa_horizon`` component from the output of
+* Remove empty ``poa_horizon`` key from the ``diffuse_components`` output of
   :py:func:`pvlib.irradiance.haydavies` when ``return_components=True``.
   (:pull:`2788`)
 

--- a/docs/sphinx/source/whatsnew/v0.16.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.16.0.rst
@@ -1,0 +1,48 @@
+.. _whatsnew_0_16_0:
+
+
+v0.16.0
+-----------------------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+* Remove empty horizon component from the output of
+:py:func:`pvlib.irradiance.haydavies` when ``return_components=True``.
+(:pull:`2788`)
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Testing
+~~~~~~~
+
+
+Benchmarking
+~~~~~~~~~~~~
+
+
+Requirements
+~~~~~~~~~~~~
+
+
+Maintenance
+~~~~~~~~~~~
+
+
+Contributors
+~~~~~~~~~~~~
+

--- a/docs/sphinx/source/whatsnew/v0.16.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.16.0.rst
@@ -6,9 +6,9 @@ v0.16.0
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-* Remove empty horizon component from the output of
-:py:func:`pvlib.irradiance.haydavies` when ``return_components=True``.
-(:pull:`2788`)
+* Remove empty ``poa_horizon`` component from the output of
+  :py:func:`pvlib.irradiance.haydavies` when ``return_components=True``.
+  (:pull:`2788`)
 
 
 Deprecations

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -797,7 +797,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
             * poa_sky_diffuse: Total sky diffuse
             * poa_isotropic
             * poa_circumsolar
-        The model does not support a horizon brightening component.
+        The model does not include a horizon brightening component.
 
     Notes
     ------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -797,8 +797,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
             * poa_sky_diffuse: Total sky diffuse
             * poa_isotropic
             * poa_circumsolar
-            * poa_horizon (always zero, not accounted for by the
-              Hay-Davies model)
+        The model does not support a horizon brightening component.
 
     Notes
     ------
@@ -862,8 +861,6 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         # Calculate the individual components
         diffuse_components['poa_isotropic'] = poa_isotropic
         diffuse_components['poa_circumsolar'] = poa_circumsolar
-        diffuse_components['poa_horizon'] = np.where(
-            np.isnan(diffuse_components['poa_isotropic']), np.nan, 0.)
 
         if isinstance(sky_diffuse, pd.Series):
             diffuse_components = pd.DataFrame(diffuse_components)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -797,7 +797,6 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
             * poa_sky_diffuse: Total sky diffuse
             * poa_isotropic
             * poa_circumsolar
-        The model does not include a horizon brightening component.
 
     Notes
     ------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -783,7 +783,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
 
     Returns
     --------
-    numeric, OrderedDict, or DataFrame
+    numeric, Dict, or DataFrame
         Return type controlled by ``return_components`` argument.
         If `False`, ``sky_diffuse`` is returned.
         If `True`, ``diffuse_components`` is returned.
@@ -792,7 +792,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         The sky diffuse component of the solar radiation on a tilted
         surface. [Wm⁻²]
 
-    diffuse_components : OrderedDict (array input) or DataFrame (Series input)
+    diffuse_components : Dict (array input) or DataFrame (Series input)
         Keys/columns are:
             * poa_sky_diffuse: Total sky diffuse
             * poa_isotropic
@@ -855,12 +855,11 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     sky_diffuse = poa_isotropic + poa_circumsolar
 
     if return_components:
-        diffuse_components = OrderedDict()
-        diffuse_components['poa_sky_diffuse'] = sky_diffuse
-
-        # Calculate the individual components
-        diffuse_components['poa_isotropic'] = poa_isotropic
-        diffuse_components['poa_circumsolar'] = poa_circumsolar
+        diffuse_components = {
+            'poa_sky_diffuse': sky_diffuse,
+            'poa_isotropic': poa_isotropic,
+            'poa_circumsolar': poa_circumsolar
+        }
 
         if isinstance(sky_diffuse, pd.Series):
             diffuse_components = pd.DataFrame(diffuse_components)

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -783,7 +783,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
 
     Returns
     --------
-    numeric, Dict, or DataFrame
+    numeric, dict, or DataFrame
         Return type controlled by ``return_components`` argument.
         If `False`, ``sky_diffuse`` is returned.
         If `True`, ``diffuse_components`` is returned.
@@ -792,7 +792,7 @@ def haydavies(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
         The sky diffuse component of the solar radiation on a tilted
         surface. [Wm⁻²]
 
-    diffuse_components : Dict (array input) or DataFrame (Series input)
+    diffuse_components : dict (array input) or DataFrame (Series input)
         Keys/columns are:
             * poa_sky_diffuse: Total sky diffuse
             * poa_isotropic

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -209,13 +209,11 @@ def test_haydavies(irrad_data, ephem_data, dni_et):
 
 
 def test_haydavies_components(irrad_data, ephem_data, dni_et):
-    keys = ['poa_sky_diffuse', 'poa_isotropic', 'poa_circumsolar',
-            'poa_horizon']
+    keys = ['poa_sky_diffuse', 'poa_isotropic', 'poa_circumsolar']
     expected = pd.DataFrame(np.array(
         [[0, 27.1775, 102.9949, 33.1909],
          [0, 27.1775, 30.1818, 27.9837],
-         [0, 0, 72.8130, 5.2071],
-         [0, 0, 0, 0]]).T,
+         [0, 0, 72.8130, 5.2071]]).T,
         columns=keys,
         index=irrad_data.index
     )


### PR DESCRIPTION
 - ~Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - ~Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR is part of my [GSoC 2026 project](https://github.com/pvlib/pvlib-python/issues/2750). One of the goals is to add support for `return_components` to all diffuse transposition models in `pvlib`, which currently is supported by some models (e.g. `perez`) but not others. This parameter allows the user to choose whether they want only the total diffuse irradiance (default), or are interested in the split between different diffuse components (sky diffuse, circumsolar, horizon brightening).

`haydavies` is one of the models which already supports `return_components`. However, the model itself supports only sky diffuse and circumsolar components, not horizon brightening. Currently, the function returns a horizon brightening component filled with zeros. As suggested by @adriesse [here](https://github.com/pvlib/pvlib-python/issues/2750#issuecomment-4390757321), I've decided not to include empty components in new additions and so, for consistency, I've also modified `haydavies` to remove the horizon brightening component.

In addition, I've changed the existing `OrderedDict` to a `dict`, as suggested by @kandersolar (see #1684).

The docstrings and the relevant test were also modified accordingly.