### PR TITLE
DOC: clarify default depo_veloc values in soiling.hsu Notes

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.16.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.16.0.rst
@@ -75,6 +75,9 @@ Enhancements
 Documentation
 ~~~~~~~~~~~~~
 * Remove `g_poa_effective` from the :ref:`nomenclature` page (:pull:`2704`)
+* Clarify in the ``Notes`` section of :py:func:`pvlib.soiling.hsu` that the
+  default ``depo_veloc`` values correspond to the settling velocity of
+  particulates. (:issue:`2535`)
 
 
 Testing

--- a/pvlib/soiling.py
+++ b/pvlib/soiling.py
@@ -67,13 +67,9 @@ def hsu(rainfall, cleaning_threshold, surface_tilt, pm2_5, pm10,
     corresponding to a soiling ratio of approximately 0.6875.
     See [1]_ for details.
 
-    The default values of ``depo_veloc`` correspond to the settling
-    velocity of particulates, i.e., only the gravitational movement of
-    particles. The model also accepts deposition velocities, which
-    comprise other types of particle-fluid interaction; however, the
-    authors of [1]_ found that deposition velocity considerably
-    overestimates soiling, while settling velocity performed well in
-    their case study.
+    As recommended by [1]_, the default values of ``depo_veloc``
+    are the settling velocities of particulates, i.e., only the gravitational
+    movement of particles.
 
     References
     -----------

--- a/pvlib/soiling.py
+++ b/pvlib/soiling.py
@@ -67,6 +67,14 @@ def hsu(rainfall, cleaning_threshold, surface_tilt, pm2_5, pm10,
     corresponding to a soiling ratio of approximately 0.6875.
     See [1]_ for details.
 
+    The default values of ``depo_veloc`` correspond to the settling
+    velocity of particulates, i.e., only the gravitational movement of
+    particles. The model also accepts deposition velocities, which
+    comprise other types of particle-fluid interaction; however, the
+    authors of [1]_ found that deposition velocity considerably
+    overestimates soiling, while settling velocity performed well in
+    their case study.
+
     References
     -----------
     .. [1] M. Coello and L. Boyle, "Simple Model For Predicting Time Series


### PR DESCRIPTION
## Description

Addresses #2535.

As discussed in the issue, the `depo_veloc` parameter of `soiling.hsu` is often left at its default (`None`), and the existing documentation did not make clear what those default values mean. The [original paper](https://ieeexplore.ieee.org/document/8735892) notes that the velocity term in the model can represent either a **deposition velocity** (which accounts for various particle–fluid interactions beyond gravity) or a **settling velocity** (the gravitational movement of particles only). The authors found that using the deposition velocity considerably overestimates soiling, while the settling velocity performed well in their case study — and pvlib's default `depo_veloc` values correspond to the settling-velocity case.

This PR expands the `Notes` section of `soiling.hsu` to make that distinction explicit: the default `depo_veloc` values correspond to the settling velocity (gravitational motion only), and the model also accepts deposition velocities, which comprise other particle–fluid interactions and typically overestimate soiling.

Changes:
- `pvlib/soiling.py`: expanded the `Notes` section of `soiling.hsu` clarifying the default `depo_veloc` values and the meaning of settling velocity (default) vs. deposition velocity.
- `docs/sphinx/source/whatsnew/v0.16.0.rst`: added a Documentation entry referencing :issue:`2535`.

No code behavior is changed; this is a documentation-only change.

## Checklist
- [x] Pull request is written in English
- [x] All tests pass locally (the `hsu`-related tests in `pvlib/tests/test_soiling.py` pass)
- [x] Added whatsnew entry
