### PR TITLE
Do not merge: debugging ReadTheDocs timezone database issue

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
     configuration: docs/sphinx/source/conf.py
 
 build:
-   os: ubuntu-22.04
+   os: ubuntu-24.04
    tools:
      python: "3.12"
    jobs:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
     configuration: docs/sphinx/source/conf.py
 
 build:
-   os: ubuntu-lts-latest
+   os: ubuntu-22.04
    tools:
      python: "3.12"
    jobs:


### PR DESCRIPTION
Investigating #2795.  Not intended to be merged.

First step: roll back to the previous OS (really, docker image), and see if the problem goes away.  If it does, that will narrow down the issue to the new RTD release @echedey-ls found.