### PR TITLE
Address minor numpy deprecation

### DIFF
--- a/tests/test_clearsky.py
+++ b/tests/test_clearsky.py
@@ -665,7 +665,8 @@ def test_detect_clearsky_irregular_times(detect_clearsky_data):
     times = cs.index.values.copy()
     times[0] += pd.Timedelta(1, unit='s')
     times = pd.DatetimeIndex(times)
-    with pytest.raises(NotImplementedError):
+    match = "does not yet support unequal time intervals"
+    with pytest.raises(NotImplementedError, match=match):
         clearsky.detect_clearsky(expected['GHI'].values, cs['ghi'].values,
                                  times, 10)
 

--- a/tests/test_clearsky.py
+++ b/tests/test_clearsky.py
@@ -663,7 +663,7 @@ def test_detect_clearsky_arrays(detect_clearsky_data):
 def test_detect_clearsky_irregular_times(detect_clearsky_data):
     expected, cs = detect_clearsky_data
     times = cs.index.values.copy()
-    times[0] += 10**9
+    times[0] += pd.Timedelta(1, unit='s')
     times = pd.DatetimeIndex(times)
     with pytest.raises(NotImplementedError):
         clearsky.detect_clearsky(expected['GHI'].values, cs['ghi'].values,


### PR DESCRIPTION
 - ~[ ] Closes #xxxx~
 - [x] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing/index.html)
 - ~[ ] I attest that all AI-generated material has been vetted for accuracy and is in compliance with the pvlib license~ No AI
 - [x] Tests added
 - ~[ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.~
 - ~[ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).~
 - ~[ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.~
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Addresses this deprecation warning shown in recent test runs:

> tests/test_clearsky.py::test_detect_clearsky_irregular_times
>   /home/runner/work/pvlib-python/pvlib-python/tests/test_clearsky.py:666: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`). Please use a specific unit instead.
>     times[0] += 10**9

https://github.com/pvlib/pvlib-python/actions/runs/34241529820/job/102112640274#step:9:77
