### PR TITLE
Use array_like in docstring style guide

### DIFF
--- a/docs/sphinx/source/contributing/style_guide.rst
+++ b/docs/sphinx/source/contributing/style_guide.rst
@@ -60,7 +60,7 @@ specific types may be used:
 
 * dict-like : dict, OrderedDict, pd.Series
 * numeric : scalar, np.array, pd.Series. Typically int or float dtype.
-* array-like : np.array, pd.Series. Typically int or float dtype.
+* array_like : np.array, pd.Series. Typically int or float dtype.
 
 Parameters that specify a specific type require that specific input type.
 
@@ -237,7 +237,7 @@ required for every function.
         ----------
         poa_global : numeric
             Plane-of-array global irradiance, see :term:`poa_global`. [Wm⁻²].
-        exponents : array-like
+        exponents : array_like
             A list of exponents. [x⁰¹²³⁴⁵⁶⁷⁸⁹⁻].
         degree_symbol : pandas.Series or pandas.DataFrame
             It's different from superscript zero. [°].


### PR DESCRIPTION
<!-- Thank you for your contribution! The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items. Feel free to remove checklist items that are not relevant to your change. -->

 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - [ ] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

<!-- Brief description of the problem and proposed solution (if not already fully described in the issue linked to above): -->

- [x]Closes #765
- [x]I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
- [x] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license
- [ ]Tests added
- [ Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
- [ ]Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ).
- [ ] New code is fully documented.Includes[numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
- [x]Pull request is nearly complete and ready for detailed review.
- [ ]Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.



###Description
Updates the contributor style guide to use `array_like` instead of `array-like`, matching NumPy terminology.

This changes the descriptor list and the example docstring in the same file.

###Notes
No tests were added because this is a documentation-only change.

No API reference files were changed because this does not modify the public API.

###Checks
- `git diff --check`