### PR TITLE
DRAFT: Handle dni/dhi=0/0 in irradiance.perez without NaNs

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -14,7 +14,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-* Fix :py:func:`pvlib.irradiance.perez` to not return NaN when both DHI and
+* Fix :py:func:`pvlib.irradiance.perez` to return 0 when both DHI and
   DNI are zero. (:issue:`2801`, :pull:`2808`)
 * Fix :py:func:`pvlib.irradiance.perez` to not return zero (instead NaN) when
   airmass is NaN and either DHI or DNI are NaN. (:issue:`2801`, :pull:`2808`)

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -14,7 +14,10 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-
+* Fix :py:func:`pvlib.irradiance.perez` to not return NaN when both DHI and
+  DNI are zero. (:issue:`2801`, :pull:`2808`)
+* Fix :py:func:`pvlib.irradiance.perez` to not return zero (instead NaN) when
+  airmass is NaN and either DHI or DNI are NaN. (:issue:`2801`, :pull:`2808`)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -48,3 +51,4 @@ Contributors
 * Eesh Saxena (:ghuser:`eeshsaxena`)
 * Karl Hill (:ghuser:`karlhillx`)
 * Yonry Zhu (:ghuser:`yonryzhu`)
+* Mark Campanelli (:ghuser:`markcampanelli`)

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -16,7 +16,7 @@ Bug fixes
 ~~~~~~~~~
 * Fix :py:func:`pvlib.irradiance.perez` to return 0 when both DHI and
   DNI are zero. (:issue:`2801`, :pull:`2808`)
-* Fix :py:func:`pvlib.irradiance.perez` to not return zero (instead NaN) when
+* Fix :py:func:`pvlib.irradiance.perez` to return NaN when
   airmass is NaN and either DHI or DNI are NaN. (:issue:`2801`, :pull:`2808`)
 
 Enhancements

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1049,7 +1049,8 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     DHI is zero, then DNI is also zero, otherwise a FloatingPointError is
     raised due to a division of a nonzero (and not NaN) value by zero. It is
     also expected that extraterrestrial irradiance is positive. If airmass
-    is NaN, then the total and all components are zero.
+    is NaN, then the total and all components are zero if they should not 
+    otherwise be NaN.
 
     Warning
     -------

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1049,8 +1049,8 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     DHI is zero, then DNI is also zero, otherwise a FloatingPointError is
     raised due to a division of a nonzero (and not NaN) value by zero. It is
     also expected that extraterrestrial irradiance is positive. If airmass
-    is NaN, then the total and all components are zero if they should not 
-    otherwise be NaN.
+    is NaN, then the total and all components are zero if they should not
+    otherwise be NaN because DHI or DNI was NaN.
 
     Warning
     -------
@@ -1218,10 +1218,15 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     sky_diffuse = np.maximum(dhi * (term1 + term2 + term3), 0)
 
     # we've preserved the input type until now, so don't ruin it!
+    airmass_nan_idx = np.logical_and(
+        np.isnan(airmass), np.logical_not(
+            np.logical_or(np.isnan(dhi), np.isnan(dni))
+        )
+    )
     if isinstance(sky_diffuse, pd.Series):
-        sky_diffuse[np.isnan(airmass)] = 0
+        sky_diffuse[airmass_nan_idx] = 0
     else:
-        sky_diffuse = np.where(np.isnan(airmass), 0, sky_diffuse)
+        sky_diffuse = np.where(airmass_nan_idx, 0, sky_diffuse)
 
     if return_components:
         diffuse_components = OrderedDict()

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1147,7 +1147,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     kappa = 1.041  # for solar_zenith in radians
     z = np.radians(solar_zenith)  # convert to radians
 
-    # delta is the sky's "brightness", assumes dni_extra > 0
+    # delta is the sky's "brightness", NaN airmass ok, assumes dni_extra > 0
     delta = dhi * airmass / dni_extra
 
     # epsilon is the sky's "clearness". Preserves NaNs for dni or dhi.

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1211,7 +1211,7 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     B = np.maximum(B, tools.cosd(85))
 
     # Calculate Diffuse POA from sky dome
-    term1 = 0.5 * (1 - F1) * (1 + tools.cosd(surface_tilt)) # isotropic
+    term1 = 0.5 * (1 - F1) * (1 + tools.cosd(surface_tilt))  # isotropic
     term2 = F1 * A / B  # circumsolar
     term3 = F2 * tools.sind(surface_tilt)  # horizon
 

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1147,12 +1147,21 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     kappa = 1.041  # for solar_zenith in radians
     z = np.radians(solar_zenith)  # convert to radians
 
-    # delta is the sky's "brightness"
+    # delta is the sky's "brightness", assumes dni_extra > 0
     delta = dhi * airmass / dni_extra
 
-    # epsilon is the sky's "clearness"
-    with np.errstate(invalid='ignore'):
-        eps = ((dhi + dni) / dhi + kappa * (z ** 3)) / (1 + kappa * (z ** 3))
+    # epsilon is the sky's "clearness". Preserves NaNs for dni or dhi.
+    # Assumes:
+    # - dni >=0 and dhi >= 0.
+    # - dni->0^+ faster than dhi->0^+.
+    irr_ratio = np.zeros(np.broadcast(dni, dhi).shape)
+    with np.errstate(divide="raise"):
+        irr_ratio = np.divide(
+            dni, dhi, out=irr_ratio, where=np.logical_not(
+                np.logical_and(dhi == 0, dni == 0)
+            )
+        )
+    eps = 1 + irr_ratio / (1 + kappa * (z ** 3))
 
     # numpy indexing below will not work with a Series
     if isinstance(eps, pd.Series):

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1042,10 +1042,14 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     Perez models determine the diffuse irradiance from the sky (ground
     reflected irradiance is not included in this algorithm) on a tilted
     surface using the surface tilt angle, surface azimuth angle, diffuse
-    horizontal irradiance, direct normal irradiance, extraterrestrial
-    irradiance, sun zenith angle, sun azimuth angle, and relative (not
-    pressure-corrected) airmass. Optionally a selector may be used to
-    use any of Perez's model coefficient sets.
+    horizontal irradiance (DHI), direct normal irradiance (DNI),
+    extraterrestrial irradiance, sun zenith angle, sun azimuth angle, and
+    relative (not pressure-corrected) airmass. Optionally a selector may be
+    used to use any of Perez's model coefficient sets. It is expected that if
+    DHI is zero, then DNI is also zero, otherwise a FloatingPointError is
+    raised due to a division of a nonzero (and not NaN) value by zero. It is
+    also expected that extraterrestrial irradiance is positive. If airmass
+    is NaN, then the total and all components are zero.
 
     Warning
     -------
@@ -1124,6 +1128,11 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
             * poa_isotropic
             * poa_circumsolar
             * poa_horizon
+
+    Raises
+    ------
+    FloatingPointError
+        If dni is zero when dhi is not zero and not NaN.
 
 
     References

--- a/pvlib/irradiance.py
+++ b/pvlib/irradiance.py
@@ -1211,18 +1211,19 @@ def perez(surface_tilt, surface_azimuth, dhi, dni, dni_extra,
     B = np.maximum(B, tools.cosd(85))
 
     # Calculate Diffuse POA from sky dome
-    term1 = 0.5 * (1 - F1) * (1 + tools.cosd(surface_tilt))
-    term2 = F1 * A / B
-    term3 = F2 * tools.sind(surface_tilt)
+    term1 = 0.5 * (1 - F1) * (1 + tools.cosd(surface_tilt)) # isotropic
+    term2 = F1 * A / B  # circumsolar
+    term3 = F2 * tools.sind(surface_tilt)  # horizon
 
     sky_diffuse = np.maximum(dhi * (term1 + term2 + term3), 0)
 
-    # we've preserved the input type until now, so don't ruin it!
+    # Use NaN airmass to coerce to zero values that are not otherwise NaN.
     airmass_nan_idx = np.logical_and(
         np.isnan(airmass), np.logical_not(
             np.logical_or(np.isnan(dhi), np.isnan(dni))
         )
     )
+    # we've preserved the input type until now, so don't ruin it!
     if isinstance(sky_diffuse, pd.Series):
         sky_diffuse[airmass_nan_idx] = 0
     else:

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -463,7 +463,7 @@ def test_perez_array_dhi_and_dni_combos_nan_airmass():
         20, 180,
         np.array([0.0, 10.0, np.nan, np.nan, 0.0, 100.0, np.nan]),
         np.array([0.0, 0.0, 0.0, 100.0, np.nan, np.nan, np.nan]),
-        1366.1, 89.96, 256.28, np.nan
+        1366.1, 91, 256.28, np.nan
     )
 
     out = irradiance.perez(*args)

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -456,6 +456,45 @@ def test_perez_array_dhi_and_dni_combos():
     )
 
 
+def test_perez_array_dhi_and_dni_combos_nan_airmass():
+    # Divides zero and non-zero by zero and various NaN division combos, when
+    # airmass is NaN (e.g., for sun below horizon).
+    args = (
+        20, 180,
+        np.array([0.0, 10.0, np.nan, np.nan, 0.0, 100.0, np.nan]),
+        np.array([0.0, 0.0, 0.0, 100.0, np.nan, np.nan, np.nan]),
+        1366.1, 89.96, 256.28, np.nan
+    )
+
+    out = irradiance.perez(*args)
+    poa_sky_diffuse_expected = np.array(
+        [0.0, 0.0, np.nan, np.nan, np.nan, np.nan, np.nan]
+    )
+    assert_allclose(out, poa_sky_diffuse_expected)
+
+    out = irradiance.perez(*args, return_components=True)
+    expected = {
+        "poa_sky_diffuse": poa_sky_diffuse_expected,
+        "poa_isotropic": np.array(
+            [0.0, 9.162258932459126, np.nan, np.nan, np.nan, np.nan, np.nan]
+        ),
+        "poa_circumsolar": np.array(
+            [0.0, 0.5187450944545264, np.nan, np.nan, np.nan, np.nan, np.nan]
+        ),
+        "poa_horizon": np.array(
+            [0.0, -0.2560798402944465, np.nan, np.nan, np.nan, np.nan, np.nan]
+        ),
+    }
+    assert len(out) == len(expected)
+    for key in expected.keys():
+        assert_allclose(out[key], expected[key], err_msg=key)
+
+    assert_almost_equal(
+        out["poa_sky_diffuse"],
+        out["poa_isotropic"] + out["poa_circumsolar"] + out["poa_horizon"],
+    )
+
+
 def test_perez_zero_dhi_nonzero_dni_scalar():
     # Divides nonzero by zero.
     args = (20, 180, 0.0, 100.0, 1366.1, 89.96, 256.28, 37.32)

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -418,23 +418,32 @@ def test_perez_zero_dhi_and_dni_scalar():
     )
 
 
-def test_perez_zero_dhi_and_dni_array():
+def test_perez_array_dhi_and_dni_combos():
     # Divides zero by zero.
     args = (
-        20, 180, np.array([0.0, 10.0, float("nan")]), 0.0, 1366.1, 89.96,
-        256.28, 37.32
+        20, 180, np.array([0.0, 10.0, np.nan, 0.0, np.nan]),
+        np.array([0.0, 0.0, 0.0, np.nan, np.nan]), 1366.1, 89.96, 256.28,
+        37.32
     )
 
     out = irradiance.perez(*args)
-    expected = np.array([0.0, 9.424924186619206, float("nan")])
+    expected = np.array([0.0, 9.424924186619206, np.nan, np.nan, np.nan])
     assert_allclose(out, expected)
 
     out = irradiance.perez(*args, return_components=True)
     expected = {
-        "poa_sky_diffuse": np.array([0.0, 9.424924186619206, float("nan")]),
-        "poa_isotropic": np.array([ 0.0, 9.162258932459126, float("nan")]),
-        "poa_circumsolar": np.array([ 0.0, 0.5187450944545264, float("nan")]),
-        "poa_horizon": np.array([0.0, -0.2560798402944465, float("nan")]),
+        "poa_sky_diffuse": np.array(
+            [0.0, 9.424924186619206, np.nan, np.nan, np.nan]
+        ),
+        "poa_isotropic": np.array(
+            [ 0.0, 9.162258932459126, np.nan, np.nan, np.nan]
+        ),
+        "poa_circumsolar": np.array(
+            [ 0.0, 0.5187450944545264, np.nan, np.nan, np.nan]
+        ),
+        "poa_horizon": np.array(
+            [0.0, -0.2560798402944465, np.nan, np.nan, np.nan]
+        ),
     }
     assert len(out) == len(expected)
     for key in expected.keys():
@@ -460,7 +469,7 @@ def test_perez_zero_dhi_nonzero_dni_scalar():
 def test_perez_zero_dhi_nonzero_dni_array():
     # Divides nonzero by zero.
     args = (
-        20, 180, np.array([0.0, 10.0, float("nan")]), 100.0, 1366.1, 89.96,
+        20, 180, np.array([0.0, 10.0, np.nan]), 100.0, 1366.1, 89.96,
         256.28, 37.32
     )
 

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -7,8 +7,9 @@ from numpy import array, nan
 import pandas as pd
 
 import pytest
-from numpy.testing import (assert_almost_equal,
-                           assert_allclose)
+from numpy.testing import (
+    assert_almost_equal, assert_allclose, assert_equal, assert_raises
+)
 from pvlib import irradiance, albedo
 
 from .conftest import (
@@ -391,6 +392,17 @@ def test_perez_negative_horizon():
 
     assert_frame_equal(out, expected, check_less_precise=2)
     assert_series_equal(sum_components, expected_for_sum, check_less_precise=2)
+
+
+def test_perez_zero_dhi_and_dni(dni_et):
+    out = irradiance.perez(20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32)
+    expected = 0.0
+    assert_equal(out, expected)
+
+
+def test_perez_zero_dhi_nonzero_dni(dni_et):
+    with assert_raises(FloatingPointError):
+        irradiance.perez(20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32)
 
 
 def test_perez_arrays(irrad_data, ephem_data, dni_et, relative_airmass):

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -398,12 +398,12 @@ def test_perez_zero_dhi_and_dni_scalar():
     args = (20, 180, 0.0, 0.0, 1366.1, 89.96, 256.28, 37.32)
 
     out = irradiance.perez(*args)
-    expected = 0.0
-    assert_equal(out, expected)
+    poa_sky_diffuse_expected = 0.0
+    assert_equal(out, poa_sky_diffuse_expected)
 
     out = irradiance.perez(*args, return_components=True)
     expected = {
-        "poa_sky_diffuse": 0.0,
+        "poa_sky_diffuse": poa_sky_diffuse_expected,
         "poa_isotropic": 0.0,
         "poa_circumsolar": 0.0,
         "poa_horizon": 0.0,
@@ -419,30 +419,31 @@ def test_perez_zero_dhi_and_dni_scalar():
 
 
 def test_perez_array_dhi_and_dni_combos():
-    # Divides zero by zero.
+    # Divides zero and non-zero by zero and various NaN division combos.
     args = (
-        20, 180, np.array([0.0, 10.0, np.nan, 0.0, np.nan]),
-        np.array([0.0, 0.0, 0.0, np.nan, np.nan]), 1366.1, 89.96, 256.28,
-        37.32
+        20, 180,
+        np.array([0.0, 10.0, np.nan, np.nan, 0.0, 100.0, np.nan]),
+        np.array([0.0, 0.0, 0.0, 100.0, np.nan, np.nan, np.nan]),
+        1366.1, 89.96, 256.28, 37.32
     )
 
     out = irradiance.perez(*args)
-    expected = np.array([0.0, 9.424924186619206, np.nan, np.nan, np.nan])
-    assert_allclose(out, expected)
+    poa_sky_diffuse_expected = np.array(
+        [0.0, 9.424924186619206, np.nan, np.nan, np.nan, np.nan, np.nan]
+    )
+    assert_allclose(out, poa_sky_diffuse_expected)
 
     out = irradiance.perez(*args, return_components=True)
     expected = {
-        "poa_sky_diffuse": np.array(
-            [0.0, 9.424924186619206, np.nan, np.nan, np.nan]
-        ),
+        "poa_sky_diffuse": poa_sky_diffuse_expected,
         "poa_isotropic": np.array(
-            [ 0.0, 9.162258932459126, np.nan, np.nan, np.nan]
+            [0.0, 9.162258932459126, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
         "poa_circumsolar": np.array(
-            [ 0.0, 0.5187450944545264, np.nan, np.nan, np.nan]
+            [0.0, 0.5187450944545264, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
         "poa_horizon": np.array(
-            [0.0, -0.2560798402944465, np.nan, np.nan, np.nan]
+            [0.0, -0.2560798402944465, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
     }
     assert len(out) == len(expected)

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -399,10 +399,28 @@ def test_perez_zero_dhi_and_dni(dni_et):
     expected = 0.0
     assert_equal(out, expected)
 
+    out = irradiance.perez(
+        20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32, return_components=True
+    )
+    expected = {
+        "poa_sky_diffuse": 0.0,
+        "poa_isotropic": 0.0,
+        "poa_circumsolar": 0.0,
+        "poa_horizon": 0.0,
+    }
+    assert len(out) == len(expected)
+    for key in expected.keys():
+        assert_equal(out[key], expected[key])
+
 
 def test_perez_zero_dhi_nonzero_dni(dni_et):
     with assert_raises(FloatingPointError):
         irradiance.perez(20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32)
+
+    with assert_raises(FloatingPointError):
+        irradiance.perez(
+            20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32, return_components=True
+        )
 
 
 def test_perez_arrays(irrad_data, ephem_data, dni_et, relative_airmass):

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -400,7 +400,8 @@ def test_perez_zero_dhi_and_dni(dni_et):
     assert_equal(out, expected)
 
     out = irradiance.perez(
-        20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32, return_components=True
+        20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32,
+        return_components=True
     )
     expected = {
         "poa_sky_diffuse": 0.0,
@@ -419,7 +420,8 @@ def test_perez_zero_dhi_nonzero_dni(dni_et):
 
     with assert_raises(FloatingPointError):
         irradiance.perez(
-            20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32, return_components=True
+            20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32,
+            return_components=True
         )
 
 

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -476,13 +476,13 @@ def test_perez_array_dhi_and_dni_combos_nan_airmass():
     expected = {
         "poa_sky_diffuse": poa_sky_diffuse_expected,
         "poa_isotropic": np.array(
-            [0.0, 9.162258932459126, np.nan, np.nan, np.nan, np.nan, np.nan]
+            [0.0, 0.0, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
         "poa_circumsolar": np.array(
-            [0.0, 0.5187450944545264, np.nan, np.nan, np.nan, np.nan, np.nan]
+            [0.0, 0.0, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
         "poa_horizon": np.array(
-            [0.0, -0.2560798402944465, np.nan, np.nan, np.nan, np.nan, np.nan]
+            [0.0, 0.0, np.nan, np.nan, np.nan, np.nan, np.nan]
         ),
     }
     assert len(out) == len(expected)

--- a/tests/test_irradiance.py
+++ b/tests/test_irradiance.py
@@ -288,7 +288,6 @@ def test_perez_driesse_airmass(irrad_data, ephem_data, dni_et):
     out = irradiance.perez_driesse(40, 180, irrad_data['dhi'], dni,
                                    dni_et, ephem_data['apparent_zenith'],
                                    ephem_data['azimuth'], airmass=None)
-    print(out)
     expected = pd.Series(np.array(
         [0.,   29.991,  np.nan,   47.397]),
         index=irrad_data.index)
@@ -394,15 +393,15 @@ def test_perez_negative_horizon():
     assert_series_equal(sum_components, expected_for_sum, check_less_precise=2)
 
 
-def test_perez_zero_dhi_and_dni(dni_et):
-    out = irradiance.perez(20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32)
+def test_perez_zero_dhi_and_dni_scalar():
+    # Divides zero by zero.
+    args = (20, 180, 0.0, 0.0, 1366.1, 89.96, 256.28, 37.32)
+
+    out = irradiance.perez(*args)
     expected = 0.0
     assert_equal(out, expected)
 
-    out = irradiance.perez(
-        20, 180, 0.0, 0.0, dni_et, 89.96, 256.28, 37.32,
-        return_components=True
-    )
+    out = irradiance.perez(*args, return_components=True)
     expected = {
         "poa_sky_diffuse": 0.0,
         "poa_isotropic": 0.0,
@@ -411,18 +410,65 @@ def test_perez_zero_dhi_and_dni(dni_et):
     }
     assert len(out) == len(expected)
     for key in expected.keys():
-        assert_equal(out[key], expected[key])
+        assert_equal(out[key], expected[key], err_msg=key)
+
+    assert_equal(
+        out["poa_sky_diffuse"],
+        out["poa_isotropic"] + out["poa_circumsolar"] + out["poa_horizon"],
+    )
 
 
-def test_perez_zero_dhi_nonzero_dni(dni_et):
+def test_perez_zero_dhi_and_dni_array():
+    # Divides zero by zero.
+    args = (
+        20, 180, np.array([0.0, 10.0, float("nan")]), 0.0, 1366.1, 89.96,
+        256.28, 37.32
+    )
+
+    out = irradiance.perez(*args)
+    expected = np.array([0.0, 9.424924186619206, float("nan")])
+    assert_allclose(out, expected)
+
+    out = irradiance.perez(*args, return_components=True)
+    expected = {
+        "poa_sky_diffuse": np.array([0.0, 9.424924186619206, float("nan")]),
+        "poa_isotropic": np.array([ 0.0, 9.162258932459126, float("nan")]),
+        "poa_circumsolar": np.array([ 0.0, 0.5187450944545264, float("nan")]),
+        "poa_horizon": np.array([0.0, -0.2560798402944465, float("nan")]),
+    }
+    assert len(out) == len(expected)
+    for key in expected.keys():
+        assert_allclose(out[key], expected[key], err_msg=key)
+
+    assert_almost_equal(
+        out["poa_sky_diffuse"],
+        out["poa_isotropic"] + out["poa_circumsolar"] + out["poa_horizon"],
+    )
+
+
+def test_perez_zero_dhi_nonzero_dni_scalar():
+    # Divides nonzero by zero.
+    args = (20, 180, 0.0, 100.0, 1366.1, 89.96, 256.28, 37.32)
+
     with assert_raises(FloatingPointError):
-        irradiance.perez(20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32)
+        irradiance.perez(*args)
 
     with assert_raises(FloatingPointError):
-        irradiance.perez(
-            20, 180, 0.0, 100.0, dni_et, 89.96, 256.28, 37.32,
-            return_components=True
-        )
+        irradiance.perez(*args, return_components=True)
+
+
+def test_perez_zero_dhi_nonzero_dni_array():
+    # Divides nonzero by zero.
+    args = (
+        20, 180, np.array([0.0, 10.0, float("nan")]), 100.0, 1366.1, 89.96,
+        256.28, 37.32
+    )
+
+    with assert_raises(FloatingPointError):
+        irradiance.perez(*args)
+
+    with assert_raises(FloatingPointError):
+        irradiance.perez(*args, return_components=True)
 
 
 def test_perez_arrays(irrad_data, ephem_data, dni_et, relative_airmass):


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Inspired by #2801
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Tests added
 - [x] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
