### PR TITLE
Add tzdata to fix ReadTheDocs build and vendor timezone data

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -14,6 +14,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+* Fix missing timezones by adding ``tzdata`` as a dependency. (:issue:`2795`)
 
 
 Enhancements

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -14,11 +14,11 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-* Fix missing timezones by adding ``tzdata`` as a dependency. (:issue:`2795`)
 
 
 Enhancements
 ~~~~~~~~~~~~
+* Ensure all timezones are available in all OSs. (:issue:`2795`, :pull:`2809`)
 
 
 Documentation
@@ -42,6 +42,7 @@ Requirements
 
 Maintenance
 ~~~~~~~~~~~
+* Fix documentation builds on runner images lacking link-type timezones. (:issue:`2795`, :pull:`2809`)
 
 
 Contributors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     'requests',
     'scipy >= 1.7.2',
     'h5py',
+    'tzdata',
 ]
 license = "BSD-3-Clause"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     'requests',
     'scipy >= 1.7.2',
     'h5py',
-    'tzdata',
+    'tzdata', # ensure all timezones are available in all installs for consistency GH#2795
 ]
 license = "BSD-3-Clause"
 classifiers = [


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [x] Closes #2795
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->
