### PR TITLE
docs: fix parameter name mismatches in docstrings

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -42,4 +42,4 @@ Maintenance
 
 Contributors
 ~~~~~~~~~~~~
-
+* Eesh Saxena (:ghuser:`eeshsaxena`)

--- a/pvlib/bifacial/infinite_sheds.py
+++ b/pvlib/bifacial/infinite_sheds.py
@@ -45,19 +45,6 @@ def _poa_sky_diffuse_pv(dhi, gcr, surface_tilt):
     Integrated view factors from the shaded and unshaded parts of
     the row slant height to the sky.
 
-    Parameters
-    ----------
-    f_x : numeric
-        Fraction of row slant height from the bottom that is shaded from
-        direct irradiance. [unitless]
-    surface_tilt : numeric
-        Surface tilt angle in degrees from horizontal, e.g., surface facing up
-        = 0, surface facing horizon = 90. [degree]
-    gcr : float
-        Ratio of row slant length to row spacing (pitch). [unitless]
-    npoints : int, default 100
-        Number of points for integration. [unitless]
-
     A detailed calculation would be
 
         dhi * (f_x * vf_shade_sky_integ + (1 - f_x) * vf_noshade_sky_integ)
@@ -73,9 +60,6 @@ def _poa_sky_diffuse_pv(dhi, gcr, surface_tilt):
 
     Parameters
     ----------
-    f_x : numeric
-        Fraction of row slant height from the bottom that is shaded from
-        direct irradiance. [unitless]
     dhi : numeric
         Diffuse horizontal irradiance (DHI). [W/m^2]
     gcr : float

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -3122,8 +3122,8 @@ def _liujordan(zenith, transmittance, airmass, dni_extra=1367.0):
     transmittance: float
         Atmospheric transmittance between 0 and 1.
 
-    pressure: float, default 101325.0
-        Air pressure
+    airmass: numeric
+        Optical air mass number. [unitless]
 
     dni_extra: float, default 1367.0
         Direct irradiance incident at the top of the atmosphere.

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -3123,7 +3123,7 @@ def _liujordan(zenith, transmittance, airmass, dni_extra=1367.0):
         Atmospheric transmittance between 0 and 1.
 
     airmass: numeric
-        Optical air mass number. [unitless]
+        Optical air mass. [unitless]
 
     dni_extra: float, default 1367.0
         Direct irradiance incident at the top of the atmosphere.

--- a/pvlib/pvsystem.py
+++ b/pvlib/pvsystem.py
@@ -395,7 +395,7 @@ class PVSystem:
         aoi : numeric or tuple of numeric
             The angle of incidence in degrees.
 
-        aoi_model : string, default 'physical'
+        iam_model : string, default 'physical'
             The IAM model to be used. Valid strings are 'physical', 'ashrae',
             'martin_ruiz', 'sapm' and 'interp'.
         Returns
@@ -1188,7 +1188,7 @@ class Array:
         aoi : numeric
             The angle of incidence in degrees.
 
-        aoi_model : string, default 'physical'
+        iam_model : string, default 'physical'
             The IAM model to be used. Valid strings are 'physical', 'ashrae',
             'martin_ruiz', 'sapm' and 'interp'.
 

--- a/pvlib/solarposition.py
+++ b/pvlib/solarposition.py
@@ -516,7 +516,7 @@ def sun_rise_set_transit_ephem(times, latitude, longitude,
 
     Parameters
     ----------
-    time : pandas.DatetimeIndex
+    times : pandas.DatetimeIndex
         Must be localized
     latitude : float
         Latitude in degrees, positive north of equator, negative to south


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
- [ ] Tests added
- [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
- [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
- [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
- [ ] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels and Milestone are assigned to the Pull Request and linked Issue.

Fixes several docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `pvlib/pvsystem.py` | `PVSystem.get_iam`, `Array.get_iam` | `aoi_model` | `iam_model` |
| `pvlib/solarposition.py` | `sun_rise_set_transit_ephem` | `time` | `times` |
| `pvlib/irradiance.py` | `_liujordan` | `pressure` (not a parameter) | `airmass` (was undocumented) |
| `pvlib/bifacial/infinite_sheds.py` | `_poa_sky_diffuse_pv` | duplicated stale Parameters block with `f_x`, `npoints` | `dhi, gcr, surface_tilt` |

Doc-only change, no behavior modified. Happy to add a whatsnew entry if maintainers want one for a docs-only fix - let me know which file it should go in.