### PR TITLE
DOC: fix read_bsrn reference

### DIFF
--- a/pvlib/iotools/bsrn.py
+++ b/pvlib/iotools/bsrn.py
@@ -379,7 +379,7 @@ def read_bsrn(filename, logical_records=('0100',)):
 
     BSRN files are freely available and can be accessed via FTP [3]_. The
     username and password for the BSRN FTP server can be obtained for free as
-    described in the BSRN's Data Release Guidelines [3]_.
+    described in the BSRN's Data Release Guidelines [4]_.
 
     Parameters
     ----------


### PR DESCRIPTION
- [x] Closes #2684
- [x] I am familiar with the contributing guidelines.
- [x] I attest that all AI-assisted material has been reviewed for accuracy and compliance with the pvlib license.
- [x] This pull request is ready for review.

## Description

Corrects the reference in the `read_bsrn` docstring from `[3]` (BSRN Data Retrieval via FTP) to `[4]` (BSRN Data Release Guidelines).

## Testing

Tests were not run because this is a documentation-only reference correction.