### PR TITLE
Fix interval keyword argument in oedi_9068 gallery example

### DIFF
--- a/docs/examples/system-models/oedi_9068.py
+++ b/docs/examples/system-models/oedi_9068.py
@@ -145,7 +145,8 @@ keys = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
         'albedo', 'precipitable_water']
 psm3, psm3_metadata = pvlib.iotools.get_nsrdb_psm4_conus(latitude, longitude,
                                                          api_key, email,
-                                                         year=2019, interval=5,
+                                                         year=2019,
+                                                         time_step=5,
                                                          parameters=keys,
                                                          map_variables=True,
                                                          leap_day=True)

--- a/docs/examples/system-models/oedi_9068.py
+++ b/docs/examples/system-models/oedi_9068.py
@@ -7,7 +7,7 @@ Colorado, United States.
 """
 # %%
 # This example model uses satellite-based solar resource data from the
-# NSRDB PSM3. This approach is useful for pre-construction energy modeling
+# NSRDB PSM4. This approach is useful for pre-construction energy modeling
 # and in retrospective analyses where the system’s own irradiance
 # measurements are not present or unreliable.
 #
@@ -135,7 +135,7 @@ model = pvlib.modelchain.ModelChain(
 #
 # The system does have measured plane-of-array irradiance data, but the
 # measurements suffer from row-to-row shading and tracker stalls. In this
-# example, we will use weather data taken from the NSRDB PSM3 for the year
+# example, we will use weather data taken from the NSRDB PSM4 for the year
 # 2019.
 
 api_key = 'DEMO_KEY'
@@ -143,7 +143,7 @@ email = 'your_email@domain.com'
 
 keys = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
         'albedo', 'precipitable_water']
-psm3, psm3_metadata = pvlib.iotools.get_nsrdb_psm4_conus(latitude, longitude,
+psm4, psm4_metadata = pvlib.iotools.get_nsrdb_psm4_conus(latitude, longitude,
                                                          api_key, email,
                                                          year=2019,
                                                          time_step=5,
@@ -168,12 +168,12 @@ psm3, psm3_metadata = pvlib.iotools.get_nsrdb_psm4_conus(latitude, longitude,
 # module fraction and returns the average irradiance over the total module
 # surface.
 
-solar_position = location.get_solarposition(psm3.index)
+solar_position = location.get_solarposition(psm4.index)
 tracker_angles = mount.get_orientation(
     solar_position['apparent_zenith'],
     solar_position['azimuth']
 )
-dni_extra = pvlib.irradiance.get_extra_radiation(psm3.index)
+dni_extra = pvlib.irradiance.get_extra_radiation(psm4.index)
 
 # note: this system is monofacial, so only calculate irradiance for the
 # front side:
@@ -181,7 +181,7 @@ averaged_irradiance = pvlib.bifacial.infinite_sheds.get_irradiance_poa(
     tracker_angles['surface_tilt'], tracker_angles['surface_azimuth'],
     solar_position['apparent_zenith'], solar_position['azimuth'],
     gcr, axis_height, pitch,
-    psm3['ghi'], psm3['dhi'], psm3['dni'], psm3['albedo'],
+    psm4['ghi'], psm4['dhi'], psm4['dni'], psm4['albedo'],
     model='haydavies', dni_extra=dni_extra,
 )
 
@@ -192,14 +192,14 @@ averaged_irradiance = pvlib.bifacial.infinite_sheds.get_irradiance_poa(
 
 cell_temperature_steady_state = pvlib.temperature.faiman(
     poa_global=averaged_irradiance['poa_global'],
-    temp_air=psm3['temp_air'],
-    wind_speed=psm3['wind_speed'],
+    temp_air=psm4['temp_air'],
+    wind_speed=psm4['wind_speed'],
     **temperature_model_parameters,
 )
 
 cell_temperature = pvlib.temperature.prilliman(
     cell_temperature_steady_state,
-    psm3['wind_speed'],
+    psm4['wind_speed'],
     unit_mass=module_unit_mass
 )
 
@@ -216,7 +216,7 @@ weather_inputs = pd.DataFrame({
     'poa_direct': averaged_irradiance['poa_direct'],
     'poa_diffuse': averaged_irradiance['poa_diffuse'],
     'cell_temperature': cell_temperature,
-    'precipitable_water': psm3['precipitable_water'],  # for the spectral model
+    'precipitable_water': psm4['precipitable_water'],  # for the spectral model
 })
 model.run_model_from_poa(weather_inputs)
 

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -45,4 +45,5 @@ Maintenance
 
 Contributors
 ~~~~~~~~~~~~
+* Karl Hill (:ghuser:`karlhillx`)
 

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -23,6 +23,9 @@ Enhancements
 Documentation
 ~~~~~~~~~~~~~
 
+* Fixed broken ``interval`` keyword argument in the ``oedi_9068`` gallery
+  example; the correct parameter name is ``time_step``. (:issue:`2791`)
+
 
 Testing
 ~~~~~~~


### PR DESCRIPTION
Fixes #2791.

## Problem

The `oedi_9068` gallery example calls `get_nsrdb_psm4_conus()` with `interval=5`, but the function's parameter is named `time_step`. The `interval` name comes from the NSRDB API query string, not the Python signature — the docstring even notes "Called ``interval`` in NSRDB API."

This was missed when PR #2582 migrated the example from `get_psm3` (which used `interval`) to `get_nsrdb_psm4_conus` (which uses `time_step`). The maintainer confirmed the fix in [#2791](https://github.com/pvlib/pvlib-python/issues/2791).

## Fix

Changes `interval=5` to `time_step=5` in the example call (one line). Also updated narrative text and variable names from PSM3 → PSM4 per @cwhanse and Copilot review feedback.

## Tests

No test changes needed — `test_get_nsrdb_psm4_conus_5min` in `tests/iotools/test_psm4.py` already exercises `time_step=5` against the function directly. The bug was in the gallery example, not the function.

## Checklist

 - [x] Closes #2791
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [ ] Tests added — not needed, existing test covers the function; bug was in docs example
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes. — no API changes
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.