### PR TITLE
DOC: add Examples to iam.ashrae docstring

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -1,45 +1,25 @@
-.. _whatsnew_0_15_3:
-
-
+﻿.. _whatsnew_0_15_3:
 v0.15.3 (Anticipated September, 2026)
 -------------------------------------
-
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-
-
 Deprecations
 ~~~~~~~~~~~~
-
-
 Bug fixes
 ~~~~~~~~~
-
-
 Enhancements
 ~~~~~~~~~~~~
-
-
 Documentation
 ~~~~~~~~~~~~~
-
-
+* Added ``Examples`` section to :py:func:`pvlib.iam.ashrae` docstring. :pull:`2797` (:ghuser:`dgowdaan-cmyk`)
 Testing
 ~~~~~~~
-
-
 Benchmarking
 ~~~~~~~~~~~~
-
-
 Requirements
 ~~~~~~~~~~~~
-
-
 Maintenance
 ~~~~~~~~~~~
-
-
 Contributors
 ~~~~~~~~~~~~
-
+* :ghuser:`dgowdaan-cmyk`

--- a/pvlib/iam.py
+++ b/pvlib/iam.py
@@ -78,6 +78,16 @@ def ashrae(aoi, b=0.05):
     pvlib.iam.physical
     pvlib.iam.martin_ruiz
     pvlib.iam.interp
+
+    Examples
+    --------
+    >>> import pvlib
+    >>> pvlib.iam.ashrae(aoi=20)
+    0.9967911113762044
+
+    >>> import numpy as np
+    >>> pvlib.iam.ashrae(aoi=np.array([0, 30, 50, 90]))
+    array([1.        , 0.99226497, 0.97221381, 0.        ])
     """
 
     iam = 1 - b * (1 / np.cos(np.radians(aoi)) - 1)
@@ -686,7 +696,7 @@ def marion_integrate(function, surface_tilt, region, num=None):
     iam : numeric
         AOI diffuse correction factor for the specified region.
 
-    See Also
+    See Also 
     --------
     pvlib.iam.marion_diffuse
 
@@ -705,7 +715,7 @@ def marion_integrate(function, surface_tilt, region, num=None):
     >>> from functools import partial
     >>> f = partial(pvlib.iam.physical, n=1.3)
     >>> marion_integrate(f, [20, 30], 'sky')
-    array([0.96225034, 0.9653219 ])
+    >>> array([0.96225034, 0.9653219 ])
     """
 
     if num is None:


### PR DESCRIPTION
Adds an Examples section to the `pvlib.iam.ashrae` docstring, 
as requested in issue #62.

The examples show basic usage with a scalar input and an array input.

- [x] Closes #62
- [x] I am familiar with the contributing guidelines
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [ ] Tests added
- [ ] Updates entries in `docs/sphinx/source/reference` for API changes
- [x] New code is fully documented. Includes numpydoc compliant docstrings, examples, and comments where necessary.
