### PR TITLE
Remove unused clearsky._is_leap_year (closes #2768)

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -1,20 +1,25 @@
 .. _whatsnew_0_15_3:
 
+
 v0.15.3 (Anticipated September, 2026)
 -------------------------------------
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+
 Deprecations
 ~~~~~~~~~~~~
+
 
 Bug fixes
 ~~~~~~~~~
 
+
 Enhancements
 ~~~~~~~~~~~~
 * Ensure all timezones are available in all OSs. (:issue:`2795`, :pull:`2809`)
+
 
 Documentation
 ~~~~~~~~~~~~~
@@ -22,19 +27,24 @@ Documentation
 * Fixed broken ``interval`` keyword argument in the ``oedi_9068`` gallery
   example; the correct parameter name is ``time_step``. (:issue:`2791`)
 
+
 Testing
 ~~~~~~~
+
 
 Benchmarking
 ~~~~~~~~~~~~
 
+
 Requirements
 ~~~~~~~~~~~~
+
 
 Maintenance
 ~~~~~~~~~~~
 * Removed unused internal function ``clearsky._is_leap_year`` (:issue:`2768`, :pull:`2813`)
 * Fix documentation builds on runner images lacking link-type timezones. (:issue:`2795`, :pull:`2809`)
+
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -43,3 +43,4 @@ Maintenance
 Contributors
 ~~~~~~~~~~~~
 
+* Darshan Gowda (:ghuser:`dgowdaan-cmyk`)

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -1,25 +1,20 @@
 .. _whatsnew_0_15_3:
 
-
 v0.15.3 (Anticipated September, 2026)
 -------------------------------------
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-
 Deprecations
 ~~~~~~~~~~~~
-
 
 Bug fixes
 ~~~~~~~~~
 
-
 Enhancements
 ~~~~~~~~~~~~
 * Ensure all timezones are available in all OSs. (:issue:`2795`, :pull:`2809`)
-
 
 Documentation
 ~~~~~~~~~~~~~
@@ -27,32 +22,23 @@ Documentation
 * Fixed broken ``interval`` keyword argument in the ``oedi_9068`` gallery
   example; the correct parameter name is ``time_step``. (:issue:`2791`)
 
-
 Testing
 ~~~~~~~
-
 
 Benchmarking
 ~~~~~~~~~~~~
 
-
 Requirements
 ~~~~~~~~~~~~
 
-
 Maintenance
 ~~~~~~~~~~~
-* Removed unused internal function ``clearsky._is_leap_year`` (:issue:`2768`, :pull:`XXXX`)
-
-Contributors
-~~~~~~~~~~~~
-
-* Darshan Gowda (:ghuser:`dgowdaan-cmyk`)
+* Removed unused internal function ``clearsky._is_leap_year`` (:issue:`2768`, :pull:`2813`)
 * Fix documentation builds on runner images lacking link-type timezones. (:issue:`2795`, :pull:`2809`)
-
 
 Contributors
 ~~~~~~~~~~~~
 * Eesh Saxena (:ghuser:`eeshsaxena`)
 * Karl Hill (:ghuser:`karlhillx`)
 * Yonry Zhu (:ghuser:`yonryzhu`)
+* Darshan Gowda (:ghuser:`dgowdaan-cmyk`)

--- a/docs/sphinx/source/whatsnew/v0.15.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.15.3.rst
@@ -38,7 +38,7 @@ Requirements
 
 Maintenance
 ~~~~~~~~~~~
-
+* Removed unused internal function ``clearsky._is_leap_year`` (:issue:`2768`, :pull:`XXXX`)
 
 Contributors
 ~~~~~~~~~~~~

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -220,22 +220,6 @@ def lookup_linke_turbidity(time, latitude, longitude, filepath=None,
     return linke_turbidity
 
 
-def _is_leap_year(year):
-    """Determine if a year is leap year.
-
-    Parameters
-    ----------
-    year : numeric
-
-    Returns
-    -------
-    isleap : array of bools
-    """
-    isleap = ((np.mod(year, 4) == 0) &
-              ((np.mod(year, 100) != 0) | (np.mod(year, 400) == 0)))
-    return isleap
-
-
 def _interpolate_turbidity(lts, time):
     """
     Interpolated monthly Linke turbidity onto daily values.


### PR DESCRIPTION
Closes #2768

Removes the unused internal function `clearsky._is_leap_year`. Verified via repo-wide search that it has no other references anywhere in the codebase. Per maintainer (@cwhanse), no deprecation cycle or new test required — see [comment](https://github.com/pvlib/pvlib-python/issues/2768#issuecomment-XXXXXXXXX).

- [x] Closes #2768
- [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [ ] Tests added
- [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
- [x] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `:issue:`num`` or this Pull Request with `:pull:`num``. Includes contributor name and/or GitHub username (link with `:ghuser:`user``).
- [x] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
- [x] Pull request is nearly complete and ready for detailed review.
- [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.