### PR TITLE
DOC: replace deprecated US/Eastern timezone alias with America/New_York

### DIFF
--- a/docs/examples/solar-tracking/plot_discontinuous_tracking.py
+++ b/docs/examples/solar-tracking/plot_discontinuous_tracking.py
@@ -50,7 +50,7 @@ class DiscontinuousTrackerMount(pvsystem.SingleAxisTrackerMount):
 # %%
 # Let's take a look at the tracker rotation curve it produces:
 
-times = pd.date_range('2019-06-01', '2019-06-02', freq='1min', tz='US/Eastern')
+times = pd.date_range('2019-06-01', '2019-06-02', freq='1min', tz='America/New_York')
 loc = location.Location(40, -80)
 solpos = loc.get_solarposition(times)
 mount = DiscontinuousTrackerMount(axis_azimuth=180, gcr=0.4)

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -22,6 +22,7 @@ Enhancements
 
 Documentation
 ~~~~~~~~~~~~~
+* Replaced deprecated ``US/Eastern`` timezone alias with ``America/New_York`` in the discontinuous tracking example. :pull:``2798`` (:ghuser:``dgowdaan-cmyk``)
 
 
 Testing


### PR DESCRIPTION
Partial fix for #2795.

Replaces the deprecated "link" type timezone alias `US/Eastern` with 
its canonical name `America/New_York` in 
docs/examples/solar-tracking/plot_discontinuous_tracking.py, which was 
failing the RTD documentation build.

This PR intentionally covers only this one file to keep the change 
small and easy to review. Several other files in docs/examples, 
docs/tutorials, and docs/sphinx also use deprecated aliases 
(Asia/Calcutta, US/Mountain, US/Arizona, MST) — happy to open follow-up 
PRs for those once the approach here is confirmed, especially since a 
couple of the affected locations (Golden, CO) need careful checking 
to use the geographically correct canonical zone (America/Denver, 
not America/Phoenix).

- [x] Closes (partial, see note above)
- [x] I am familiar with the contributing guidelines
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [ ] Tests added
- [ ] Updates entries in `docs/sphinx/source/reference` for API changes
- [ ] Adds whatsnew entry